### PR TITLE
Added preprocessor check for OS X and clang when including unordered_map

### DIFF
--- a/LASlib/src/lasindex.cpp
+++ b/LASlib/src/lasindex.cpp
@@ -40,10 +40,16 @@
 #include "bytestreamin_file.hpp"
 #include "bytestreamout_file.hpp"
 
-#ifdef UNORDERED
-#include <tr1/unordered_map>
 using namespace std;
-using namespace tr1;
+
+#ifdef UNORDERED
+  // Check if on OS X and using cland (unordered map isn't part of tr1 namespace)
+  #if defined(__APPLE__) && defined(__clang__)
+    #include <unordered_map>
+  #else
+    #include <tr1/unordered_map>
+    using namespace tr1;
+  #endif
 typedef unordered_map<I32,U32> my_cell_hash;
 #else
 #include <hash_map>

--- a/LASlib/src/lasinterval.cpp
+++ b/LASlib/src/lasinterval.cpp
@@ -43,8 +43,13 @@
 using namespace std;
 
 #ifdef UNORDERED
-#include <tr1/unordered_map>
-using namespace tr1;
+  // Check if on OS X and using cland (unordered map isn't part of tr1 namespace)
+  #if defined(__APPLE__) && defined(__clang__)
+    #include <unordered_map>
+  #else
+    #include <tr1/unordered_map>
+    using namespace tr1;
+  #endif
 typedef unordered_map<I32, LASintervalStartCell*> my_cell_hash;
 #else
 #include <hash_map>


### PR DESCRIPTION
Don't check for unordered_map in tr1 if using cland under OS X as is part of std namespace.

Solution taken from Ravi Peters on LAStools mailing list:

https://groups.google.com/forum/#!topic/lastools/5PO6Wa0svGA

Changes shouldn't impact compilation on other platforms.