### PR TITLE
fix small bug about seeking big file

### DIFF
--- a/LASzip/src/lasreadpoint.cpp
+++ b/LASzip/src/lasreadpoint.cpp
@@ -319,7 +319,7 @@ BOOL LASreadPoint::seek(const U32 current, const U32 target)
   {
     if (current != target)
     {
-      instream->seek(point_start+point_size*target);
+      instream->seek(point_start+(I64)point_size*target);
     }
   }
   return TRUE;


### PR DESCRIPTION
When I try to seek a big file（about 9G）, I get a wrong point value. 