### PR TITLE
Fixed assignment to rvalue

### DIFF
--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -4037,7 +4037,7 @@ laszip_read_point(
       flags_and_channel = point->extra_bytes[laszip_dll->start_flags_and_channel];
       if (laszip_dll->start_NIR_band != -1)
       {
-        ((U16)point->rgb[3]) = *((U16*)(point->extra_bytes + laszip_dll->start_NIR_band));
+        point->rgb[3] = *((U16*)(point->extra_bytes + laszip_dll->start_NIR_band));
       }
 
       // decompose into individual attributes


### PR DESCRIPTION
Fixes an issue causing a compilation failure with warnings on, whereby a rvalue (cast to a non-reference) is assigned to.