### PR TITLE
fix possible double free from invoking fclose in destructor

### DIFF
--- a/LASlib/src/lasreader_txt.cpp
+++ b/LASlib/src/lasreader_txt.cpp
@@ -624,8 +624,8 @@ BOOL LASreaderTXT::open(FILE* file, const char* file_name, const char* parse_str
   if (i != 1)
   {
     fprintf(stderr, "ERROR: could not parse any lines with '%s'\n", this->parse_string);
-    fclose(file);
-    file = 0;
+    fclose(this->file);
+    this->file = 0;
     free(this->parse_string);
     this->parse_string = 0;
     return FALSE;


### PR DESCRIPTION
If the las text reader fails to read any valid lines, the file is closed and set to NULL.  The mirrored member is closed as well, but not NULLed out.  When the destructor is called, fclose is called on the invalid file descriptor this->fclose which is invalid.

I sent a message to the list, but this seems easier.