### PR TITLE
fix "error: 'fabs' was not declared in this scope"

### DIFF
--- a/LASlib/src/lasreader_las.cpp
+++ b/LASlib/src/lasreader_las.cpp
@@ -39,9 +39,9 @@
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
-#include <math.h>
 #endif
 
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
under Linux because of <math.h> being only included on Windows
systems. ref #10