### PR TITLE
Refactored the seek_next method to include both signatures.

### DIFF
--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -36,11 +36,8 @@
 
 #include "lasquadtree.hpp"
 #include "lasinterval.hpp"
-#ifdef LASZIPDLL_EXPORTS
 #include "lasreadpoint.hpp"
-#else
 #include "lasreader.hpp"
-#endif
 #include "bytestreamin_file.hpp"
 #include "bytestreamout_file.hpp"
 
@@ -585,7 +582,6 @@ BOOL LASindex::write(ByteStreamOut* stream) const
 
 // seek to next interval point
 
-#ifdef LASZIPDLL_EXPORTS
 BOOL LASindex::seek_next(LASreadPoint* reader, I64 &p_count)
 {
   if (!have_interval)
@@ -600,7 +596,7 @@ BOOL LASindex::seek_next(LASreadPoint* reader, I64 &p_count)
   }
   return TRUE;
 }
-#else
+
 BOOL LASindex::seek_next(LASreader* lasreader)
 {
   if (!have_interval)
@@ -614,7 +610,6 @@ BOOL LASindex::seek_next(LASreader* lasreader)
   }
   return TRUE;
 }
-#endif
 
 // merge the intervals of non-empty cells
 BOOL LASindex::merge_intervals()

--- a/LASzip/src/lasindex.hpp
+++ b/LASzip/src/lasindex.hpp
@@ -41,11 +41,8 @@
 
 class LASquadtree;
 class LASinterval;
-#ifdef LASZIPDLL_EXPORTS
 class LASreadPoint;
-#else
 class LASreader;
-#endif
 class ByteStreamIn;
 class ByteStreamOut;
 
@@ -83,11 +80,8 @@ public:
   U32 cells;
 
   // seek to next interval
-#ifdef LASZIPDLL_EXPORTS
   BOOL seek_next(LASreadPoint* reader, I64 &p_count);
-#else
   BOOL seek_next(LASreader* lasreader);
-#endif
 
   // for debugging
   void print(BOOL verbose);


### PR DESCRIPTION
I'm not sure that I entirely understand the context, but this allows the same LAStools library to be used both when accessed via the DLL header and when accessed without.  Otherwise I needed to compile the library twice with `LASZIPDLL_EXPORTS` having different values in order to be compatible with the used software.