### PR TITLE
Replaced BOOL by bool

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -244,7 +244,7 @@ public:
 
   // set functions
 
-  void set_bounding_box(F64 min_x, F64 min_y, F64 min_z, F64 max_x, F64 max_y, F64 max_z, BOOL auto_scale=TRUE, BOOL auto_offset=TRUE)
+  void set_bounding_box(F64 min_x, F64 min_y, F64 min_z, F64 max_x, F64 max_y, F64 max_z, bool auto_scale=TRUE, bool auto_offset=TRUE)
   {
     if (auto_scale)
     {
@@ -288,9 +288,9 @@ public:
     global_encoding |= (1 << bit);
   }
 
-  BOOL get_global_encoding_bit(I32 bit) const
+  bool get_global_encoding_bit(I32 bit) const
   {
-    return (BOOL)(global_encoding & (1 << bit));
+    return (bool)(global_encoding & (1 << bit));
   }
 
   // clean functions
@@ -448,7 +448,7 @@ public:
     return *this;
   };
 
-  BOOL check() const
+  bool check() const
   {
     if (strncmp(file_signature, "LASF", 4) != 0)
     {
@@ -488,7 +488,7 @@ public:
     return TRUE;
   };
 
-  BOOL is_compressed() const
+  bool is_compressed() const
   {
     if (laszip)
     {
@@ -500,7 +500,7 @@ public:
     return FALSE;
   };
 
-  BOOL is_lonlat() const
+  bool is_lonlat() const
   {
     if ((-360.0 <= min_x) && (-90.0 <= min_y) && (max_x <= 360.0) && (max_y <= 90.0))
     {
@@ -511,10 +511,10 @@ public:
 
   // note that data needs to be allocated with new [] and not malloc and that LASheader
   // will become the owner over this and manage its deallocation 
-  void add_vlr(const CHAR* user_id, const U16 record_id, const U16 record_length_after_header, U8* data, const BOOL keep_description=FALSE, const CHAR* description=0, const BOOL keep_existing=FALSE)
+  void add_vlr(const CHAR* user_id, const U16 record_id, const U16 record_length_after_header, U8* data, const bool keep_description=FALSE, const CHAR* description=0, const bool keep_existing=FALSE)
   {
     U32 i = 0;
-    BOOL found_description = FALSE;
+    bool found_description = FALSE;
     if (vlrs)
     {
       if (keep_existing)
@@ -591,7 +591,7 @@ public:
     return 0;
   };
 
-  BOOL remove_vlr(U32 i)
+  bool remove_vlr(U32 i)
   {
     if (vlrs)
     {
@@ -619,7 +619,7 @@ public:
     return FALSE;
   };
 
-  BOOL remove_vlr(const CHAR* user_id, U16 record_id)
+  bool remove_vlr(const CHAR* user_id, U16 record_id)
   {
     U32 i;
     for (i = 0; i < number_of_variable_length_records; i++)
@@ -632,7 +632,7 @@ public:
     return FALSE;
   };
 
-  void set_lastiling(U32 level, U32 level_index, U32 implicit_levels, BOOL buffer, BOOL reversible, F32 min_x, F32 max_x, F32 min_y, F32 max_y)
+  void set_lastiling(U32 level, U32 level_index, U32 implicit_levels, bool buffer, bool reversible, F32 min_x, F32 max_x, F32 min_y, F32 max_y)
   {
     clean_lastiling();
     vlr_lastiling = new LASvlr_lastiling();
@@ -687,7 +687,7 @@ public:
     vlr_lasoriginal->min_z = min_z;
   }
 
-  BOOL restore_lasoriginal()
+  bool restore_lasoriginal()
   {
     if (vlr_lasoriginal)
     {
@@ -808,7 +808,7 @@ public:
     }
   }
 
-  void update_extra_bytes_vlr(const BOOL keep_description=FALSE)
+  void update_extra_bytes_vlr(const bool keep_description=FALSE)
   {
     if (number_attributes)
     {

--- a/LASlib/inc/lasfilter.hpp
+++ b/LASlib/inc/lasfilter.hpp
@@ -38,7 +38,7 @@ class LAScriterion
 public:
   virtual const CHAR * name() const = 0;
   virtual I32 get_command(CHAR* string) const = 0;
-  virtual BOOL filter(const LASpoint* point) = 0;
+  virtual bool filter(const LASpoint* point) = 0;
   virtual void reset(){};
   virtual ~LAScriterion(){};
 };
@@ -49,16 +49,16 @@ public:
 
   void usage() const;
   void clean();
-  BOOL parse(int argc, char* argv[]);
-  BOOL parse(CHAR* string);
+  bool parse(int argc, char* argv[]);
+  bool parse(CHAR* string);
   I32 unparse(CHAR* string) const;
-  inline BOOL active() const { return (num_criteria != 0); };
+  inline bool active() const { return (num_criteria != 0); };
 
   void addClipCircle(F64 x, F64 y, F64 radius);
   void addClipBox(F64 min_x, F64 min_y, F64 min_z, F64 max_x, F64 max_y, F64 max_z);
   void addKeepScanDirectionChange();
 
-  BOOL filter(const LASpoint* point);
+  bool filter(const LASpoint* point);
   void reset();
 
   LASfilter();

--- a/LASlib/inc/lasreader.hpp
+++ b/LASlib/inc/lasreader.hpp
@@ -59,7 +59,7 @@ public:
   I64 p_count;
 
   virtual I32 get_format() const = 0;
-  virtual BOOL has_layers() const { return FALSE; };
+  virtual bool has_layers() const { return FALSE; };
 
   void set_index(LASindex* index);
   inline LASindex* get_index() const { return index; };
@@ -69,23 +69,23 @@ public:
   inline LAStransform* get_transform() const { return transform; };
 
   inline U32 get_inside() const { return inside; };
-  virtual BOOL inside_none();
-  virtual BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+  virtual bool inside_none();
+  virtual bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
   inline F32 get_t_ll_x() const { return t_ll_x; };
   inline F32 get_t_ll_y() const { return t_ll_y; };
   inline F32 get_t_size() const { return t_size; };
-  virtual BOOL inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
+  virtual bool inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
   inline F64 get_c_center_x() const { return c_center_x; };
   inline F64 get_c_center_y() const { return c_center_y; };
   inline F64 get_c_radius() const { return c_radius; };
-  virtual BOOL inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
+  virtual bool inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
   inline F64 get_r_min_x() const { return r_min_x; };
   inline F64 get_r_min_y() const { return r_min_y; };
   inline F64 get_r_max_x() const { return r_max_x; };
   inline F64 get_r_max_y() const { return r_max_y; };
 
-  virtual BOOL seek(const I64 p_index) = 0;
-  BOOL read_point() { return (this->*read_simple)(); };
+  virtual bool seek(const I64 p_index) = 0;
+  bool read_point() { return (this->*read_simple)(); };
 
   inline void compute_coordinates() { point.compute_coordinates(); };
 
@@ -110,13 +110,13 @@ public:
   inline I32 get_Z(const F64 z) const { return header.get_Z(z); };
 
   virtual ByteStreamIn* get_stream() const = 0;
-  virtual void close(BOOL close_stream=TRUE) = 0;
+  virtual void close(bool close_stream=TRUE) = 0;
 
   LASreader();
   virtual ~LASreader();
 
 protected:
-  virtual BOOL read_point_default() = 0;
+  virtual bool read_point_default() = 0;
 
   LASindex* index;
   LASfilter* filter;
@@ -129,20 +129,20 @@ protected:
   F64 orig_min_x, orig_min_y, orig_max_x, orig_max_y;
 
 private:
-  BOOL (LASreader::*read_simple)();
-  BOOL (LASreader::*read_complex)();
+  bool (LASreader::*read_simple)();
+  bool (LASreader::*read_complex)();
 
-  BOOL read_point_none();
-  BOOL read_point_filtered();
-  BOOL read_point_transformed();
-  BOOL read_point_filtered_and_transformed();
+  bool read_point_none();
+  bool read_point_filtered();
+  bool read_point_transformed();
+  bool read_point_filtered_and_transformed();
 
-  BOOL read_point_inside_tile();
-  BOOL read_point_inside_tile_indexed();
-  BOOL read_point_inside_circle();
-  BOOL read_point_inside_circle_indexed();
-  BOOL read_point_inside_rectangle();
-  BOOL read_point_inside_rectangle_indexed();
+  bool read_point_inside_tile();
+  bool read_point_inside_tile_indexed();
+  bool read_point_inside_circle();
+  bool read_point_inside_circle_indexed();
+  bool read_point_inside_rectangle();
+  bool read_point_inside_rectangle_indexed();
 };
 
 #include "laswaveform13reader.hpp"
@@ -156,24 +156,24 @@ public:
   U32 get_file_name_current() const;
   const CHAR* get_file_name() const;
   const CHAR* get_file_name(U32 number) const;
-  void set_file_name(const CHAR* file_name, BOOL unique=FALSE);
-  BOOL add_file_name(const CHAR* file_name, BOOL unique=FALSE);
-  BOOL add_list_of_files(const CHAR* list_of_files, BOOL unique=FALSE);
+  void set_file_name(const CHAR* file_name, bool unique=FALSE);
+  bool add_file_name(const CHAR* file_name, bool unique=FALSE);
+  bool add_list_of_files(const CHAR* list_of_files, bool unique=FALSE);
   void delete_file_name(U32 file_name_id);
-  BOOL set_file_name_current(U32 file_name_id);
+  bool set_file_name_current(U32 file_name_id);
   I32 get_file_format(U32 number) const;
-  void set_merged(const BOOL merged);
-  BOOL is_merged() const { return merged; };
+  void set_merged(const bool merged);
+  bool is_merged() const { return merged; };
   void set_buffer_size(const F32 buffer_size);
   F32 get_buffer_size() const;
-  void set_neighbor_file_name(const CHAR* neighbor_file_name, BOOL unique=FALSE);
-  BOOL add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL unique=FALSE);
-  void set_auto_reoffset(const BOOL auto_reoffset);
-  inline BOOL is_auto_reoffset() const { return auto_reoffset; };
-  void set_files_are_flightlines(const BOOL files_are_flightlines);
-  inline BOOL are_files_flightlines() const { return files_are_flightlines; };
-  void set_apply_file_source_ID(const BOOL apply_file_source_ID);
-  inline BOOL applying_file_source_ID() const { return apply_file_source_ID; };
+  void set_neighbor_file_name(const CHAR* neighbor_file_name, bool unique=FALSE);
+  bool add_neighbor_file_name(const CHAR* neighbor_file_name, bool unique=FALSE);
+  void set_auto_reoffset(const bool auto_reoffset);
+  inline bool is_auto_reoffset() const { return auto_reoffset; };
+  void set_files_are_flightlines(const bool files_are_flightlines);
+  inline bool are_files_flightlines() const { return files_are_flightlines; };
+  void set_apply_file_source_ID(const bool apply_file_source_ID);
+  inline bool applying_file_source_ID() const { return apply_file_source_ID; };
   void set_scale_factor(const F64* scale_factor);
   inline const F64* get_scale_factor() const { return scale_factor; };
   void set_offset(const F64* offset);
@@ -185,20 +185,20 @@ public:
   void add_attribute(I32 data_type, const CHAR* name, const CHAR* description=0, F64 scale=1.0, F64 offset=0.0, F64 pre_scale=1.0, F64 pre_offset=0.0);
   void set_parse_string(const CHAR* parse_string);
   void set_skip_lines(I32 skip_lines);
-  void set_populate_header(BOOL populate_header);
-  void set_keep_lastiling(BOOL keep_lastiling);
-  void set_pipe_on(BOOL pipe_on);
+  void set_populate_header(bool populate_header);
+  void set_keep_lastiling(bool keep_lastiling);
+  void set_pipe_on(bool pipe_on);
   const CHAR* get_parse_string() const;
   void usage() const;
   void set_inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
   void set_inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
   void set_inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
-  BOOL parse(int argc, char* argv[]);
-  BOOL is_piped() const;
-  BOOL is_buffered() const;
-  BOOL is_header_populated() const;
-  BOOL active() const;
-  BOOL is_inside() const;
+  bool parse(int argc, char* argv[]);
+  bool is_piped() const;
+  bool is_buffered() const;
+  bool is_header_populated() const;
+  bool active() const;
+  bool is_inside() const;
   I32 unparse(CHAR* string) const;
   void set_filter(LASfilter* filter);
   const LASfilter* get_filter() { return filter; };
@@ -206,20 +206,20 @@ public:
   const LAStransform* get_transform() { return transform; };
   void reset();
   const CHAR* get_temp_file_base() const { return temp_file_base; };
-  LASreader* open(const CHAR* other_file_name=0, BOOL reset_after_other=TRUE);
-  BOOL reopen(LASreader* lasreader, BOOL remain_buffered=TRUE);
+  LASreader* open(const CHAR* other_file_name=0, bool reset_after_other=TRUE);
+  bool reopen(LASreader* lasreader, bool remain_buffered=TRUE);
   LASwaveform13reader* open_waveform13(const LASheader* lasheader);
   LASreadOpener();
   ~LASreadOpener();
 private:
 #ifdef _WIN32
-  BOOL add_file_name_single(const CHAR* file_name, BOOL unique=FALSE);
-  BOOL add_neighbor_file_name_single(const CHAR* neighbor_file_name, BOOL unique=FALSE);
+  bool add_file_name_single(const CHAR* file_name, bool unique=FALSE);
+  bool add_neighbor_file_name_single(const CHAR* neighbor_file_name, bool unique=FALSE);
 #endif
   I32 io_ibuffer_size;
   CHAR** file_names;
   const CHAR* file_name;
-  BOOL merged;
+  bool merged;
   U32 file_name_number;
   U32 file_name_allocated;
   U32 file_name_current;
@@ -228,15 +228,15 @@ private:
   CHAR** neighbor_file_names;
   U32 neighbor_file_name_number;
   U32 neighbor_file_name_allocated;
-  BOOL comma_not_point;
+  bool comma_not_point;
   F64* scale_factor;
   F64* offset;
-  BOOL auto_reoffset;
-  BOOL files_are_flightlines;
-  BOOL apply_file_source_ID;
-  BOOL itxt;
-  BOOL ipts;
-  BOOL iptx;
+  bool auto_reoffset;
+  bool files_are_flightlines;
+  bool apply_file_source_ID;
+  bool itxt;
+  bool ipts;
+  bool iptx;
   F32 translate_intensity;
   F32 scale_intensity;
   F32 translate_scan_angle;
@@ -251,11 +251,11 @@ private:
   F64 attribute_pre_offsets[10];
   CHAR* parse_string;
   I32 skip_lines;
-  BOOL populate_header;
-  BOOL keep_lastiling;
-  BOOL pipe_on;
-  BOOL use_stdin;
-  BOOL unique;
+  bool populate_header;
+  bool keep_lastiling;
+  bool pipe_on;
+  bool use_stdin;
+  bool unique;
 
   // optional extras
   LASindex* index;

--- a/LASlib/inc/lasreader_asc.hpp
+++ b/LASlib/inc/lasreader_asc.hpp
@@ -42,25 +42,25 @@ public:
 
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
-  virtual BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
+  virtual bool open(const CHAR* file_name, bool comma_not_point=FALSE);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_ASC; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const CHAR* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const CHAR* file_name);
 
   LASreaderASC();
   virtual ~LASreaderASC();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   bool piped;
-  BOOL comma_not_point;
+  bool comma_not_point;
   F64* scale_factor;
   F64* offset;
   FILE* file;
@@ -81,7 +81,7 @@ private:
 class LASreaderASCrescale : public virtual LASreaderASC
 {
 public:
-  virtual BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
+  virtual bool open(const CHAR* file_name, bool comma_not_point=FALSE);
   LASreaderASCrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -91,7 +91,7 @@ protected:
 class LASreaderASCreoffset : public virtual LASreaderASC
 {
 public:
-  virtual BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
+  virtual bool open(const CHAR* file_name, bool comma_not_point=FALSE);
   LASreaderASCreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -100,7 +100,7 @@ protected:
 class LASreaderASCrescalereoffset : public LASreaderASCrescale, LASreaderASCreoffset
 {
 public:
-  BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
+  bool open(const CHAR* file_name, bool comma_not_point=FALSE);
   LASreaderASCrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_bil.hpp
+++ b/LASlib/inc/lasreader_bil.hpp
@@ -41,21 +41,21 @@ public:
 
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_BIL; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const CHAR* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const CHAR* file_name);
 
   LASreaderBIL();
   virtual ~LASreaderBIL();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   F64* scale_factor;
@@ -65,11 +65,11 @@ private:
   F64 ulxcenter, ulycenter;
   F32 xdim, ydim;
   F32 nodata;
-  BOOL floatpixels;
+  bool floatpixels;
 
   void clean();
-  BOOL read_hdr_file(const CHAR* file_name);
-  BOOL read_blw_file(const CHAR* file_name);
+  bool read_hdr_file(const CHAR* file_name);
+  bool read_blw_file(const CHAR* file_name);
   void populate_scale_and_offset();
   void populate_bounding_box();
 };
@@ -77,7 +77,7 @@ private:
 class LASreaderBILrescale : public virtual LASreaderBIL
 {
 public:
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
   LASreaderBILrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -87,7 +87,7 @@ protected:
 class LASreaderBILreoffset : public virtual LASreaderBIL
 {
 public:
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
   LASreaderBILreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -96,7 +96,7 @@ protected:
 class LASreaderBILrescalereoffset : public LASreaderBILrescale, LASreaderBILreoffset
 {
 public:
-  BOOL open(const CHAR* file_name);
+  bool open(const CHAR* file_name);
   LASreaderBILrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_bin.hpp
+++ b/LASlib/inc/lasreader_bin.hpp
@@ -41,22 +41,22 @@ class LASreaderBIN : public LASreader
 {
 public:
 
-  BOOL open(const char* file_name);
+  bool open(const char* file_name);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_BIN; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const char* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const char* file_name);
 
   LASreaderBIN();
   virtual ~LASreaderBIN();
 
 protected:
-  virtual BOOL open(ByteStreamIn* stream);
-  BOOL read_point_default();
+  virtual bool open(ByteStreamIn* stream);
+  bool read_point_default();
 
 private:
   FILE* file;
@@ -67,7 +67,7 @@ private:
 class LASreaderBINrescale : public virtual LASreaderBIN
 {
 public:
-  virtual BOOL open(ByteStreamIn* stream);
+  virtual bool open(ByteStreamIn* stream);
   LASreaderBINrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -77,7 +77,7 @@ protected:
 class LASreaderBINreoffset : public virtual LASreaderBIN
 {
 public:
-  virtual BOOL open(ByteStreamIn* stream);
+  virtual bool open(ByteStreamIn* stream);
   LASreaderBINreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -86,7 +86,7 @@ protected:
 class LASreaderBINrescalereoffset : public LASreaderBINrescale, LASreaderBINreoffset
 {
 public:
-  BOOL open(ByteStreamIn* stream);
+  bool open(ByteStreamIn* stream);
   LASreaderBINrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_dtm.hpp
+++ b/LASlib/inc/lasreader_dtm.hpp
@@ -41,21 +41,21 @@ public:
 
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_BIL; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const CHAR* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const CHAR* file_name);
 
   LASreaderDTM();
   virtual ~LASreaderDTM();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   F64* scale_factor;
@@ -75,7 +75,7 @@ private:
 class LASreaderDTMrescale : public virtual LASreaderDTM
 {
 public:
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
   LASreaderDTMrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -85,7 +85,7 @@ protected:
 class LASreaderDTMreoffset : public virtual LASreaderDTM
 {
 public:
-  virtual BOOL open(const CHAR* file_name);
+  virtual bool open(const CHAR* file_name);
   LASreaderDTMreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -94,7 +94,7 @@ protected:
 class LASreaderDTMrescalereoffset : public LASreaderDTMrescale, LASreaderDTMreoffset
 {
 public:
-  BOOL open(const CHAR* file_name);
+  bool open(const CHAR* file_name);
   LASreaderDTMrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_las.hpp
+++ b/LASlib/inc/lasreader_las.hpp
@@ -56,41 +56,41 @@ class LASreaderLAS : public LASreader
 {
 public:
 
-  BOOL open(const char* file_name, I32 io_buffer_size=LAS_TOOLS_IO_IBUFFER_SIZE, BOOL peek_only=FALSE);
-  BOOL open(FILE* file, BOOL peek_only=FALSE);
-  BOOL open(istream& stream, BOOL peek_only=FALSE);
+  bool open(const char* file_name, I32 io_buffer_size=LAS_TOOLS_IO_IBUFFER_SIZE, bool peek_only=FALSE);
+  bool open(FILE* file, bool peek_only=FALSE);
+  bool open(istream& stream, bool peek_only=FALSE);
 
   I32 get_format() const;
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
+  void close(bool close_stream=TRUE);
 
   LASreaderLAS();
   virtual ~LASreaderLAS();
 
 protected:
-  virtual BOOL open(ByteStreamIn* stream, BOOL peek_only=FALSE);
-  virtual BOOL read_point_default();
+  virtual bool open(ByteStreamIn* stream, bool peek_only=FALSE);
+  virtual bool read_point_default();
 
 private:
   FILE* file;
   ByteStreamIn* stream;
   LASreadPoint* reader;
-  BOOL checked_end;
+  bool checked_end;
 };
 
 class LASreaderLASrescale : public virtual LASreaderLAS
 {
 public:
-  LASreaderLASrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, BOOL check_for_overflow=TRUE);
+  LASreaderLASrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, bool check_for_overflow=TRUE);
 
 protected:
-  virtual BOOL open(ByteStreamIn* stream, BOOL peek_only=FALSE);
-  virtual BOOL read_point_default();
-  BOOL rescale_x, rescale_y, rescale_z;
-  BOOL check_for_overflow;
+  virtual bool open(ByteStreamIn* stream, bool peek_only=FALSE);
+  virtual bool read_point_default();
+  bool rescale_x, rescale_y, rescale_z;
+  bool check_for_overflow;
   F64 scale_factor[3];
   F64 orig_x_scale_factor, orig_y_scale_factor, orig_z_scale_factor;
 };
@@ -102,10 +102,10 @@ public:
   LASreaderLASreoffset(); // auto reoffset
 
 protected:
-  virtual BOOL open(ByteStreamIn* stream, BOOL peek_only=FALSE);
-  virtual BOOL read_point_default();
-  BOOL auto_reoffset;
-  BOOL reoffset_x, reoffset_y, reoffset_z;
+  virtual bool open(ByteStreamIn* stream, bool peek_only=FALSE);
+  virtual bool read_point_default();
+  bool auto_reoffset;
+  bool reoffset_x, reoffset_y, reoffset_z;
   F64 offset[3];
   F64 orig_x_offset, orig_y_offset, orig_z_offset;
 };
@@ -117,8 +117,8 @@ public:
   LASreaderLASrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor); // auto reoffset
 
 protected:
-  BOOL open(ByteStreamIn* stream, BOOL peek_only=FALSE);
-  BOOL read_point_default();
+  bool open(ByteStreamIn* stream, bool peek_only=FALSE);
+  bool read_point_default();
 };
 
 #endif

--- a/LASlib/inc/lasreader_qfit.hpp
+++ b/LASlib/inc/lasreader_qfit.hpp
@@ -42,32 +42,32 @@ class LASreaderQFIT : public LASreader
 {
 public:
 
-  BOOL open(const char* file_name);
+  bool open(const char* file_name);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_QFIT; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const char* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const char* file_name);
 
   LASreaderQFIT();
   virtual ~LASreaderQFIT();
 
 protected:
-  virtual BOOL open(ByteStreamIn* stream);
-  BOOL read_point_default();
+  virtual bool open(ByteStreamIn* stream);
+  bool read_point_default();
 
 private:
   FILE* file;
   ByteStreamIn* stream;
   I32 version;
-  BOOL little_endian;
-  BOOL endian_swap;
+  bool little_endian;
+  bool endian_swap;
   I32 offset;
   I32 buffer[14];
-  BOOL populated_header;
+  bool populated_header;
   I32 scan_azimuth_start;
   I32 pitch_start;
   I32 roll_start;
@@ -77,7 +77,7 @@ private:
 class LASreaderQFITrescale : public virtual LASreaderQFIT
 {
 public:
-  virtual BOOL open(ByteStreamIn* stream);
+  virtual bool open(ByteStreamIn* stream);
   LASreaderQFITrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -87,7 +87,7 @@ protected:
 class LASreaderQFITreoffset : public virtual LASreaderQFIT
 {
 public:
-  virtual BOOL open(ByteStreamIn* stream);
+  virtual bool open(ByteStreamIn* stream);
   LASreaderQFITreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -96,7 +96,7 @@ protected:
 class LASreaderQFITrescalereoffset : public LASreaderQFITrescale, LASreaderQFITreoffset
 {
 public:
-  BOOL open(ByteStreamIn* stream);
+  bool open(ByteStreamIn* stream);
   LASreaderQFITrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_shp.hpp
+++ b/LASlib/inc/lasreader_shp.hpp
@@ -41,21 +41,21 @@ public:
 
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
-  virtual BOOL open(const char* file_name);
+  virtual bool open(const char* file_name);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_SHP; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const char* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const char* file_name);
 
   LASreaderSHP();
   virtual ~LASreaderSHP();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   F64* scale_factor;
@@ -75,7 +75,7 @@ private:
 class LASreaderSHPrescale : public virtual LASreaderSHP
 {
 public:
-  virtual BOOL open(const char* file_name);
+  virtual bool open(const char* file_name);
   LASreaderSHPrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -85,7 +85,7 @@ protected:
 class LASreaderSHPreoffset : public virtual LASreaderSHP
 {
 public:
-  virtual BOOL open(const char* file_name);
+  virtual bool open(const char* file_name);
   LASreaderSHPreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -94,7 +94,7 @@ protected:
 class LASreaderSHPrescalereoffset : public LASreaderSHPrescale, LASreaderSHPreoffset
 {
 public:
-  BOOL open(const char* file_name);
+  bool open(const char* file_name);
   LASreaderSHPrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreader_txt.hpp
+++ b/LASlib/inc/lasreader_txt.hpp
@@ -41,8 +41,8 @@ class LASreaderTXT : public LASreader
 {
 public:
 
-  void set_pts(BOOL pts);
-  void set_ptx(BOOL ptx);
+  void set_pts(bool pts);
+  void set_ptx(bool ptx);
 
   void set_translate_intensity(F32 translate_intensity);
   void set_scale_intensity(F32 scale_intensity);
@@ -51,22 +51,22 @@ public:
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
   void add_attribute(I32 data_type, const CHAR* name, const CHAR* description=0, F64 scale=1.0, F64 offset=0.0, F64 pre_scale=1.0, F64 pre_offset=0.0);
-  virtual BOOL open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, BOOL populate_header=FALSE);
-  virtual BOOL open(FILE* file, const CHAR* file_name=0, const CHAR* parse_string=0, I32 skip_lines=0, BOOL populate_header=FALSE);
+  virtual bool open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, bool populate_header=FALSE);
+  virtual bool open(FILE* file, const CHAR* file_name=0, const CHAR* parse_string=0, I32 skip_lines=0, bool populate_header=FALSE);
 
   I32 get_format() const { return LAS_TOOLS_FORMAT_TXT; };
 
-  BOOL seek(const I64 p_index);
+  bool seek(const I64 p_index);
 
   ByteStreamIn* get_stream() const;
-  void close(BOOL close_stream=TRUE);
-  BOOL reopen(const CHAR* file_name);
+  void close(bool close_stream=TRUE);
+  bool reopen(const CHAR* file_name);
 
   LASreaderTXT();
   virtual ~LASreaderTXT();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   CHAR* parse_string;
@@ -77,9 +77,9 @@ private:
   F64* scale_factor;
   F64* offset;
   I32 skip_lines;
-  BOOL populated_header;
-  BOOL ipts;
-  BOOL iptx;
+  bool populated_header;
+  bool ipts;
+  bool iptx;
   FILE* file;
   bool piped;
   CHAR line[512];
@@ -92,9 +92,9 @@ private:
   F64 attribute_pre_scales[10];
   F64 attribute_pre_offsets[10];
   I32 attribute_starts[10];
-  BOOL parse_attribute(const CHAR* l, I32 index);
-  BOOL parse(const CHAR* parse_string);
-  BOOL check_parse_string(const CHAR* parse_string);
+  bool parse_attribute(const CHAR* l, I32 index);
+  bool parse(const CHAR* parse_string);
+  bool check_parse_string(const CHAR* parse_string);
   void populate_scale_and_offset();
   void populate_bounding_box();
   void clean();
@@ -103,7 +103,7 @@ private:
 class LASreaderTXTrescale : public virtual LASreaderTXT
 {
 public:
-  virtual BOOL open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, BOOL populate_header=FALSE);
+  virtual bool open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, bool populate_header=FALSE);
   LASreaderTXTrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor);
 
 protected:
@@ -113,7 +113,7 @@ protected:
 class LASreaderTXTreoffset : public virtual LASreaderTXT
 {
 public:
-  virtual BOOL open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, BOOL populate_header=FALSE);
+  virtual bool open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, bool populate_header=FALSE);
   LASreaderTXTreoffset(F64 x_offset, F64 y_offset, F64 z_offset);
 protected:
   F64 offset[3];
@@ -122,7 +122,7 @@ protected:
 class LASreaderTXTrescalereoffset : public LASreaderTXTrescale, LASreaderTXTreoffset
 {
 public:
-  BOOL open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, BOOL populate_header=FALSE);
+  bool open(const CHAR* file_name, const CHAR* parse_string=0, I32 skip_lines=0, bool populate_header=FALSE);
   LASreaderTXTrescalereoffset(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
 };
 

--- a/LASlib/inc/lasreaderbuffered.hpp
+++ b/LASlib/inc/lasreaderbuffered.hpp
@@ -51,43 +51,43 @@ public:
   void set_scale_scan_angle(F32 scale_scan_angle);
   void set_parse_string(const CHAR* parse_string);
   void set_skip_lines(I32 skip_lines);
-  void set_populate_header(BOOL populate_header);
+  void set_populate_header(bool populate_header);
 
-  BOOL set_file_name(const CHAR* file_name);
-  BOOL add_neighbor_file_name(const CHAR* file_name);
+  bool set_file_name(const CHAR* file_name);
+  bool add_neighbor_file_name(const CHAR* file_name);
   void set_buffer_size(const F32 buffer_size);
 
-  BOOL remove_buffer();
+  bool remove_buffer();
 
-  BOOL open();
-  BOOL reopen();
+  bool open();
+  bool reopen();
 
   void set_filter(LASfilter* filter);
   void set_transform(LAStransform* transform);
 
-  BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
-  BOOL inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
-  BOOL inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
+  bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+  bool inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
+  bool inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
 
   I32 get_format() const;
 
-  BOOL seek(const I64 p_index){ return FALSE; };
+  bool seek(const I64 p_index){ return FALSE; };
 
   ByteStreamIn* get_stream() const { return 0; };
-  void close(BOOL close_stream=TRUE);
+  void close(bool close_stream=TRUE);
 
   LASreaderBuffered();
   ~LASreaderBuffered();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   void clean();
 
   void clean_buffer();
-  BOOL copy_point_to_buffer();
-  BOOL copy_point_from_buffer();
+  bool copy_point_to_buffer();
+  bool copy_point_from_buffer();
   U32 get_number_buffered_points() const;
 
   const U32 points_per_buffer;
@@ -102,10 +102,10 @@ private:
   LASreadOpener lasreadopener_neighbors;
   LASreader* lasreader;
   F32 buffer_size;
-  BOOL point_type_change;
-  BOOL point_size_change;
-  BOOL rescale;
-  BOOL reoffset;
+  bool point_type_change;
+  bool point_size_change;
+  bool rescale;
+  bool reoffset;
   F64* scale_factor;
   F64* offset;
 };

--- a/LASlib/inc/lasreadermerged.hpp
+++ b/LASlib/inc/lasreadermerged.hpp
@@ -47,44 +47,44 @@ public:
 
   void set_io_ibuffer_size(I32 io_ibuffer_size);
   inline I32 get_io_ibuffer_size() const { return io_ibuffer_size; };
-  BOOL add_file_name(const CHAR* file_name);
+  bool add_file_name(const CHAR* file_name);
   void set_scale_factor(const F64* scale_factor);
   void set_offset(const F64* offset);
-  void set_files_are_flightlines(BOOL files_are_flightlines);
-  void set_apply_file_source_ID(BOOL apply_file_source_ID);
+  void set_files_are_flightlines(bool files_are_flightlines);
+  void set_apply_file_source_ID(bool apply_file_source_ID);
   void set_translate_intensity(F32 translate_intensity);
   void set_scale_intensity(F32 scale_intensity);
   void set_translate_scan_angle(F32 translate_scan_angle);
   void set_scale_scan_angle(F32 scale_scan_angle);
   void set_parse_string(const CHAR* parse_string);
   void set_skip_lines(I32 skip_lines);
-  void set_populate_header(BOOL populate_header);
-  void set_keep_lastiling(BOOL keep_lastiling);
-  BOOL open();
-  BOOL reopen();
+  void set_populate_header(bool populate_header);
+  void set_keep_lastiling(bool keep_lastiling);
+  bool open();
+  bool reopen();
 
   void set_filter(LASfilter* filter);
   void set_transform(LAStransform* transform);
 
-  BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
-  BOOL inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
-  BOOL inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
+  bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+  bool inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
+  bool inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
 
   I32 get_format() const;
 
-  BOOL seek(const I64 p_index){ return FALSE; };
+  bool seek(const I64 p_index){ return FALSE; };
 
   ByteStreamIn* get_stream() const { return 0; };
-  void close(BOOL close_stream=TRUE);
+  void close(bool close_stream=TRUE);
 
   LASreaderMerged();
   ~LASreaderMerged();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
-  BOOL open_next_file();
+  bool open_next_file();
   void clean();
 
   LASreader* lasreader;
@@ -96,22 +96,22 @@ private:
   LASreaderBIL* lasreaderbil;
   LASreaderDTM* lasreaderdtm;
   LASreaderTXT* lasreadertxt;
-  BOOL point_type_change;
-  BOOL point_size_change;
-  BOOL rescale;
-  BOOL reoffset;
+  bool point_type_change;
+  bool point_size_change;
+  bool rescale;
+  bool reoffset;
   F64* scale_factor;
   F64* offset;
-  BOOL files_are_flightlines;
-  BOOL apply_file_source_ID;
+  bool files_are_flightlines;
+  bool apply_file_source_ID;
   F32 translate_intensity;
   F32 scale_intensity;
   F32 translate_scan_angle;
   F32 scale_scan_angle;
   CHAR* parse_string;
   I32 skip_lines;
-  BOOL populate_header;
-  BOOL keep_lastiling;
+  bool populate_header;
+  bool keep_lastiling;
   U32 file_name_current;
   U32 file_name_number;
   U32 file_name_allocated;

--- a/LASlib/inc/lasreaderpipeon.hpp
+++ b/LASlib/inc/lasreaderpipeon.hpp
@@ -39,7 +39,7 @@ class LASreaderPipeOn : public LASreader
 {
 public:
 
-  BOOL open(LASreader* lasreader);
+  bool open(LASreader* lasreader);
   LASreader* get_lasreader() const { return lasreader; };
 
   I32 get_format() const;
@@ -49,20 +49,20 @@ public:
   void set_filter(LASfilter* filter);
   void set_transform(LAStransform* transform);
 
-  BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
-  BOOL inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
-  BOOL inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
+  bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+  bool inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
+  bool inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
 
-  BOOL seek(const I64 p_index){ return FALSE; };
+  bool seek(const I64 p_index){ return FALSE; };
 
   ByteStreamIn* get_stream() const { return 0; };
-  void close(BOOL close_stream=TRUE);
+  void close(bool close_stream=TRUE);
 
   LASreaderPipeOn();
   ~LASreaderPipeOn();
 
 protected:
-  BOOL read_point_default();
+  bool read_point_default();
 
 private:
   LASreader* lasreader;

--- a/LASlib/inc/lastransform.hpp
+++ b/LASlib/inc/lastransform.hpp
@@ -54,15 +54,15 @@ class LAStransform
 {
 public:
 
-  BOOL change_coordinates;
+  bool change_coordinates;
 
   void usage() const;
   void clean();
-  BOOL parse(int argc, char* argv[]);
-  BOOL parse(CHAR* string);
+  bool parse(int argc, char* argv[]);
+  bool parse(CHAR* string);
   I32 unparse(CHAR* string) const;
-  inline BOOL active() const { return (num_operations != 0); };
-  inline BOOL filtered() const { return is_filtered; };
+  inline bool active() const { return (num_operations != 0); };
+  inline bool filtered() const { return is_filtered; };
 
   void setFilter(LASfilter* filter);
 
@@ -80,7 +80,7 @@ private:
   U32 num_operations;
   U32 alloc_operations;
   LASoperation** operations;
-  BOOL is_filtered;
+  bool is_filtered;
   LASfilter* filter;
 };
 

--- a/LASlib/inc/lasutility.hpp
+++ b/LASlib/inc/lasutility.hpp
@@ -37,7 +37,7 @@
 class LASinventory
 {
 public:
-  BOOL active() const { return (first == FALSE); }; 
+  bool active() const { return (first == FALSE); }; 
   I64 extended_number_of_point_records;
   I64 extended_number_of_points_by_return[16];
   I32 max_X;
@@ -46,18 +46,18 @@ public:
   I32 min_Y;
   I32 max_Z;
   I32 min_Z;
-  BOOL init(const LASheader* header);
-  BOOL add(const LASpoint* point);
-  BOOL update_header(LASheader* header) const;
+  bool init(const LASheader* header);
+  bool add(const LASpoint* point);
+  bool update_header(LASheader* header) const;
   LASinventory();
 private:
-  BOOL first;
+  bool first;
 };
 
 class LASsummary
 {
 public:
-  BOOL active() const { return (first == FALSE); }; 
+  bool active() const { return (first == FALSE); }; 
   I64 number_of_point_records;
   I64 number_of_points_by_return[16];
   I64 number_of_returns[16];
@@ -73,18 +73,18 @@ public:
   I64 xyz_fluff_100[3];
   I64 xyz_fluff_1000[3];
   I64 xyz_fluff_10000[3];
-  BOOL add(const LASpoint* point);
-  BOOL has_fluff() const { return has_fluff(0) || has_fluff(1) || has_fluff(2); };
-  BOOL has_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_10[i])); };
-  BOOL has_serious_fluff() const { return has_serious_fluff(0) || has_serious_fluff(1) || has_serious_fluff(2); };
-  BOOL has_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_100[i])); };
-  BOOL has_very_serious_fluff() const { return has_very_serious_fluff(0) || has_very_serious_fluff(1) || has_very_serious_fluff(2); };
-  BOOL has_very_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_1000[i])); };
-  BOOL has_extremely_serious_fluff() const { return has_extremely_serious_fluff(0) || has_extremely_serious_fluff(1) || has_extremely_serious_fluff(2); };
-  BOOL has_extremely_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_10000[i])); };
+  bool add(const LASpoint* point);
+  bool has_fluff() const { return has_fluff(0) || has_fluff(1) || has_fluff(2); };
+  bool has_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_10[i])); };
+  bool has_serious_fluff() const { return has_serious_fluff(0) || has_serious_fluff(1) || has_serious_fluff(2); };
+  bool has_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_100[i])); };
+  bool has_very_serious_fluff() const { return has_very_serious_fluff(0) || has_very_serious_fluff(1) || has_very_serious_fluff(2); };
+  bool has_very_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_1000[i])); };
+  bool has_extremely_serious_fluff() const { return has_extremely_serious_fluff(0) || has_extremely_serious_fluff(1) || has_extremely_serious_fluff(2); };
+  bool has_extremely_serious_fluff(U32 i) const { return (number_of_point_records && (number_of_point_records == xyz_fluff_10000[i])); };
   LASsummary();
 private:
-  BOOL first;
+  bool first;
 };
 
 class LASbin
@@ -108,7 +108,7 @@ private:
   F32 clamp_min;
   F32 clamp_max;
   F32 one_over_step;
-  BOOL first;
+  bool first;
   I32 anker;
   I32 size_pos;
   I32 size_neg;
@@ -121,18 +121,18 @@ private:
 class LAShistogram
 {
 public:
-  BOOL active() const { return is_active; }; 
-  BOOL parse(int argc, char* argv[]);
+  bool active() const { return is_active; }; 
+  bool parse(int argc, char* argv[]);
   I32 unparse(CHAR* string) const;
-  BOOL histo(const CHAR* name, F32 step);
-  BOOL histo_avg(const CHAR* name, F32 step, const CHAR* name_avg);
+  bool histo(const CHAR* name, F32 step);
+  bool histo_avg(const CHAR* name, F32 step, const CHAR* name_avg);
   void add(const LASpoint* point);
   void report(FILE* file) const;
   void reset();
   LAShistogram();
   ~LAShistogram();
 private:
-  BOOL is_active;
+  bool is_active;
   // counter bins
   LASbin* x_bin;
   LASbin* y_bin;
@@ -173,23 +173,23 @@ class LASoccupancyGrid
 {
 public:
   void reset();
-  BOOL add(const LASpoint* point);
-  BOOL add(I32 pos_x, I32 pos_y);
-  BOOL occupied(const LASpoint* point) const;
-  BOOL occupied(I32 pos_x, I32 pos_y) const;
-  BOOL active() const;
+  bool add(const LASpoint* point);
+  bool add(I32 pos_x, I32 pos_y);
+  bool occupied(const LASpoint* point) const;
+  bool occupied(I32 pos_x, I32 pos_y) const;
+  bool active() const;
   U32 get_num_occupied() const { return num_occupied; };
-  BOOL write_asc_grid(const CHAR* file_name) const;
+  bool write_asc_grid(const CHAR* file_name) const;
 
   // read from file or write to file
-//  BOOL read(ByteStreamIn* stream);
-//  BOOL write(ByteStreamOut* stream) const;
+//  bool read(ByteStreamIn* stream);
+//  bool write(ByteStreamOut* stream) const;
 
   LASoccupancyGrid(F32 grid_spacing);
   ~LASoccupancyGrid();
   I32 min_x, min_y, max_x, max_y;
 private:
-  BOOL add_internal(I32 pos_x, I32 pos_y);
+  bool add_internal(I32 pos_x, I32 pos_y);
   F32 grid_spacing;
   I32 anker;
   I32* minus_ankers;

--- a/LASlib/inc/laswaveform13reader.hpp
+++ b/LASlib/inc/laswaveform13reader.hpp
@@ -59,16 +59,16 @@ public:
 
   U8* samples;
 
-  BOOL open(const char* file_name, I64 start_of_waveform_data_packet_record, const LASvlr_wave_packet_descr * const * wave_packet_descr);
-  BOOL is_compressed() const;
+  bool open(const char* file_name, I64 start_of_waveform_data_packet_record, const LASvlr_wave_packet_descr * const * wave_packet_descr);
+  bool is_compressed() const;
 
-  BOOL read_waveform(const LASpoint* point);
+  bool read_waveform(const LASpoint* point);
 
-  BOOL get_samples();
-  BOOL has_samples();
+  bool get_samples();
+  bool has_samples();
 
-  BOOL get_samples_xyz();
-  BOOL has_samples_xyz();
+  bool get_samples_xyz();
+  bool has_samples_xyz();
 
   void close();
 
@@ -76,7 +76,7 @@ public:
   ~LASwaveform13reader();
 
 private:
-  BOOL compressed;
+  bool compressed;
   U32 size;
   const LASvlr_wave_packet_descr * const * wave_packet_descr;
   FILE* file;

--- a/LASlib/inc/laswaveform13writer.hpp
+++ b/LASlib/inc/laswaveform13writer.hpp
@@ -42,9 +42,9 @@ class IntegerCompressor;
 class LASwaveform13writer
 {
 public:
-  BOOL open(const char* file_name, const LASvlr_wave_packet_descr * const * wave_packet_descr);
+  bool open(const char* file_name, const LASvlr_wave_packet_descr * const * wave_packet_descr);
 
-  BOOL write_waveform(LASpoint* point, U8* samples);
+  bool write_waveform(LASpoint* point, U8* samples);
 
   void close();
 

--- a/LASlib/inc/laswriter.hpp
+++ b/LASlib/inc/laswriter.hpp
@@ -52,12 +52,12 @@ public:
   I64 p_count;
   LASinventory inventory;
 
-  virtual BOOL write_point(const LASpoint* point) = 0;
+  virtual bool write_point(const LASpoint* point) = 0;
   virtual void update_inventory(const LASpoint* point) { inventory.add(point); };
-  virtual BOOL chunk() = 0;
+  virtual bool chunk() = 0;
 
-  virtual BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE) = 0;
-  virtual I64 close(BOOL update_npoints=TRUE) = 0;
+  virtual bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE) = 0;
+  virtual I64 close(bool update_npoints=TRUE) = 0;
 
   LASwriter() { npoints = 0; p_count = 0; };
   virtual ~LASwriter() {};
@@ -74,9 +74,9 @@ public:
   void set_file_name(const CHAR* file_name);
   void set_appendix(const CHAR* appendix);
   void set_cut(U32 cut);
-  BOOL set_format(I32 format);
-  BOOL set_format(const CHAR* format);
-  void set_force(BOOL force);
+  bool set_format(I32 format);
+  bool set_format(const CHAR* format);
+  void set_force(bool force);
   void set_chunk_size(U32 chunk_size);
   void make_numbered_file_name(const CHAR* file_name, I32 digits);
   void make_file_name(const CHAR* file_name, I32 file_number=-1);
@@ -86,7 +86,7 @@ public:
   const CHAR* get_file_name_only() const;
   CHAR* get_file_name_base() const;
   U32 get_cut() const;
-  BOOL format_was_specified() const;
+  bool format_was_specified() const;
   I32 get_format() const;
   const CHAR* get_format_name() const;
   void set_parse_string(const CHAR* parse_string);
@@ -95,9 +95,9 @@ public:
   inline const CHAR* get_separator() const { return separator; };
   void set_scale_rgb(F32 scale_rgb);
   void usage() const;
-  BOOL parse(int argc, char* argv[]);
-  BOOL active() const;
-  BOOL is_piped() const;
+  bool parse(int argc, char* argv[]);
+  bool active() const;
+  bool is_piped() const;
   LASwriter* open(const LASheader* header);
   LASwaveform13writer* open_waveform13(const LASheader* lasheader);
   LASwriteOpener();
@@ -111,18 +111,18 @@ private:
   CHAR* file_name;
   CHAR* appendix;
   U32 cut;
-  BOOL opts;
-  BOOL optx;
+  bool opts;
+  bool optx;
   CHAR* parse_string;
   CHAR* separator;
   F32 scale_rgb;
   U32 format;
-  BOOL specified;
-  BOOL force;
+  bool specified;
+  bool force;
   U32 chunk_size;
-  BOOL use_stdout;
-  BOOL use_nil;
-  BOOL buffered;
+  bool use_stdout;
+  bool use_nil;
+  bool buffered;
 };
 
 #endif

--- a/LASlib/inc/laswriter_bin.hpp
+++ b/LASlib/inc/laswriter_bin.hpp
@@ -43,17 +43,17 @@ class LASwriterBIN : public LASwriter
 {
 public:
 
-  BOOL refile(FILE* file);
+  bool refile(FILE* file);
 
-  BOOL open(const char* file_name, const LASheader* header, const char* version, U32 io_buffer_size=LAS_TOOLS_IO_OBUFFER_SIZE );
-  BOOL open(FILE* file, const LASheader* header, const char* version);
-  BOOL open(ByteStreamOut* stream, const LASheader* header, const char* version);
+  bool open(const char* file_name, const LASheader* header, const char* version, U32 io_buffer_size=LAS_TOOLS_IO_OBUFFER_SIZE );
+  bool open(FILE* file, const LASheader* header, const char* version);
+  bool open(ByteStreamOut* stream, const LASheader* header, const char* version);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterBIN();
   ~LASwriterBIN();

--- a/LASlib/inc/laswriter_las.hpp
+++ b/LASlib/inc/laswriter_las.hpp
@@ -58,30 +58,30 @@ class LASwriterLAS : public LASwriter
 {
 public:
 
-  BOOL refile(FILE* file);
+  bool refile(FILE* file);
 
-  BOOL open(const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
-  BOOL open(const char* file_name, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000, I32 io_buffer_size=LAS_TOOLS_IO_OBUFFER_SIZE);
-  BOOL open(FILE* file, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
-  BOOL open(ostream& ostream, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
+  bool open(const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
+  bool open(const char* file_name, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000, I32 io_buffer_size=LAS_TOOLS_IO_OBUFFER_SIZE);
+  bool open(FILE* file, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
+  bool open(ostream& ostream, const LASheader* header, U32 compressor=LASZIP_COMPRESSOR_NONE, I32 requested_version=0, I32 chunk_size=50000);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk();
+  bool write_point(const LASpoint* point);
+  bool chunk();
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterLAS();
   ~LASwriterLAS();
 
 private:
-  BOOL open(ByteStreamOut* stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size);
+  bool open(ByteStreamOut* stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size);
   ByteStreamOut* stream;
   LASwritePoint* writer;
   FILE* file;
   I64 header_start_position;
-  BOOL writing_las_1_4;
-  BOOL writing_new_point_type;
+  bool writing_las_1_4;
+  bool writing_new_point_type;
 };
 
 #endif

--- a/LASlib/inc/laswriter_qfit.hpp
+++ b/LASlib/inc/laswriter_qfit.hpp
@@ -41,17 +41,17 @@ class LASwriterQFIT : public LASwriter
 {
 public:
 
-  BOOL refile(FILE* file);
+  bool refile(FILE* file);
 
-  BOOL open(const char* file_name, const LASheader* header, I32 version=48, U32 io_buffer_size=65536);
-  BOOL open(FILE* file, const LASheader* header, I32 version=48);
-  BOOL open(ByteStreamOut* stream, const LASheader* header, I32 version=48);
+  bool open(const char* file_name, const LASheader* header, I32 version=48, U32 io_buffer_size=65536);
+  bool open(FILE* file, const LASheader* header, I32 version=48);
+  bool open(ByteStreamOut* stream, const LASheader* header, I32 version=48);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterQFIT();
   ~LASwriterQFIT();
@@ -60,8 +60,8 @@ private:
   ByteStreamOut* stream;
   FILE* file;
   I32 version;
-  BOOL endian_swap;
-  BOOL rescale_reoffset;
+  bool endian_swap;
+  bool rescale_reoffset;
   I32 buffer[14];
   I32 scan_azimuth_array_offset;
   I32 pitch_array_offset;

--- a/LASlib/inc/laswriter_txt.hpp
+++ b/LASlib/inc/laswriter_txt.hpp
@@ -39,37 +39,37 @@ class LASwriterTXT : public LASwriter
 {
 public:
 
-  void set_pts(BOOL pts);
-  void set_ptx(BOOL ptx);
+  void set_pts(bool pts);
+  void set_ptx(bool ptx);
   void set_scale_rgb(F32 scale_rgb);
 
-  BOOL refile(FILE* file);
+  bool refile(FILE* file);
 
-  BOOL open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string=0, const CHAR* separator=0);
-  BOOL open(FILE* file, const LASheader* header, const CHAR* parse_string=0, const CHAR* separator=0);
+  bool open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string=0, const CHAR* separator=0);
+  bool open(FILE* file, const LASheader* header, const CHAR* parse_string=0, const CHAR* separator=0);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterTXT();
   ~LASwriterTXT();
 
 private:
-  BOOL close_file;
+  bool close_file;
   FILE* file;
   const LASheader* header;
   CHAR* parse_string;
-  BOOL opts;
-  BOOL optx;
+  bool opts;
+  bool optx;
   F32 scale_rgb;
   CHAR separator_sign;
   CHAR printstring[512];
   I32 attribute_starts[10];
-  BOOL check_parse_string(const CHAR* parse_string);
-  BOOL unparse_attribute(const LASpoint* point, I32 index);
+  bool check_parse_string(const CHAR* parse_string);
+  bool unparse_attribute(const LASpoint* point, I32 index);
 };
 
 #endif

--- a/LASlib/inc/laswriter_wrl.hpp
+++ b/LASlib/inc/laswriter_wrl.hpp
@@ -39,20 +39,20 @@ class LASwriterWRL : public LASwriter
 {
 public:
 
-  BOOL open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string=0);
-  BOOL open(FILE* file, const LASheader* header, const CHAR* parse_string=0);
+  bool open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string=0);
+  bool open(FILE* file, const LASheader* header, const CHAR* parse_string=0);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterWRL();
   ~LASwriterWRL();
 
 private:
-  BOOL close_file;
+  bool close_file;
   FILE* file;
   const LASheader* header;
   CHAR printstring[512];

--- a/LASlib/inc/laswritercompatible.hpp
+++ b/LASlib/inc/laswritercompatible.hpp
@@ -37,13 +37,13 @@
 class LASwriterCompatibleDown : public LASwriter
 {
 public:
-  BOOL open(LASheader* header, LASwriteOpener* laswriteopener, BOOL moveCRSfromEVLRtoVLR=FALSE, BOOL moveEVLRtoVLR=FALSE);
+  bool open(LASheader* header, LASwriteOpener* laswriteopener, bool moveCRSfromEVLRtoVLR=FALSE, bool moveEVLRtoVLR=FALSE);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterCompatibleDown();
   ~LASwriterCompatibleDown();
@@ -62,13 +62,13 @@ private:
 class LASwriterCompatibleUp : public LASwriter
 {
 public:
-  BOOL open(LASheader* header, LASwriteOpener* laswriteopener);
+  bool open(LASheader* header, LASwriteOpener* laswriteopener);
 
-  BOOL write_point(const LASpoint* point);
-  BOOL chunk() { return FALSE; };
+  bool write_point(const LASpoint* point);
+  bool chunk() { return FALSE; };
 
-  BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE);
-  I64 close(BOOL update_npoints=TRUE);
+  bool update_header(const LASheader* header, bool use_inventory=FALSE, bool update_extra_bytes=FALSE);
+  I64 close(bool update_npoints=TRUE);
 
   LASwriterCompatibleUp();
   ~LASwriterCompatibleUp();

--- a/LASlib/src/lasfilter.cpp
+++ b/LASlib/src/lasfilter.cpp
@@ -44,7 +44,7 @@ class LAScriterionAnd : public LAScriterion
 public:
   inline const CHAR* name() const { return "filter_and"; };
   inline I32 get_command(CHAR* string) const { int n = 0; n += one->get_command(&string[n]); n += two->get_command(&string[n]); n += sprintf(&string[n], "-%s ", name()); return n; };
-  inline BOOL filter(const LASpoint* point) { return one->filter(point) && two->filter(point); };
+  inline bool filter(const LASpoint* point) { return one->filter(point) && two->filter(point); };
   LAScriterionAnd(LAScriterion* one, LAScriterion* two) { this->one = one; this->two = two; };
 private:
   LAScriterion* one;
@@ -56,7 +56,7 @@ class LAScriterionOr : public LAScriterion
 public:
   inline const CHAR* name() const { return "filter_or"; };
   inline I32 get_command(CHAR* string) const { int n = 0; n += one->get_command(&string[n]); n += two->get_command(&string[n]); n += sprintf(&string[n], "-%s ", name()); return n; };
-  inline BOOL filter(const LASpoint* point) { return one->filter(point) || two->filter(point); };
+  inline bool filter(const LASpoint* point) { return one->filter(point) || two->filter(point); };
   LAScriterionOr(LAScriterion* one, LAScriterion* two) { this->one = one; this->two = two; };
 private:
   LAScriterion* one;
@@ -68,7 +68,7 @@ class LAScriterionKeepTile : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_tile"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g ", name(), ll_x, ll_y, tile_size); };
-  inline BOOL filter(const LASpoint* point) { return (!point->inside_tile(ll_x, ll_y, ur_x, ur_y)); };
+  inline bool filter(const LASpoint* point) { return (!point->inside_tile(ll_x, ll_y, ur_x, ur_y)); };
   LAScriterionKeepTile(F32 ll_x, F32 ll_y, F32 tile_size) { this->ll_x = ll_x; this->ll_y = ll_y; this->ur_x = ll_x+tile_size; this->ur_y = ll_y+tile_size; this->tile_size = tile_size; };
 private:
   F32 ll_x, ll_y, ur_x, ur_y, tile_size;
@@ -79,7 +79,7 @@ class LAScriterionKeepCircle : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_circle"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g ", name(), center_x, center_y, radius); };
-  inline BOOL filter(const LASpoint* point) { return (!point->inside_circle(center_x, center_y, radius_squared)); };
+  inline bool filter(const LASpoint* point) { return (!point->inside_circle(center_x, center_y, radius_squared)); };
   LAScriterionKeepCircle(F64 x, F64 y, F64 radius) { this->center_x = x; this->center_y = y; this->radius = radius; this->radius_squared = radius*radius; };
 private:
   F64 center_x, center_y, radius, radius_squared;
@@ -90,7 +90,7 @@ class LAScriterionKeepxyz : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_xyz"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g %g %g %g ", name(), min_x, min_y, min_z, max_x, max_y, max_z); };
-  inline BOOL filter(const LASpoint* point) { return (!point->inside_box(min_x, min_y, min_z, max_x, max_y, max_z)); };
+  inline bool filter(const LASpoint* point) { return (!point->inside_box(min_x, min_y, min_z, max_x, max_y, max_z)); };
   LAScriterionKeepxyz(F64 min_x, F64 min_y, F64 min_z, F64 max_x, F64 max_y, F64 max_z) { this->min_x = min_x; this->min_y = min_y; this->min_z = min_z; this->max_x = max_x; this->max_y = max_y; this->max_z = max_z; };
 private:
   F64 min_x, min_y, min_z, max_x, max_y, max_z;
@@ -101,7 +101,7 @@ class LAScriterionDropxyz : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_xyz"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g %g %g %g ", name(), min_x, min_y, min_z, max_x, max_y, max_z); };
-  inline BOOL filter(const LASpoint* point) { return (point->inside_box(min_x, min_y, min_z, max_x, max_y, max_z)); };
+  inline bool filter(const LASpoint* point) { return (point->inside_box(min_x, min_y, min_z, max_x, max_y, max_z)); };
   LAScriterionDropxyz(F64 min_x, F64 min_y, F64 min_z, F64 max_x, F64 max_y, F64 max_z) { this->min_x = min_x; this->min_y = min_y; this->min_z = min_z; this->max_x = max_x; this->max_y = max_y; this->max_z = max_z; };
 private:
   F64 min_x, min_y, min_z, max_x, max_y, max_z;
@@ -112,7 +112,7 @@ class LAScriterionKeepxy : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_xy"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g %g ", name(), below_x, below_y, above_x, above_y); };
-  inline BOOL filter(const LASpoint* point) { return (!point->inside_rectangle(below_x, below_y, above_x, above_y)); };
+  inline bool filter(const LASpoint* point) { return (!point->inside_rectangle(below_x, below_y, above_x, above_y)); };
   LAScriterionKeepxy(F64 below_x, F64 below_y, F64 above_x, F64 above_y) { this->below_x = below_x; this->below_y = below_y; this->above_x = above_x; this->above_y = above_y; };
 private:
   F64 below_x, below_y, above_x, above_y;
@@ -123,7 +123,7 @@ class LAScriterionDropxy : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_xy"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g %g %g ", name(), below_x, below_y, above_x, above_y); };
-  inline BOOL filter(const LASpoint* point) { return (point->inside_rectangle(below_x, below_y, above_x, above_y)); };
+  inline bool filter(const LASpoint* point) { return (point->inside_rectangle(below_x, below_y, above_x, above_y)); };
   LAScriterionDropxy(F64 below_x, F64 below_y, F64 above_x, F64 above_y) { this->below_x = below_x; this->below_y = below_y; this->above_x = above_x; this->above_y = above_y; };
 private:
   F64 below_x, below_y, above_x, above_y;
@@ -134,7 +134,7 @@ class LAScriterionKeepx : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_x"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_x, above_x); };
-  inline BOOL filter(const LASpoint* point) { F64 x = point->get_x(); return (x < below_x) || (x >= above_x); };
+  inline bool filter(const LASpoint* point) { F64 x = point->get_x(); return (x < below_x) || (x >= above_x); };
   LAScriterionKeepx(F64 below_x, F64 above_x) { this->below_x = below_x; this->above_x = above_x; };
 private:
   F64 below_x, above_x;
@@ -145,7 +145,7 @@ class LAScriterionDropx : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_x"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_x, above_x); };
-  inline BOOL filter(const LASpoint* point) { F64 x = point->get_x(); return ((below_x <= x) && (x < above_x)); };
+  inline bool filter(const LASpoint* point) { F64 x = point->get_x(); return ((below_x <= x) && (x < above_x)); };
   LAScriterionDropx(F64 below_x, F64 above_x) { this->below_x = below_x; this->above_x = above_x; };
 private:
   F64 below_x, above_x;
@@ -156,7 +156,7 @@ class LAScriterionKeepy : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_y"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_y, above_y); };
-  inline BOOL filter(const LASpoint* point) { F64 y = point->get_y(); return (y < below_y) || (y >= above_y); };
+  inline bool filter(const LASpoint* point) { F64 y = point->get_y(); return (y < below_y) || (y >= above_y); };
   LAScriterionKeepy(F64 below_y, F64 above_y) { this->below_y = below_y; this->above_y = above_y; };
 private:
   F64 below_y, above_y;
@@ -167,7 +167,7 @@ class LAScriterionDropy : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_y"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_y, above_y); };
-  inline BOOL filter(const LASpoint* point) { F64 y = point->get_y(); return ((below_y <= y) && (y < above_y)); };
+  inline bool filter(const LASpoint* point) { F64 y = point->get_y(); return ((below_y <= y) && (y < above_y)); };
   LAScriterionDropy(F64 below_y, F64 above_y) { this->below_y = below_y; this->above_y = above_y; };
 private:
   F64 below_y, above_y;
@@ -178,7 +178,7 @@ class LAScriterionKeepz : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_z"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_z, above_z); };
-  inline BOOL filter(const LASpoint* point) { F64 z = point->get_z(); return (z < below_z) || (z >= above_z); };
+  inline bool filter(const LASpoint* point) { F64 z = point->get_z(); return (z < below_z) || (z >= above_z); };
   LAScriterionKeepz(F64 below_z, F64 above_z) { this->below_z = below_z; this->above_z = above_z; };
 private:
   F64 below_z, above_z;
@@ -189,7 +189,7 @@ class LAScriterionDropz : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_z"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(), below_z, above_z); };
-  inline BOOL filter(const LASpoint* point) { F64 z = point->get_z(); return ((below_z <= z) && (z < above_z)); };
+  inline bool filter(const LASpoint* point) { F64 z = point->get_z(); return ((below_z <= z) && (z < above_z)); };
   LAScriterionDropz(F64 below_z, F64 above_z) { this->below_z = below_z; this->above_z = above_z; };
 private:
   F64 below_z, above_z;
@@ -200,7 +200,7 @@ class LAScriterionDropxBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_x_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), below_x); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_x() < below_x); };
+  inline bool filter(const LASpoint* point) { return (point->get_x() < below_x); };
   LAScriterionDropxBelow(F64 below_x) { this->below_x = below_x; };
 private:
   F64 below_x;
@@ -211,7 +211,7 @@ class LAScriterionDropxAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_x_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), above_x); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_x() >= above_x); };
+  inline bool filter(const LASpoint* point) { return (point->get_x() >= above_x); };
   LAScriterionDropxAbove(F64 above_x) { this->above_x = above_x; };
 private:
   F64 above_x;
@@ -222,7 +222,7 @@ class LAScriterionDropyBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_y_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), below_y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_y() < below_y); };
+  inline bool filter(const LASpoint* point) { return (point->get_y() < below_y); };
   LAScriterionDropyBelow(F64 below_y) { this->below_y = below_y; };
 private:
   F64 below_y;
@@ -233,7 +233,7 @@ class LAScriterionDropyAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_y_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), above_y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_y() >= above_y); };
+  inline bool filter(const LASpoint* point) { return (point->get_y() >= above_y); };
   LAScriterionDropyAbove(F64 above_y) { this->above_y = above_y; };
 private:
   F64 above_y;
@@ -244,7 +244,7 @@ class LAScriterionDropzBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_z_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), below_z); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_z() < below_z); };
+  inline bool filter(const LASpoint* point) { return (point->get_z() < below_z); };
   LAScriterionDropzBelow(F64 below_z) { this->below_z = below_z; };
 private:
   F64 below_z;
@@ -255,7 +255,7 @@ class LAScriterionDropzAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_z_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), above_z); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_z() >= above_z); };
+  inline bool filter(const LASpoint* point) { return (point->get_z() >= above_z); };
   LAScriterionDropzAbove(F64 above_z) { this->above_z = above_z; };
 private:
   F64 above_z;
@@ -266,7 +266,7 @@ class LAScriterionKeepXY : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_XY"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d %d %d ", name(), below_X, below_Y, above_X, above_Y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_X() < below_X) || (point->get_Y() < below_Y) || (point->get_X() >= above_X) || (point->get_Y() >= above_Y); };
+  inline bool filter(const LASpoint* point) { return (point->get_X() < below_X) || (point->get_Y() < below_Y) || (point->get_X() >= above_X) || (point->get_Y() >= above_Y); };
   LAScriterionKeepXY(I32 below_X, I32 below_Y, I32 above_X, I32 above_Y) { this->below_X = below_X; this->below_Y = below_Y; this->above_X = above_X; this->above_Y = above_Y; };
 private:
   I32 below_X, below_Y, above_X, above_Y;
@@ -277,7 +277,7 @@ class LAScriterionKeepX : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_X"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_X, above_X); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_X() < below_X) || (above_X <= point->get_X()); };
+  inline bool filter(const LASpoint* point) { return (point->get_X() < below_X) || (above_X <= point->get_X()); };
   LAScriterionKeepX(I32 below_X, I32 above_X) { this->below_X = below_X; this->above_X = above_X; };
 private:
   I32 below_X, above_X;
@@ -288,7 +288,7 @@ class LAScriterionDropX : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_X"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_X, above_X); };
-  inline BOOL filter(const LASpoint* point) { return ((below_X <= point->get_X()) && (point->get_X() < above_X)); };
+  inline bool filter(const LASpoint* point) { return ((below_X <= point->get_X()) && (point->get_X() < above_X)); };
   LAScriterionDropX(I32 below_X, I32 above_X) { this->below_X = below_X; this->above_X = above_X; };
 private:
   I32 below_X;
@@ -300,7 +300,7 @@ class LAScriterionKeepY : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_Y"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_Y, above_Y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Y() < below_Y) || (above_Y <= point->get_Y()); };
+  inline bool filter(const LASpoint* point) { return (point->get_Y() < below_Y) || (above_Y <= point->get_Y()); };
   LAScriterionKeepY(I32 below_Y, I32 above_Y) { this->below_Y = below_Y; this->above_Y = above_Y; };
 private:
   I32 below_Y, above_Y;
@@ -311,7 +311,7 @@ class LAScriterionDropY : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Y"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_Y, above_Y); };
-  inline BOOL filter(const LASpoint* point) { return ((below_Y <= point->get_Y()) && (point->get_Y() < above_Y)); };
+  inline bool filter(const LASpoint* point) { return ((below_Y <= point->get_Y()) && (point->get_Y() < above_Y)); };
   LAScriterionDropY(I32 below_Y, I32 above_Y) { this->below_Y = below_Y; this->above_Y = above_Y; };
 private:
   I32 below_Y;
@@ -323,7 +323,7 @@ class LAScriterionKeepZ : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_Z"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_Z, above_Z); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Z() < below_Z) || (above_Z <= point->get_Z()); };
+  inline bool filter(const LASpoint* point) { return (point->get_Z() < below_Z) || (above_Z <= point->get_Z()); };
   LAScriterionKeepZ(I32 below_Z, I32 above_Z) { this->below_Z = below_Z; this->above_Z = above_Z; };
 private:
   I32 below_Z, above_Z;
@@ -334,7 +334,7 @@ class LAScriterionDropZ : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Z"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_Z, above_Z); };
-  inline BOOL filter(const LASpoint* point) { return ((below_Z <= point->get_Z()) && (point->get_Z() < above_Z)); };
+  inline bool filter(const LASpoint* point) { return ((below_Z <= point->get_Z()) && (point->get_Z() < above_Z)); };
   LAScriterionDropZ(I32 below_Z, I32 above_Z) { this->below_Z = below_Z; this->above_Z = above_Z; };
 private:
   I32 below_Z;
@@ -346,7 +346,7 @@ class LAScriterionDropXBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_X_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_X); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_X() < below_X); };
+  inline bool filter(const LASpoint* point) { return (point->get_X() < below_X); };
   LAScriterionDropXBelow(I32 below_X) { this->below_X = below_X; };
 private:
   I32 below_X;
@@ -357,7 +357,7 @@ class LAScriterionDropXAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_X_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_X); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_X() >= above_X); };
+  inline bool filter(const LASpoint* point) { return (point->get_X() >= above_X); };
   LAScriterionDropXAbove(I32 above_X) { this->above_X = above_X; };
 private:
   I32 above_X;
@@ -368,7 +368,7 @@ class LAScriterionDropYBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Y_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_Y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Y() < below_Y); };
+  inline bool filter(const LASpoint* point) { return (point->get_Y() < below_Y); };
   LAScriterionDropYBelow(I32 below_Y) { this->below_Y = below_Y; };
 private:
   I32 below_Y;
@@ -379,7 +379,7 @@ class LAScriterionDropYAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Y_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_Y); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Y() >= above_Y); };
+  inline bool filter(const LASpoint* point) { return (point->get_Y() >= above_Y); };
   LAScriterionDropYAbove(I32 above_Y) { this->above_Y = above_Y; };
 private:
   I32 above_Y;
@@ -390,7 +390,7 @@ class LAScriterionDropZBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Z_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_Z); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Z() < below_Z); };
+  inline bool filter(const LASpoint* point) { return (point->get_Z() < below_Z); };
   LAScriterionDropZBelow(I32 below_Z) { this->below_Z = below_Z; };
 private:
   I32 below_Z;
@@ -401,7 +401,7 @@ class LAScriterionDropZAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_Z_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_Z); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_Z() >= above_Z); };
+  inline bool filter(const LASpoint* point) { return (point->get_Z() >= above_Z); };
   LAScriterionDropZAbove(I32 above_Z) { this->above_Z = above_Z; };
 private:
   I32 above_Z;
@@ -412,7 +412,7 @@ class LAScriterionKeepFirstReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_first"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->return_number > 1); };
+  inline bool filter(const LASpoint* point) { return (point->return_number > 1); };
 };
 
 class LAScriterionKeepFirstOfManyReturn : public LAScriterion
@@ -420,7 +420,7 @@ class LAScriterionKeepFirstOfManyReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_first_of_many"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->number_of_returns == 1) || (point->return_number > 1)); };
+  inline bool filter(const LASpoint* point) { return ((point->number_of_returns == 1) || (point->return_number > 1)); };
 };
 
 class LAScriterionKeepMiddleReturn : public LAScriterion
@@ -428,7 +428,7 @@ class LAScriterionKeepMiddleReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_middle"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->return_number == 1) || (point->return_number >= point->number_of_returns)); };
+  inline bool filter(const LASpoint* point) { return ((point->return_number == 1) || (point->return_number >= point->number_of_returns)); };
 };
 
 class LAScriterionKeepLastReturn : public LAScriterion
@@ -436,7 +436,7 @@ class LAScriterionKeepLastReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_last"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->return_number < point->number_of_returns); };
+  inline bool filter(const LASpoint* point) { return (point->return_number < point->number_of_returns); };
 };
 
 class LAScriterionKeepLastOfManyReturn : public LAScriterion
@@ -444,7 +444,7 @@ class LAScriterionKeepLastOfManyReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_last_of_many"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->return_number == 1) || (point->return_number < point->number_of_returns)); };
+  inline bool filter(const LASpoint* point) { return ((point->return_number == 1) || (point->return_number < point->number_of_returns)); };
 };
 
 class LAScriterionDropFirstReturn : public LAScriterion
@@ -452,7 +452,7 @@ class LAScriterionDropFirstReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_first"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->return_number == 1); };
+  inline bool filter(const LASpoint* point) { return (point->return_number == 1); };
 };
 
 class LAScriterionDropFirstOfManyReturn : public LAScriterion
@@ -460,7 +460,7 @@ class LAScriterionDropFirstOfManyReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_first_of_many"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->number_of_returns > 1) && (point->return_number == 1)); };
+  inline bool filter(const LASpoint* point) { return ((point->number_of_returns > 1) && (point->return_number == 1)); };
 };
 
 class LAScriterionDropMiddleReturn : public LAScriterion
@@ -468,7 +468,7 @@ class LAScriterionDropMiddleReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_middle"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->return_number > 1) && (point->return_number < point->number_of_returns)); };
+  inline bool filter(const LASpoint* point) { return ((point->return_number > 1) && (point->return_number < point->number_of_returns)); };
 };
 
 class LAScriterionDropLastReturn : public LAScriterion
@@ -476,7 +476,7 @@ class LAScriterionDropLastReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_last"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->return_number >= point->number_of_returns); };
+  inline bool filter(const LASpoint* point) { return (point->return_number >= point->number_of_returns); };
 };
 
 class LAScriterionDropLastOfManyReturn : public LAScriterion
@@ -484,7 +484,7 @@ class LAScriterionDropLastOfManyReturn : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_last_of_many"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return ((point->number_of_returns > 1) && (point->return_number >= point->number_of_returns)); };
+  inline bool filter(const LASpoint* point) { return ((point->number_of_returns > 1) && (point->return_number >= point->number_of_returns)); };
 };
 
 class LAScriterionKeepReturns : public LAScriterion
@@ -492,7 +492,7 @@ class LAScriterionKeepReturns : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_return_mask"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %u ", name(), ~drop_return_mask); };
-  inline BOOL filter(const LASpoint* point) { return ((1 << point->return_number) & drop_return_mask); };
+  inline bool filter(const LASpoint* point) { return ((1 << point->return_number) & drop_return_mask); };
   LAScriterionKeepReturns(U32 keep_return_mask) { drop_return_mask = ~keep_return_mask; };
 private:
   U32 drop_return_mask;
@@ -503,7 +503,7 @@ class LAScriterionKeepSpecificNumberOfReturns : public LAScriterion
 public:
   inline const CHAR* name() const { return (numberOfReturns == 1 ? "keep_single" : (numberOfReturns == 2 ? "keep_double" : (numberOfReturns == 3 ? "keep_triple" : (numberOfReturns == 4 ? "keep_quadruple" : "keep_quintuple")))); };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->number_of_returns != numberOfReturns); };
+  inline bool filter(const LASpoint* point) { return (point->number_of_returns != numberOfReturns); };
   LAScriterionKeepSpecificNumberOfReturns(U32 numberOfReturns) { this->numberOfReturns = numberOfReturns; };
 private:
   U32 numberOfReturns;
@@ -514,7 +514,7 @@ class LAScriterionDropSpecificNumberOfReturns : public LAScriterion
 public:
   inline const CHAR* name() const { return (numberOfReturns == 1 ? "drop_single" : (numberOfReturns == 2 ? "drop_double" : (numberOfReturns == 3 ? "drop_triple" : (numberOfReturns == 4 ? "drop_quadruple" : "drop_quintuple")))); };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->number_of_returns == numberOfReturns); };
+  inline bool filter(const LASpoint* point) { return (point->number_of_returns == numberOfReturns); };
   LAScriterionDropSpecificNumberOfReturns(U32 numberOfReturns) { this->numberOfReturns = numberOfReturns; };
 private:
   U32 numberOfReturns;
@@ -525,7 +525,7 @@ class LAScriterionDropScanDirection : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_scan_direction"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), scan_direction); };
-  inline BOOL filter(const LASpoint* point) { return (scan_direction == point->scan_direction_flag); };
+  inline bool filter(const LASpoint* point) { return (scan_direction == point->scan_direction_flag); };
   LAScriterionDropScanDirection(I32 scan_direction) { this->scan_direction = scan_direction; };
 private:
   I32 scan_direction;
@@ -536,7 +536,7 @@ class LAScriterionKeepScanDirectionChange : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_scan_direction_change"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { if (scan_direction_flag == point->scan_direction_flag) return TRUE; I32 s = scan_direction_flag; scan_direction_flag = point->scan_direction_flag; return s == -1; };
+  inline bool filter(const LASpoint* point) { if (scan_direction_flag == point->scan_direction_flag) return TRUE; I32 s = scan_direction_flag; scan_direction_flag = point->scan_direction_flag; return s == -1; };
   void reset() { scan_direction_flag = -1; };
   LAScriterionKeepScanDirectionChange() { reset(); };
 private:
@@ -548,7 +548,7 @@ class LAScriterionKeepEdgeOfFlightLine : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_edge_of_flight_line"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->edge_of_flight_line == 0); };
+  inline bool filter(const LASpoint* point) { return (point->edge_of_flight_line == 0); };
 };
 
 class LAScriterionKeepScannerChannel : public LAScriterion
@@ -556,7 +556,7 @@ class LAScriterionKeepScannerChannel : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_extended_scanner_channel"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), scanner_channel); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_extended_scanner_channel() != scanner_channel); };
+  inline bool filter(const LASpoint* point) { return (point->get_extended_scanner_channel() != scanner_channel); };
   LAScriterionKeepScannerChannel(I32 scanner_channel) { this->scanner_channel = scanner_channel; };
 private:
   I32 scanner_channel;
@@ -567,7 +567,7 @@ class LAScriterionDropScannerChannel : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_extended_scanner_channel"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), scanner_channel); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_extended_scanner_channel() == scanner_channel); };
+  inline bool filter(const LASpoint* point) { return (point->get_extended_scanner_channel() == scanner_channel); };
   LAScriterionDropScannerChannel(I32 scanner_channel) { this->scanner_channel = scanner_channel; };
 private:
   I32 scanner_channel;
@@ -578,7 +578,7 @@ class LAScriterionKeepRGB : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_RGB"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s_%s %d %d ", name(), (channel == 0 ? "red" : (channel == 1 ? "green" : (channel == 2 ? "blue" : "nir"))),  below_RGB, above_RGB); };
-  inline BOOL filter(const LASpoint* point) { return ((point->rgb[channel] < below_RGB) || (above_RGB < point->rgb[channel])); };
+  inline bool filter(const LASpoint* point) { return ((point->rgb[channel] < below_RGB) || (above_RGB < point->rgb[channel])); };
   LAScriterionKeepRGB(I32 below_RGB, I32 above_RGB, I32 channel) { if (above_RGB < below_RGB) { this->below_RGB = above_RGB; this->above_RGB = below_RGB; } else { this->below_RGB = below_RGB; this->above_RGB = above_RGB; }; this->channel = channel; };
 private:
   I32 below_RGB, above_RGB, channel;
@@ -589,7 +589,7 @@ class LAScriterionKeepNDVI : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_NDVI"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s%s %g %g ", name(), (NIR == 1 ? "_green_is_NIR" : "_blue_is_NIR"),  below_NDVI, above_NDVI); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   { 
     F32 NDVI = ((F32)(point->rgb[NIR] - point->get_R())) / ((F32)(point->rgb[NIR] + point->get_R()));
     return (NDVI < below_NDVI) || (above_NDVI < NDVI);
@@ -605,7 +605,7 @@ class LAScriterionKeepNDVIfromCIR : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_NDVI_from_CIR"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(),  below_NDVI, above_NDVI); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   { 
     F32 NDVI = ((F32)(point->get_R() - point->get_G())) / ((F32)(point->get_R() + point->get_G()));
     return (NDVI < below_NDVI) || (above_NDVI < NDVI);
@@ -620,7 +620,7 @@ class LAScriterionKeepNDVIintensityIsNIR : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_NDVI_intensity_is_NIR"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g %g ", name(),  below_NDVI, above_NDVI); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   { 
     F32 NDVI = ((F32)(point->get_intensity() - point->get_R())) / ((F32)(point->get_intensity() + point->get_R()));
     return (NDVI < below_NDVI) || (above_NDVI < NDVI);
@@ -635,7 +635,7 @@ class LAScriterionKeepScanAngle : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_scan_angle"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_scan, above_scan); };
-  inline BOOL filter(const LASpoint* point) { return (point->scan_angle_rank < below_scan) || (above_scan < point->scan_angle_rank); };
+  inline bool filter(const LASpoint* point) { return (point->scan_angle_rank < below_scan) || (above_scan < point->scan_angle_rank); };
   LAScriterionKeepScanAngle(I32 below_scan, I32 above_scan) { if (above_scan < below_scan) { this->below_scan = above_scan; this->above_scan = below_scan; } else { this->below_scan = below_scan; this->above_scan = above_scan; } };
 private:
   I32 below_scan, above_scan;
@@ -646,7 +646,7 @@ class LAScriterionDropScanAngleBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_scan_angle_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_scan); };
-  inline BOOL filter(const LASpoint* point) { return (point->scan_angle_rank < below_scan); };
+  inline bool filter(const LASpoint* point) { return (point->scan_angle_rank < below_scan); };
   LAScriterionDropScanAngleBelow(I32 below_scan) { this->below_scan = below_scan; };
 private:
   I32 below_scan;
@@ -657,7 +657,7 @@ class LAScriterionDropScanAngleAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_scan_angle_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_scan); };
-  inline BOOL filter(const LASpoint* point) { return (point->scan_angle_rank > above_scan); };
+  inline bool filter(const LASpoint* point) { return (point->scan_angle_rank > above_scan); };
   LAScriterionDropScanAngleAbove(I32 above_scan) { this->above_scan = above_scan; };
 private:
   I32 above_scan;
@@ -668,7 +668,7 @@ class LAScriterionDropScanAngleBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_scan_angle_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_scan, above_scan); };
-  inline BOOL filter(const LASpoint* point) { return (below_scan <= point->scan_angle_rank) && (point->scan_angle_rank <= above_scan); };
+  inline bool filter(const LASpoint* point) { return (below_scan <= point->scan_angle_rank) && (point->scan_angle_rank <= above_scan); };
   LAScriterionDropScanAngleBetween(I32 below_scan, I32 above_scan) { if (above_scan < below_scan) { this->below_scan = above_scan; this->above_scan = below_scan; } else { this->below_scan = below_scan; this->above_scan = above_scan; } };
 private:
   I32 below_scan, above_scan;
@@ -679,7 +679,7 @@ class LAScriterionKeepIntensity : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_intensity"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_intensity, above_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (point->intensity < below_intensity) || (point->intensity > above_intensity); };
+  inline bool filter(const LASpoint* point) { return (point->intensity < below_intensity) || (point->intensity > above_intensity); };
   LAScriterionKeepIntensity(I32 below_intensity, I32 above_intensity) { this->below_intensity = below_intensity; this->above_intensity = above_intensity; };
 private:
   I32 below_intensity, above_intensity;
@@ -690,7 +690,7 @@ class LAScriterionKeepIntensityBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_intensity_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (point->intensity >= below_intensity); };
+  inline bool filter(const LASpoint* point) { return (point->intensity >= below_intensity); };
   LAScriterionKeepIntensityBelow(I32 below_intensity) { this->below_intensity = below_intensity; };
 private:
   I32 below_intensity;
@@ -701,7 +701,7 @@ class LAScriterionKeepIntensityAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_intensity_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (point->intensity <= above_intensity); };
+  inline bool filter(const LASpoint* point) { return (point->intensity <= above_intensity); };
   LAScriterionKeepIntensityAbove(I32 above_intensity) { this->above_intensity = above_intensity; };
 private:
   I32 above_intensity;
@@ -712,7 +712,7 @@ class LAScriterionDropIntensityBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_intensity_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (point->intensity < below_intensity); };
+  inline bool filter(const LASpoint* point) { return (point->intensity < below_intensity); };
   LAScriterionDropIntensityBelow(I32 below_intensity) { this->below_intensity = below_intensity; };
 private:
   I32 below_intensity;
@@ -723,7 +723,7 @@ class LAScriterionDropIntensityAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_intensity_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (point->intensity > above_intensity); };
+  inline bool filter(const LASpoint* point) { return (point->intensity > above_intensity); };
   LAScriterionDropIntensityAbove(I32 above_intensity) { this->above_intensity = above_intensity; };
 private:
   I32 above_intensity;
@@ -734,7 +734,7 @@ class LAScriterionDropIntensityBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_intensity_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_intensity, above_intensity); };
-  inline BOOL filter(const LASpoint* point) { return (below_intensity <= point->intensity) && (point->intensity <= above_intensity); };
+  inline bool filter(const LASpoint* point) { return (below_intensity <= point->intensity) && (point->intensity <= above_intensity); };
   LAScriterionDropIntensityBetween(I32 below_intensity, I32 above_intensity) { this->below_intensity = below_intensity; this->above_intensity = above_intensity; };
 private:
   I32 below_intensity, above_intensity;
@@ -759,7 +759,7 @@ public:
     }
     return n;
   };
-  inline BOOL filter(const LASpoint* point) { return ((1 << point->classification) & drop_classification_mask); };
+  inline bool filter(const LASpoint* point) { return ((1 << point->classification) & drop_classification_mask); };
   LAScriterionDropClassifications(U32 drop_classification_mask) { this->drop_classification_mask = drop_classification_mask; };
 private:
   U32 drop_classification_mask;
@@ -770,7 +770,7 @@ class LAScriterionDropExtendedClassifications : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_extended_classification_mask"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %u %u %u %u %u %u %u %u ", name(), drop_extended_classification_mask[7], drop_extended_classification_mask[6], drop_extended_classification_mask[5], drop_extended_classification_mask[4], drop_extended_classification_mask[3], drop_extended_classification_mask[2], drop_extended_classification_mask[1], drop_extended_classification_mask[0]); };
-  inline BOOL filter(const LASpoint* point) { return ((1 << (point->extended_classification - (32 * (point->extended_classification / 32)))) & drop_extended_classification_mask[point->extended_classification / 32]); };
+  inline bool filter(const LASpoint* point) { return ((1 << (point->extended_classification - (32 * (point->extended_classification / 32)))) & drop_extended_classification_mask[point->extended_classification / 32]); };
   LAScriterionDropExtendedClassifications(U32 drop_extended_classification_mask[8]) { for (I32 i = 0; i < 8; i++) this->drop_extended_classification_mask[i] = drop_extended_classification_mask[i]; };
 private:
   U32 drop_extended_classification_mask[8];
@@ -781,7 +781,7 @@ class LAScriterionDropSynthetic : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_synthetic"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_synthetic_flag() == 1); };
+  inline bool filter(const LASpoint* point) { return (point->get_synthetic_flag() == 1); };
 };
 
 class LAScriterionKeepSynthetic : public LAScriterion
@@ -789,7 +789,7 @@ class LAScriterionKeepSynthetic : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_synthetic"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_synthetic_flag() == 0); };
+  inline bool filter(const LASpoint* point) { return (point->get_synthetic_flag() == 0); };
 };
 
 class LAScriterionDropKeypoint : public LAScriterion
@@ -797,7 +797,7 @@ class LAScriterionDropKeypoint : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_keypoint"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_keypoint_flag() == 1); };
+  inline bool filter(const LASpoint* point) { return (point->get_keypoint_flag() == 1); };
 };
 
 class LAScriterionKeepKeypoint : public LAScriterion
@@ -805,7 +805,7 @@ class LAScriterionKeepKeypoint : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_keypoint"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_keypoint_flag() == 0); };
+  inline bool filter(const LASpoint* point) { return (point->get_keypoint_flag() == 0); };
 };
 
 class LAScriterionDropWithheld : public LAScriterion
@@ -813,7 +813,7 @@ class LAScriterionDropWithheld : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_withheld"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_withheld_flag() == 1); };
+  inline bool filter(const LASpoint* point) { return (point->get_withheld_flag() == 1); };
 };
 
 class LAScriterionKeepWithheld : public LAScriterion
@@ -821,7 +821,7 @@ class LAScriterionKeepWithheld : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_withheld"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_withheld_flag() == 0); };
+  inline bool filter(const LASpoint* point) { return (point->get_withheld_flag() == 0); };
 };
 
 class LAScriterionDropOverlap : public LAScriterion
@@ -829,7 +829,7 @@ class LAScriterionDropOverlap : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_overlap"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_extended_overlap_flag() == 1); };
+  inline bool filter(const LASpoint* point) { return (point->get_extended_overlap_flag() == 1); };
 };
 
 class LAScriterionKeepOverlap : public LAScriterion
@@ -837,7 +837,7 @@ class LAScriterionKeepOverlap : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_overlap"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s ", name()); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_extended_overlap_flag() == 0); };
+  inline bool filter(const LASpoint* point) { return (point->get_extended_overlap_flag() == 0); };
 };
 
 class LAScriterionKeepUserData : public LAScriterion
@@ -845,7 +845,7 @@ class LAScriterionKeepUserData : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_user_data"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data != user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data != user_data); };
   LAScriterionKeepUserData(U8 user_data) { this->user_data = user_data; };
 private:
   U8 user_data;
@@ -856,7 +856,7 @@ class LAScriterionKeepUserDataBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_user_data_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data >= below_user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data >= below_user_data); };
   LAScriterionKeepUserDataBelow(U8 below_user_data) { this->below_user_data = below_user_data; };
 private:
   U8 below_user_data;
@@ -867,7 +867,7 @@ class LAScriterionKeepUserDataAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_user_data_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data <= above_user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data <= above_user_data); };
   LAScriterionKeepUserDataAbove(U8 above_user_data) { this->above_user_data = above_user_data; };
 private:
   U8 above_user_data;
@@ -878,7 +878,7 @@ class LAScriterionKeepUserDataBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_user_data_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_user_data, above_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data < below_user_data) || (above_user_data < point->user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data < below_user_data) || (above_user_data < point->user_data); };
   LAScriterionKeepUserDataBetween(U8 below_user_data, U8 above_user_data) { this->below_user_data = below_user_data; this->above_user_data = above_user_data; };
 private:
   U8 below_user_data, above_user_data;
@@ -889,7 +889,7 @@ class LAScriterionDropUserData : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_user_data"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data == user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data == user_data); };
   LAScriterionDropUserData(U8 user_data) { this->user_data = user_data; };
 private:
   U8 user_data;
@@ -900,7 +900,7 @@ class LAScriterionDropUserDataBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_user_data_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data < below_user_data) ; };
+  inline bool filter(const LASpoint* point) { return (point->user_data < below_user_data) ; };
   LAScriterionDropUserDataBelow(U8 below_user_data) { this->below_user_data = below_user_data; };
 private:
   U8 below_user_data;
@@ -911,7 +911,7 @@ class LAScriterionDropUserDataAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_user_data_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (point->user_data > above_user_data); };
+  inline bool filter(const LASpoint* point) { return (point->user_data > above_user_data); };
   LAScriterionDropUserDataAbove(U8 above_user_data) { this->above_user_data = above_user_data; };
 private:
   U8 above_user_data;
@@ -922,7 +922,7 @@ class LAScriterionDropUserDataBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_user_data_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_user_data, above_user_data); };
-  inline BOOL filter(const LASpoint* point) { return (below_user_data <= point->user_data) && (point->user_data <= above_user_data); };
+  inline bool filter(const LASpoint* point) { return (below_user_data <= point->user_data) && (point->user_data <= above_user_data); };
   LAScriterionDropUserDataBetween(U8 below_user_data, U8 above_user_data) { this->below_user_data = below_user_data; this->above_user_data = above_user_data; };
 private:
   U8 below_user_data, above_user_data;
@@ -933,7 +933,7 @@ class LAScriterionKeepPointSource : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_point_source"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (point->point_source_ID != point_source_id); };
+  inline bool filter(const LASpoint* point) { return (point->point_source_ID != point_source_id); };
   LAScriterionKeepPointSource(U16 point_source_id) { this->point_source_id = point_source_id; };
 private:
   U16 point_source_id;
@@ -944,7 +944,7 @@ class LAScriterionKeepPointSourceBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_point_source_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_point_source_id, above_point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (point->point_source_ID < below_point_source_id) || (above_point_source_id < point->point_source_ID); };
+  inline bool filter(const LASpoint* point) { return (point->point_source_ID < below_point_source_id) || (above_point_source_id < point->point_source_ID); };
   LAScriterionKeepPointSourceBetween(U16 below_point_source_id, U16 above_point_source_id) { this->below_point_source_id = below_point_source_id; this->above_point_source_id = above_point_source_id; };
 private:
   U16 below_point_source_id, above_point_source_id;
@@ -955,7 +955,7 @@ class LAScriterionDropPointSource : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_point_source"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (point->point_source_ID == point_source_id) ; };
+  inline bool filter(const LASpoint* point) { return (point->point_source_ID == point_source_id) ; };
   LAScriterionDropPointSource(U16 point_source_id) { this->point_source_id = point_source_id; };
 private:
   U16 point_source_id;
@@ -966,7 +966,7 @@ class LAScriterionDropPointSourceBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_point_source_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), below_point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (point->point_source_ID < below_point_source_id) ; };
+  inline bool filter(const LASpoint* point) { return (point->point_source_ID < below_point_source_id) ; };
   LAScriterionDropPointSourceBelow(U16 below_point_source_id) { this->below_point_source_id = below_point_source_id; };
 private:
   U16 below_point_source_id;
@@ -977,7 +977,7 @@ class LAScriterionDropPointSourceAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_point_source_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), above_point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (point->point_source_ID > above_point_source_id); };
+  inline bool filter(const LASpoint* point) { return (point->point_source_ID > above_point_source_id); };
   LAScriterionDropPointSourceAbove(U16 above_point_source_id) { this->above_point_source_id = above_point_source_id; };
 private:
   U16 above_point_source_id;
@@ -988,7 +988,7 @@ class LAScriterionDropPointSourceBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_point_source_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %d ", name(), below_point_source_id, above_point_source_id); };
-  inline BOOL filter(const LASpoint* point) { return (below_point_source_id <= point->point_source_ID) && (point->point_source_ID <= above_point_source_id); };
+  inline bool filter(const LASpoint* point) { return (below_point_source_id <= point->point_source_ID) && (point->point_source_ID <= above_point_source_id); };
   LAScriterionDropPointSourceBetween(U16 below_point_source_id, U16 above_point_source_id) { this->below_point_source_id = below_point_source_id; this->above_point_source_id = above_point_source_id; };
 private:
   U16 below_point_source_id, above_point_source_id;
@@ -999,7 +999,7 @@ class LAScriterionKeepGpsTime : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_gps_time"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %.6f %.6f ", name(), below_gpstime, above_gpstime); };
-  inline BOOL filter(const LASpoint* point) { return (point->have_gps_time && ((point->gps_time < below_gpstime) || (point->gps_time > above_gpstime))); };
+  inline bool filter(const LASpoint* point) { return (point->have_gps_time && ((point->gps_time < below_gpstime) || (point->gps_time > above_gpstime))); };
   LAScriterionKeepGpsTime(F64 below_gpstime, F64 above_gpstime) { this->below_gpstime = below_gpstime; this->above_gpstime = above_gpstime; };
 private:
   F64 below_gpstime, above_gpstime;
@@ -1010,7 +1010,7 @@ class LAScriterionDropGpsTimeBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_gps_time_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %.6f ", name(), below_gpstime); };
-  inline BOOL filter(const LASpoint* point) { return (point->have_gps_time && (point->gps_time < below_gpstime)); };
+  inline bool filter(const LASpoint* point) { return (point->have_gps_time && (point->gps_time < below_gpstime)); };
   LAScriterionDropGpsTimeBelow(F64 below_gpstime) { this->below_gpstime = below_gpstime; };
 private:
   F64 below_gpstime;
@@ -1021,7 +1021,7 @@ class LAScriterionDropGpsTimeAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_gps_time_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %.6f ", name(), above_gpstime); };
-  inline BOOL filter(const LASpoint* point) { return (point->have_gps_time && (point->gps_time > above_gpstime)); };
+  inline bool filter(const LASpoint* point) { return (point->have_gps_time && (point->gps_time > above_gpstime)); };
   LAScriterionDropGpsTimeAbove(F64 above_gpstime) { this->above_gpstime = above_gpstime; };
 private:
   F64 above_gpstime;
@@ -1032,7 +1032,7 @@ class LAScriterionDropGpsTimeBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_gps_time_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %.6f %.6f ", name(), below_gpstime, above_gpstime); };
-  inline BOOL filter(const LASpoint* point) { return (point->have_gps_time && ((below_gpstime <= point->gps_time) && (point->gps_time <= above_gpstime))); };
+  inline bool filter(const LASpoint* point) { return (point->have_gps_time && ((below_gpstime <= point->gps_time) && (point->gps_time <= above_gpstime))); };
   LAScriterionDropGpsTimeBetween(F64 below_gpstime, F64 above_gpstime) { this->below_gpstime = below_gpstime; this->above_gpstime = above_gpstime; };
 private:
   F64 below_gpstime, above_gpstime;
@@ -1043,7 +1043,7 @@ class LAScriterionKeepWavepacket : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_wavepacket"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %u ", name(), keep_wavepacket); };
-  inline BOOL filter(const LASpoint* point) { return (point->wavepacket.getIndex() != keep_wavepacket); };
+  inline bool filter(const LASpoint* point) { return (point->wavepacket.getIndex() != keep_wavepacket); };
   LAScriterionKeepWavepacket(U32 keep_wavepacket) { this->keep_wavepacket = keep_wavepacket; };
 private:
   U32 keep_wavepacket;
@@ -1054,7 +1054,7 @@ class LAScriterionDropWavepacket : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_wavepacket"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %u ", name(), drop_wavepacket); };
-  inline BOOL filter(const LASpoint* point) { return (point->wavepacket.getIndex() == drop_wavepacket); };
+  inline bool filter(const LASpoint* point) { return (point->wavepacket.getIndex() == drop_wavepacket); };
   LAScriterionDropWavepacket(U32 drop_wavepacket) { this->drop_wavepacket = drop_wavepacket; };
 private:
   U32 drop_wavepacket;
@@ -1065,7 +1065,7 @@ class LAScriterionKeepAttributeBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_attribute_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g ", name(), index, below_attribute); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_attribute_as_float(index) >= below_attribute); };
+  inline bool filter(const LASpoint* point) { return (point->get_attribute_as_float(index) >= below_attribute); };
   LAScriterionKeepAttributeBelow(I32 index, F64 below_attribute) { this->index = index; this->below_attribute = below_attribute; };
 private:
   I32 index;
@@ -1077,7 +1077,7 @@ class LAScriterionKeepAttributeAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_attribute_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g ", name(), index, above_attribute); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_attribute_as_float(index) <= above_attribute); };
+  inline bool filter(const LASpoint* point) { return (point->get_attribute_as_float(index) <= above_attribute); };
   LAScriterionKeepAttributeAbove(I32 index, F64 above_attribute) { this->index = index; this->above_attribute = above_attribute; };
 private:
   I32 index;
@@ -1089,7 +1089,7 @@ class LAScriterionKeepAttributeBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_attribute_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g %g ", name(), index, below_attribute, above_attribute); };
-  inline BOOL filter(const LASpoint* point) { F64 attribute = point->get_attribute_as_float(index); return (attribute < below_attribute) || (above_attribute < attribute); };
+  inline bool filter(const LASpoint* point) { F64 attribute = point->get_attribute_as_float(index); return (attribute < below_attribute) || (above_attribute < attribute); };
   LAScriterionKeepAttributeBetween(I32 index, F64 below_attribute, F64 above_attribute) { this->index = index; this->below_attribute = below_attribute; this->above_attribute = above_attribute; };
 private:
   I32 index;
@@ -1102,7 +1102,7 @@ class LAScriterionDropAttributeBelow : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_attribute_below"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g ", name(), index, below_attribute); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_attribute_as_float(index) < below_attribute); };
+  inline bool filter(const LASpoint* point) { return (point->get_attribute_as_float(index) < below_attribute); };
   LAScriterionDropAttributeBelow(I32 index, F64 below_attribute) { this->index = index; this->below_attribute = below_attribute; };
 private:
   I32 index;
@@ -1114,7 +1114,7 @@ class LAScriterionDropAttributeAbove : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_attribute_above"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g ", name(), index, above_attribute); };
-  inline BOOL filter(const LASpoint* point) { return (point->get_attribute_as_float(index) > above_attribute); };
+  inline bool filter(const LASpoint* point) { return (point->get_attribute_as_float(index) > above_attribute); };
   LAScriterionDropAttributeAbove(I32 index, F64 above_attribute) { this->index = index; this->above_attribute = above_attribute; };
 private:
   I32 index;
@@ -1126,7 +1126,7 @@ class LAScriterionDropAttributeBetween : public LAScriterion
 public:
   inline const CHAR* name() const { return "drop_attribute_between"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d %g %g ", name(), index, below_attribute, above_attribute); };
-  inline BOOL filter(const LASpoint* point) { F64 attribute = point->get_attribute_as_float(index); return (below_attribute <= attribute) && (attribute <= above_attribute); };
+  inline bool filter(const LASpoint* point) { F64 attribute = point->get_attribute_as_float(index); return (below_attribute <= attribute) && (attribute <= above_attribute); };
   LAScriterionDropAttributeBetween(I32 index, F64 below_attribute, F64 above_attribute) { this->index = index; this->below_attribute = below_attribute; this->above_attribute = above_attribute; };
 private:
   I32 index;
@@ -1139,7 +1139,7 @@ class LAScriterionKeepEveryNth : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_every_nth"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %d ", name(), every); };
-  inline BOOL filter(const LASpoint* point) { if (counter == every) { counter = 1; return FALSE; } else { counter++; return TRUE; } };
+  inline bool filter(const LASpoint* point) { if (counter == every) { counter = 1; return FALSE; } else { counter++; return TRUE; } };
   LAScriterionKeepEveryNth(I32 every) { this->every = every; counter = 1; };
 private:
   I32 counter;
@@ -1151,7 +1151,7 @@ class LAScriterionKeepRandomFraction : public LAScriterion
 public:
   inline const CHAR* name() const { return "keep_random_fraction"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), fraction); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   {
     srand(seed);
     seed = rand();
@@ -1169,7 +1169,7 @@ class LAScriterionThinWithGrid : public LAScriterion
 public:
   inline const CHAR* name() const { return "thin_with_grid"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), (grid_spacing > 0 ? grid_spacing : -grid_spacing)); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   { 
     if (grid_spacing < 0)
     {
@@ -1178,7 +1178,7 @@ public:
     }
     I32 pos_x = I32_FLOOR(point->get_x() / grid_spacing);
     I32 pos_y = I32_FLOOR(point->get_y() / grid_spacing) - anker;
-    BOOL no_x_anker = FALSE;
+    bool no_x_anker = FALSE;
     U32* array_size;
     I32** ankers;
     U32*** array;
@@ -1380,7 +1380,7 @@ class LAScriterionThinWithTime : public LAScriterion
 public:
   inline const CHAR* name() const { return "thin_with_time"; };
   inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %g ", name(), (time_spacing > 0 ? time_spacing : -time_spacing)); };
-  inline BOOL filter(const LASpoint* point)
+  inline bool filter(const LASpoint* point)
   { 
     I64 pos_t = I64_FLOOR(point->get_gps_time() / time_spacing);
     my_I64_F64_map::iterator map_element = times.find(pos_t);
@@ -1529,7 +1529,7 @@ void LASfilter::usage() const
   fprintf(stderr,"  -filter_and\n");
 }
 
-BOOL LASfilter::parse(int argc, char* argv[])
+bool LASfilter::parse(int argc, char* argv[])
 {
   int i;
 
@@ -2954,7 +2954,7 @@ BOOL LASfilter::parse(int argc, char* argv[])
   return TRUE;
 }
 
-BOOL LASfilter::parse(CHAR* string)
+bool LASfilter::parse(CHAR* string)
 {
   int p = 0;
   int argc = 1;
@@ -3003,7 +3003,7 @@ void LASfilter::addKeepScanDirectionChange()
   add_criterion(new LAScriterionKeepScanDirectionChange());
 }
 
-BOOL LASfilter::filter(const LASpoint* point)
+bool LASfilter::filter(const LASpoint* point)
 {
   U32 i;
 

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -133,7 +133,7 @@ void LASreader::set_transform(LAStransform* transform)
   read_complex = &LASreader::read_point_default;
 }
 
-BOOL LASreader::inside_none()
+bool LASreader::inside_none()
 {
   if (filter || transform)
   {
@@ -154,7 +154,7 @@ BOOL LASreader::inside_none()
   return TRUE;
 }
 
-BOOL LASreader::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
+bool LASreader::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
 {
   inside = 1;
   t_ll_x = ll_x;
@@ -210,7 +210,7 @@ BOOL LASreader::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
   return TRUE;
 }
 
-BOOL LASreader::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
+bool LASreader::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
 {
   inside = 2;
   c_center_x = center_x;
@@ -263,7 +263,7 @@ BOOL LASreader::inside_circle(const F64 center_x, const F64 center_y, const F64 
   return TRUE;
 }
 
-BOOL LASreader::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
+bool LASreader::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
 {
   inside = 3;
   r_min_x = min_x;
@@ -316,7 +316,7 @@ BOOL LASreader::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max
   return TRUE;
 }
 
-BOOL LASreader::read_point_inside_tile()
+bool LASreader::read_point_inside_tile()
 {
   while (read_point_default())
   {
@@ -325,7 +325,7 @@ BOOL LASreader::read_point_inside_tile()
   return FALSE;
 }
 
-BOOL LASreader::read_point_inside_tile_indexed()
+bool LASreader::read_point_inside_tile_indexed()
 {
   while (index->seek_next((LASreader*)this))
   {
@@ -334,7 +334,7 @@ BOOL LASreader::read_point_inside_tile_indexed()
   return FALSE;
 }
 
-BOOL LASreader::read_point_inside_circle()
+bool LASreader::read_point_inside_circle()
 {
   while (read_point_default())
   {
@@ -343,7 +343,7 @@ BOOL LASreader::read_point_inside_circle()
   return FALSE;
 }
 
-BOOL LASreader::read_point_inside_circle_indexed()
+bool LASreader::read_point_inside_circle_indexed()
 {
   while (index->seek_next((LASreader*)this))
   {
@@ -352,7 +352,7 @@ BOOL LASreader::read_point_inside_circle_indexed()
   return FALSE;
 }
 
-BOOL LASreader::read_point_inside_rectangle()
+bool LASreader::read_point_inside_rectangle()
 {
   while (read_point_default())
   {
@@ -361,7 +361,7 @@ BOOL LASreader::read_point_inside_rectangle()
   return FALSE;
 }
 
-BOOL LASreader::read_point_inside_rectangle_indexed()
+bool LASreader::read_point_inside_rectangle_indexed()
 {
   while (index->seek_next((LASreader*)this))
   {
@@ -370,12 +370,12 @@ BOOL LASreader::read_point_inside_rectangle_indexed()
   return FALSE;
 }
 
-BOOL LASreader::read_point_none()
+bool LASreader::read_point_none()
 {
   return FALSE;
 }
 
-BOOL LASreader::read_point_filtered()
+bool LASreader::read_point_filtered()
 {
   while ((this->*read_complex)())
   {
@@ -384,7 +384,7 @@ BOOL LASreader::read_point_filtered()
   return FALSE;
 }
 
-BOOL LASreader::read_point_transformed()
+bool LASreader::read_point_transformed()
 {
   if ((this->*read_complex)())
   {
@@ -394,7 +394,7 @@ BOOL LASreader::read_point_transformed()
   return FALSE;
 }
 
-BOOL LASreader::read_point_filtered_and_transformed()
+bool LASreader::read_point_filtered_and_transformed()
 {
   if (read_point_filtered())
   {
@@ -404,12 +404,12 @@ BOOL LASreader::read_point_filtered_and_transformed()
   return FALSE;
 }
 
-BOOL LASreadOpener::is_piped() const
+bool LASreadOpener::is_piped() const
 {
   return (!file_names && use_stdin);
 }
 
-BOOL LASreadOpener::is_inside() const
+bool LASreadOpener::is_inside() const
 {
   return (inside_tile != 0 || inside_circle != 0 || inside_rectangle != 0);
 }
@@ -477,12 +477,12 @@ I32 LASreadOpener::unparse(CHAR* string) const
   return n;
 }
 
-BOOL LASreadOpener::is_buffered() const
+bool LASreadOpener::is_buffered() const
 {
   return ((buffer_size > 0) && ((file_name_number > 1) || (neighbor_file_name_number > 0)));
 }
 
-BOOL LASreadOpener::is_header_populated() const
+bool LASreadOpener::is_header_populated() const
 {
   return (populate_header || (file_name && (strstr(file_name, ".las") || strstr(file_name, ".laz") || strstr(file_name, ".LAS") || strstr(file_name, ".LAZ"))));
 }
@@ -493,7 +493,7 @@ void LASreadOpener::reset()
   file_name = 0;
 }
 
-LASreader* LASreadOpener::open(const CHAR* other_file_name, BOOL reset_after_other)
+LASreader* LASreadOpener::open(const CHAR* other_file_name, bool reset_after_other)
 {
   if (filter) filter->reset();
   if (transform) transform->reset();
@@ -1081,7 +1081,7 @@ LASreader* LASreadOpener::open(const CHAR* other_file_name, BOOL reset_after_oth
   }
 }
 
-BOOL LASreadOpener::reopen(LASreader* lasreader, BOOL remain_buffered)
+bool LASreadOpener::reopen(LASreader* lasreader, bool remain_buffered)
 {
   if (lasreader == 0)
   {
@@ -1342,7 +1342,7 @@ void LASreadOpener::usage() const
   fprintf(stderr,"  -inside_circle center_x center_y radius\n");
 }
 
-BOOL LASreadOpener::parse(int argc, char* argv[])
+bool LASreadOpener::parse(int argc, char* argv[])
 {
   int i;
   for (i = 1; i < argc; i++)
@@ -1854,7 +1854,7 @@ I32 LASreadOpener::get_file_format(U32 number) const
   }
 }
 
-void LASreadOpener::set_merged(const BOOL merged)
+void LASreadOpener::set_merged(const bool merged)
 {
   this->merged = merged;
 }
@@ -1879,17 +1879,17 @@ void LASreadOpener::set_transform(LAStransform* transform)
   this->transform = transform;
 }
 
-void LASreadOpener::set_auto_reoffset(const BOOL auto_reoffset)
+void LASreadOpener::set_auto_reoffset(const bool auto_reoffset)
 {
   this->auto_reoffset = auto_reoffset;
 }
 
-void LASreadOpener::set_files_are_flightlines(const BOOL files_are_flightlines)
+void LASreadOpener::set_files_are_flightlines(const bool files_are_flightlines)
 {
   this->files_are_flightlines = files_are_flightlines;
 }
 
-void LASreadOpener::set_apply_file_source_ID(const BOOL apply_file_source_ID)
+void LASreadOpener::set_apply_file_source_ID(const bool apply_file_source_ID)
 {
   this->apply_file_source_ID = apply_file_source_ID;
 }
@@ -1899,16 +1899,16 @@ void LASreadOpener::set_io_ibuffer_size(I32 io_ibuffer_size)
   this->io_ibuffer_size = io_ibuffer_size;
 }
 
-void LASreadOpener::set_file_name(const CHAR* file_name, BOOL unique)
+void LASreadOpener::set_file_name(const CHAR* file_name, bool unique)
 {
   add_file_name(file_name, unique);
 }
 
 #ifdef _WIN32
 #include <windows.h>
-BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
+bool LASreadOpener::add_file_name(const CHAR* file_name, bool unique)
 {
-  BOOL r = FALSE;
+  bool r = FALSE;
   HANDLE h;
   WIN32_FIND_DATA info;
   h = FindFirstFile(file_name, &info);
@@ -1942,9 +1942,9 @@ BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
 #endif
 
 #ifdef _WIN32
-BOOL LASreadOpener::add_file_name_single(const CHAR* file_name, BOOL unique)
+bool LASreadOpener::add_file_name_single(const CHAR* file_name, bool unique)
 #else
-BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
+bool LASreadOpener::add_file_name(const CHAR* file_name, bool unique)
 #endif
 {
   if (unique)
@@ -1980,7 +1980,7 @@ BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
   return TRUE;
 }
 
-BOOL LASreadOpener::add_list_of_files(const CHAR* list_of_files, BOOL unique)
+bool LASreadOpener::add_list_of_files(const CHAR* list_of_files, bool unique)
 {
   FILE* file = fopen(list_of_files, "r");
   if (file == 0)
@@ -2019,7 +2019,7 @@ void LASreadOpener::delete_file_name(U32 file_name_id)
   file_name_number--;
 }
 
-BOOL LASreadOpener::set_file_name_current(U32 file_name_id)
+bool LASreadOpener::set_file_name_current(U32 file_name_id)
 {
   if (file_name_id < file_name_number)
   {
@@ -2032,9 +2032,9 @@ BOOL LASreadOpener::set_file_name_current(U32 file_name_id)
 
 #ifdef _WIN32
 #include <windows.h>
-BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL unique)
+bool LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, bool unique)
 {
-  BOOL r = FALSE;
+  bool r = FALSE;
   HANDLE h;
   WIN32_FIND_DATA info;
   h = FindFirstFile(neighbor_file_name, &info);
@@ -2068,9 +2068,9 @@ BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL 
 #endif
 
 #ifdef _WIN32
-BOOL LASreadOpener::add_neighbor_file_name_single(const CHAR* neighbor_file_name, BOOL unique)
+bool LASreadOpener::add_neighbor_file_name_single(const CHAR* neighbor_file_name, bool unique)
 #else
-BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL unique)
+bool LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, bool unique)
 #endif
 {
   if (unique)
@@ -2193,17 +2193,17 @@ void LASreadOpener::set_skip_lines(I32 skip_lines)
   this->skip_lines = skip_lines;
 }
 
-void LASreadOpener::set_populate_header(BOOL populate_header)
+void LASreadOpener::set_populate_header(bool populate_header)
 {
   this->populate_header = populate_header;
 }
 
-void LASreadOpener::set_keep_lastiling(BOOL keep_lastiling)
+void LASreadOpener::set_keep_lastiling(bool keep_lastiling)
 {
   this->keep_lastiling = keep_lastiling;
 }
 
-void LASreadOpener::set_pipe_on(BOOL pipe_on)
+void LASreadOpener::set_pipe_on(bool pipe_on)
 {
   this->pipe_on = pipe_on;
 }
@@ -2233,7 +2233,7 @@ void LASreadOpener::set_inside_rectangle(const F64 min_x, const F64 min_y, const
   inside_rectangle[3] = max_y;
 }
 
-BOOL LASreadOpener::active() const
+bool LASreadOpener::active() const
 {
   return ((file_name_current < file_name_number) || use_stdin);
 }

--- a/LASlib/src/lasreader_asc.cpp
+++ b/LASlib/src/lasreader_asc.cpp
@@ -39,7 +39,7 @@
 
 extern "C" FILE* fopen_compressed(const char* filename, const char* mode, bool* piped);
 
-BOOL LASreaderASC::open(const CHAR* file_name, BOOL comma_not_point)
+bool LASreaderASC::open(const CHAR* file_name, bool comma_not_point)
 {
   if (file_name == 0)
   {
@@ -104,7 +104,7 @@ BOOL LASreaderASC::open(const CHAR* file_name, BOOL comma_not_point)
   }
 
   CHAR dummy[32];
-  BOOL complete = FALSE;
+  bool complete = FALSE;
   ncols = 0;
   nrows = 0;
   F64 xllcorner = F64_MAX;
@@ -351,12 +351,12 @@ void LASreaderASC::set_offset(const F64* offset)
   }
 }
 
-BOOL LASreaderASC::seek(const I64 p_index)
+bool LASreaderASC::seek(const I64 p_index)
 {
   return FALSE;
 }
 
-BOOL LASreaderASC::read_point_default()
+bool LASreaderASC::read_point_default()
 {
   F32 elevation;
   while (p_count < npoints)
@@ -423,7 +423,7 @@ ByteStreamIn* LASreaderASC::get_stream() const
   return 0;
 }
 
-void LASreaderASC::close(BOOL close_stream)
+void LASreaderASC::close(bool close_stream)
 {
   if (file)
   {
@@ -433,7 +433,7 @@ void LASreaderASC::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderASC::reopen(const CHAR* file_name)
+bool LASreaderASC::reopen(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -659,7 +659,7 @@ LASreaderASCrescale::LASreaderASCrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderASCrescale::open(const CHAR* file_name, BOOL comma_not_point)
+bool LASreaderASCrescale::open(const CHAR* file_name, bool comma_not_point)
 {
   LASreaderASC::set_scale_factor(scale_factor);
   if (!LASreaderASC::open(file_name, comma_not_point)) return FALSE;
@@ -673,7 +673,7 @@ LASreaderASCreoffset::LASreaderASCreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderASCreoffset::open(const CHAR* file_name, BOOL comma_not_point)
+bool LASreaderASCreoffset::open(const CHAR* file_name, bool comma_not_point)
 {
   LASreaderASC::set_offset(offset);
   if (!LASreaderASC::open(file_name, comma_not_point)) return FALSE;
@@ -684,7 +684,7 @@ LASreaderASCrescalereoffset::LASreaderASCrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderASCrescalereoffset::open(const CHAR* file_name, BOOL comma_not_point)
+bool LASreaderASCrescalereoffset::open(const CHAR* file_name, bool comma_not_point)
 {
   LASreaderASC::set_scale_factor(scale_factor);
   LASreaderASC::set_offset(offset);

--- a/LASlib/src/lasreader_bil.cpp
+++ b/LASlib/src/lasreader_bil.cpp
@@ -37,7 +37,7 @@
 #include <windows.h>
 #endif
 
-BOOL LASreaderBIL::open(const CHAR* file_name)
+bool LASreaderBIL::open(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -281,7 +281,7 @@ BOOL LASreaderBIL::open(const CHAR* file_name)
   return reopen(file_name);
 }
 
-BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
+bool LASreaderBIL::read_hdr_file(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -450,7 +450,7 @@ BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
   return TRUE;
 }
 
-BOOL LASreaderBIL::read_blw_file(const CHAR* file_name)
+bool LASreaderBIL::read_blw_file(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -572,12 +572,12 @@ void LASreaderBIL::set_offset(const F64* offset)
 }
 
 
-BOOL LASreaderBIL::seek(const I64 p_index)
+bool LASreaderBIL::seek(const I64 p_index)
 {
   return FALSE;
 }
 
-BOOL LASreaderBIL::read_point_default()
+bool LASreaderBIL::read_point_default()
 {
   F32 elevation;
   while (p_count < npoints)
@@ -672,7 +672,7 @@ ByteStreamIn* LASreaderBIL::get_stream() const
   return 0;
 }
 
-void LASreaderBIL::close(BOOL close_stream)
+void LASreaderBIL::close(bool close_stream)
 {
   if (file)
   {
@@ -681,7 +681,7 @@ void LASreaderBIL::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderBIL::reopen(const CHAR* file_name)
+bool LASreaderBIL::reopen(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -878,7 +878,7 @@ LASreaderBILrescale::LASreaderBILrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderBILrescale::open(const CHAR* file_name)
+bool LASreaderBILrescale::open(const CHAR* file_name)
 {
   LASreaderBIL::set_scale_factor(scale_factor);
   if (!LASreaderBIL::open(file_name)) return FALSE;
@@ -892,7 +892,7 @@ LASreaderBILreoffset::LASreaderBILreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderBILreoffset::open(const CHAR* file_name)
+bool LASreaderBILreoffset::open(const CHAR* file_name)
 {
   LASreaderBIL::set_offset(offset);
   if (!LASreaderBIL::open(file_name)) return FALSE;
@@ -903,7 +903,7 @@ LASreaderBILrescalereoffset::LASreaderBILrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderBILrescalereoffset::open(const CHAR* file_name)
+bool LASreaderBILrescalereoffset::open(const CHAR* file_name)
 {
   LASreaderBIL::set_scale_factor(scale_factor);
   LASreaderBIL::set_offset(offset);

--- a/LASlib/src/lasreader_bin.cpp
+++ b/LASlib/src/lasreader_bin.cpp
@@ -78,7 +78,7 @@ struct TSheader
   I32 rgb;
 };
 
-BOOL LASreaderBIN::open(const char* file_name)
+bool LASreaderBIN::open(const char* file_name)
 {
   if (file_name == 0)
   {
@@ -132,7 +132,7 @@ BOOL LASreaderBIN::open(const char* file_name)
   return open(in);
 }
 
-BOOL LASreaderBIN::open(ByteStreamIn* stream)
+bool LASreaderBIN::open(ByteStreamIn* stream)
 {
   int i;
 
@@ -250,7 +250,7 @@ BOOL LASreaderBIN::open(ByteStreamIn* stream)
   return seek(0);
 }
 
-BOOL LASreaderBIN::seek(const I64 p_index)
+bool LASreaderBIN::seek(const I64 p_index)
 {
   if (p_index < npoints)
   {
@@ -269,7 +269,7 @@ BOOL LASreaderBIN::seek(const I64 p_index)
   return FALSE;
 }
 
-BOOL LASreaderBIN::read_point_default()
+bool LASreaderBIN::read_point_default()
 {
   if (p_count < npoints)
   {
@@ -373,7 +373,7 @@ ByteStreamIn* LASreaderBIN::get_stream() const
   return stream;
 }
 
-void LASreaderBIN::close(BOOL close_stream)
+void LASreaderBIN::close(bool close_stream)
 {
   if (close_stream)
   {
@@ -408,7 +408,7 @@ LASreaderBINrescale::LASreaderBINrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderBINrescale::open(ByteStreamIn* stream)
+bool LASreaderBINrescale::open(ByteStreamIn* stream)
 {
   if (!LASreaderBIN::open(stream)) return FALSE;
   // do we need to change anything
@@ -434,7 +434,7 @@ LASreaderBINreoffset::LASreaderBINreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderBINreoffset::open(ByteStreamIn* stream)
+bool LASreaderBINreoffset::open(ByteStreamIn* stream)
 {
   if (!LASreaderBIN::open(stream)) return FALSE;
   // do we need to change anything
@@ -457,7 +457,7 @@ LASreaderBINrescalereoffset::LASreaderBINrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderBINrescalereoffset::open(ByteStreamIn* stream)
+bool LASreaderBINrescalereoffset::open(ByteStreamIn* stream)
 {
   if (!LASreaderBIN::open(stream)) return FALSE;
   // do we need to change anything

--- a/LASlib/src/lasreader_dtm.cpp
+++ b/LASlib/src/lasreader_dtm.cpp
@@ -285,7 +285,7 @@ static const unsigned short GCTP_NAD83_Puerto_Rico = 5200;
 #include <windows.h>
 #endif
 
-BOOL LASreaderDTM::open(const CHAR* file_name)
+bool LASreaderDTM::open(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -1196,12 +1196,12 @@ void LASreaderDTM::set_offset(const F64* offset)
   }
 }
 
-BOOL LASreaderDTM::seek(const I64 p_index)
+bool LASreaderDTM::seek(const I64 p_index)
 {
   return FALSE;
 }
 
-BOOL LASreaderDTM::read_point_default()
+bool LASreaderDTM::read_point_default()
 {
   while (p_count < npoints)
   {
@@ -1299,7 +1299,7 @@ ByteStreamIn* LASreaderDTM::get_stream() const
   return 0;
 }
 
-void LASreaderDTM::close(BOOL close_stream)
+void LASreaderDTM::close(bool close_stream)
 {
   if (file)
   {
@@ -1308,7 +1308,7 @@ void LASreaderDTM::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderDTM::reopen(const CHAR* file_name)
+bool LASreaderDTM::reopen(const CHAR* file_name)
 {
   if (file_name == 0)
   {
@@ -1519,7 +1519,7 @@ LASreaderDTMrescale::LASreaderDTMrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderDTMrescale::open(const CHAR* file_name)
+bool LASreaderDTMrescale::open(const CHAR* file_name)
 {
   LASreaderDTM::set_scale_factor(scale_factor);
   if (!LASreaderDTM::open(file_name)) return FALSE;
@@ -1533,7 +1533,7 @@ LASreaderDTMreoffset::LASreaderDTMreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderDTMreoffset::open(const CHAR* file_name)
+bool LASreaderDTMreoffset::open(const CHAR* file_name)
 {
   LASreaderDTM::set_offset(offset);
   if (!LASreaderDTM::open(file_name)) return FALSE;
@@ -1544,7 +1544,7 @@ LASreaderDTMrescalereoffset::LASreaderDTMrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderDTMrescalereoffset::open(const CHAR* file_name)
+bool LASreaderDTMrescalereoffset::open(const CHAR* file_name)
 {
   LASreaderDTM::set_scale_factor(scale_factor);
   LASreaderDTM::set_offset(offset);

--- a/LASlib/src/lasreader_las.cpp
+++ b/LASlib/src/lasreader_las.cpp
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-BOOL LASreaderLAS::open(const char* file_name, I32 io_buffer_size, BOOL peek_only)
+bool LASreaderLAS::open(const char* file_name, I32 io_buffer_size, bool peek_only)
 {
   if (file_name == 0)
   {
@@ -74,7 +74,7 @@ BOOL LASreaderLAS::open(const char* file_name, I32 io_buffer_size, BOOL peek_onl
   return open(in, peek_only);
 }
 
-BOOL LASreaderLAS::open(FILE* file, BOOL peek_only)
+bool LASreaderLAS::open(FILE* file, bool peek_only)
 {
   if (file == 0)
   {
@@ -103,7 +103,7 @@ BOOL LASreaderLAS::open(FILE* file, BOOL peek_only)
   return open(in);
 }
 
-BOOL LASreaderLAS::open(istream& stream, BOOL peek_only)
+bool LASreaderLAS::open(istream& stream, bool peek_only)
 {
   // create input
   ByteStreamIn* in;
@@ -115,7 +115,7 @@ BOOL LASreaderLAS::open(istream& stream, BOOL peek_only)
   return open(in, peek_only);
 }
 
-BOOL LASreaderLAS::open(ByteStreamIn* stream, BOOL peek_only)
+bool LASreaderLAS::open(ByteStreamIn* stream, bool peek_only)
 {
   U32 i,j;
 
@@ -1281,7 +1281,7 @@ I32 LASreaderLAS::get_format() const
   return LAS_TOOLS_FORMAT_LAS;
 }
 
-BOOL LASreaderLAS::seek(const I64 p_index)
+bool LASreaderLAS::seek(const I64 p_index)
 {
   if (reader)
   {
@@ -1297,7 +1297,7 @@ BOOL LASreaderLAS::seek(const I64 p_index)
   return FALSE;
 }
 
-BOOL LASreaderLAS::read_point_default()
+bool LASreaderLAS::read_point_default()
 {
   if (p_count < npoints)
   {
@@ -1363,7 +1363,7 @@ ByteStreamIn* LASreaderLAS::get_stream() const
   return stream;
 }
 
-void LASreaderLAS::close(BOOL close_stream)
+void LASreaderLAS::close(bool close_stream)
 {
   if (reader) 
   {
@@ -1398,7 +1398,7 @@ LASreaderLAS::~LASreaderLAS()
   if (reader || stream) close(TRUE);
 }
 
-LASreaderLASrescale::LASreaderLASrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, BOOL check_for_overflow) : LASreaderLAS()
+LASreaderLASrescale::LASreaderLASrescale(F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, bool check_for_overflow) : LASreaderLAS()
 {
   scale_factor[0] = x_scale_factor;
   scale_factor[1] = y_scale_factor;
@@ -1406,7 +1406,7 @@ LASreaderLASrescale::LASreaderLASrescale(F64 x_scale_factor, F64 y_scale_factor,
   this->check_for_overflow = check_for_overflow;
 }
 
-BOOL LASreaderLASrescale::read_point_default()
+bool LASreaderLASrescale::read_point_default()
 {
   if (!LASreaderLAS::read_point_default()) return FALSE;
   if (rescale_x)
@@ -1427,7 +1427,7 @@ BOOL LASreaderLASrescale::read_point_default()
   return TRUE;
 }
 
-BOOL LASreaderLASrescale::open(ByteStreamIn* stream, BOOL peek_only)
+bool LASreaderLASrescale::open(ByteStreamIn* stream, bool peek_only)
 {
   LASquantizer quantizer = header;
   if (!LASreaderLAS::open(stream, peek_only)) return FALSE;
@@ -1530,7 +1530,7 @@ LASreaderLASreoffset::LASreaderLASreoffset() : LASreaderLAS()
   auto_reoffset = TRUE;
 }
 
-BOOL LASreaderLASreoffset::read_point_default()
+bool LASreaderLASreoffset::read_point_default()
 {
   if (!LASreaderLAS::read_point_default()) return FALSE;
   if (reoffset_x)
@@ -1551,7 +1551,7 @@ BOOL LASreaderLASreoffset::read_point_default()
   return TRUE;
 }
 
-BOOL LASreaderLASreoffset::open(ByteStreamIn* stream, BOOL peek_only)
+bool LASreaderLASreoffset::open(ByteStreamIn* stream, bool peek_only)
 {
   LASquantizer quantizer = header;
   if (!LASreaderLAS::open(stream, peek_only)) return FALSE;
@@ -1664,7 +1664,7 @@ LASreaderLASrescalereoffset::LASreaderLASrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderLASrescalereoffset::read_point_default()
+bool LASreaderLASrescalereoffset::read_point_default()
 {
   if (!LASreaderLAS::read_point_default()) return FALSE;
   if (reoffset_x)
@@ -1700,7 +1700,7 @@ BOOL LASreaderLASrescalereoffset::read_point_default()
   return TRUE;
 }
 
-BOOL LASreaderLASrescalereoffset::open(ByteStreamIn* stream, BOOL peek_only)
+bool LASreaderLASrescalereoffset::open(ByteStreamIn* stream, bool peek_only)
 {
   LASquantizer quantizer = header;
   if (!LASreaderLASrescale::open(stream, peek_only)) return FALSE;

--- a/LASlib/src/lasreader_qfit.cpp
+++ b/LASlib/src/lasreader_qfit.cpp
@@ -40,7 +40,7 @@
 #include <windows.h>
 #endif
 
-BOOL LASreaderQFIT::open(const char* file_name)
+bool LASreaderQFIT::open(const char* file_name)
 {
   if (file_name == 0)
   {
@@ -119,7 +119,7 @@ BOOL LASreaderQFIT::open(const char* file_name)
   return open(in);
 }
 
-BOOL LASreaderQFIT::open(ByteStreamIn* stream)
+bool LASreaderQFIT::open(ByteStreamIn* stream)
 {
   U32 i;
 
@@ -298,7 +298,7 @@ BOOL LASreaderQFIT::open(ByteStreamIn* stream)
   return seek(0);
 }
 
-BOOL LASreaderQFIT::seek(const I64 p_index)
+bool LASreaderQFIT::seek(const I64 p_index)
 {
   if (p_index < npoints)
   {
@@ -308,7 +308,7 @@ BOOL LASreaderQFIT::seek(const I64 p_index)
   return FALSE;
 }
 
-BOOL LASreaderQFIT::read_point_default()
+bool LASreaderQFIT::read_point_default()
 {
   if (p_count < npoints)
   {
@@ -381,7 +381,7 @@ ByteStreamIn* LASreaderQFIT::get_stream() const
   return stream;
 }
 
-void LASreaderQFIT::close(BOOL close_stream)
+void LASreaderQFIT::close(bool close_stream)
 {
   if (close_stream)
   {
@@ -398,7 +398,7 @@ void LASreaderQFIT::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderQFIT::reopen(const char* file_name)
+bool LASreaderQFIT::reopen(const char* file_name)
 {
   if (file_name == 0)
   {
@@ -454,7 +454,7 @@ LASreaderQFITrescale::LASreaderQFITrescale(F64 x_scale_factor, F64 y_scale_facto
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderQFITrescale::open(ByteStreamIn* stream)
+bool LASreaderQFITrescale::open(ByteStreamIn* stream)
 {
   if (!LASreaderQFIT::open(stream)) return FALSE;
   // do we need to change anything
@@ -480,7 +480,7 @@ LASreaderQFITreoffset::LASreaderQFITreoffset(F64 x_offset, F64 y_offset, F64 z_o
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderQFITreoffset::open(ByteStreamIn* stream)
+bool LASreaderQFITreoffset::open(ByteStreamIn* stream)
 {
   if (!LASreaderQFIT::open(stream)) return FALSE;
   // do we need to change anything
@@ -503,7 +503,7 @@ LASreaderQFITrescalereoffset::LASreaderQFITrescalereoffset(F64 x_scale_factor, F
 {
 }
 
-BOOL LASreaderQFITrescalereoffset::open(ByteStreamIn* stream)
+bool LASreaderQFITrescalereoffset::open(ByteStreamIn* stream)
 {
   if (!LASreaderQFIT::open(stream)) return FALSE;
   // do we need to change anything

--- a/LASlib/src/lasreader_shp.cpp
+++ b/LASlib/src/lasreader_shp.cpp
@@ -101,7 +101,7 @@ static void from_little_endian(double* value)
   }
 }
 
-BOOL LASreaderSHP::open(const char* file_name)
+bool LASreaderSHP::open(const char* file_name)
 {
   if (file_name == 0)
   {
@@ -282,12 +282,12 @@ void LASreaderSHP::set_offset(const F64* offset)
   }
 }
 
-BOOL LASreaderSHP::seek(const I64 p_index)
+bool LASreaderSHP::seek(const I64 p_index)
 {
   return FALSE;
 }
 
-BOOL LASreaderSHP::read_point_default()
+bool LASreaderSHP::read_point_default()
 {
   if (point_count == number_of_points)
   {
@@ -402,7 +402,7 @@ ByteStreamIn* LASreaderSHP::get_stream() const
   return 0;
 }
 
-void LASreaderSHP::close(BOOL close_stream)
+void LASreaderSHP::close(bool close_stream)
 {
   if (file)
   {
@@ -412,7 +412,7 @@ void LASreaderSHP::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderSHP::reopen(const char* file_name)
+bool LASreaderSHP::reopen(const char* file_name)
 {
   if (file_name == 0)
   {
@@ -627,7 +627,7 @@ LASreaderSHPrescale::LASreaderSHPrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderSHPrescale::open(const char* file_name)
+bool LASreaderSHPrescale::open(const char* file_name)
 {
   if (!LASreaderSHP::open(file_name)) return FALSE;
   // do we need to change anything
@@ -653,7 +653,7 @@ LASreaderSHPreoffset::LASreaderSHPreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderSHPreoffset::open(const char* file_name)
+bool LASreaderSHPreoffset::open(const char* file_name)
 {
   if (!LASreaderSHP::open(file_name)) return FALSE;
   // do we need to change anything
@@ -676,7 +676,7 @@ LASreaderSHPrescalereoffset::LASreaderSHPrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderSHPrescalereoffset::open(const char* file_name)
+bool LASreaderSHPrescalereoffset::open(const char* file_name)
 {
   if (!LASreaderSHP::open(file_name)) return FALSE;
   // do we need to change anything

--- a/LASlib/src/lasreader_txt.cpp
+++ b/LASlib/src/lasreader_txt.cpp
@@ -39,7 +39,7 @@
 
 extern "C" FILE* fopen_compressed(const char* filename, const char* mode, bool* piped);
 
-BOOL LASreaderTXT::open(const char* file_name, const char* parse_string, I32 skip_lines, BOOL populate_header)
+bool LASreaderTXT::open(const char* file_name, const char* parse_string, I32 skip_lines, bool populate_header)
 {
   if (file_name == 0)
   {
@@ -62,7 +62,7 @@ BOOL LASreaderTXT::open(const char* file_name, const char* parse_string, I32 ski
   return open(file, file_name, parse_string, skip_lines, populate_header);
 }
 
-BOOL LASreaderTXT::open(FILE* file, const char* file_name, const char* parse_string, I32 skip_lines, BOOL populate_header)
+bool LASreaderTXT::open(FILE* file, const char* file_name, const char* parse_string, I32 skip_lines, bool populate_header)
 {
   int i;
 
@@ -660,14 +660,14 @@ BOOL LASreaderTXT::open(FILE* file, const char* file_name, const char* parse_str
   return TRUE;
 }
 
-void LASreaderTXT::set_pts(BOOL pts)
+void LASreaderTXT::set_pts(bool pts)
 {
   translate_intensity = 2048.0f;
   scale_intensity = 1.0f;
   this->ipts = pts;
 }
 
-void LASreaderTXT::set_ptx(BOOL ptx)
+void LASreaderTXT::set_ptx(bool ptx)
 {
   translate_intensity = 0.0f;
   scale_intensity = 4095.0f;
@@ -754,7 +754,7 @@ void LASreaderTXT::add_attribute(I32 data_type, const char* name, const char* de
   number_attributes++;
 }
 
-BOOL LASreaderTXT::seek(const I64 p_index)
+bool LASreaderTXT::seek(const I64 p_index)
 {
   U32 delta = 0;
   if (p_index > p_count)
@@ -805,7 +805,7 @@ BOOL LASreaderTXT::seek(const I64 p_index)
   return TRUE;
 }
 
-BOOL LASreaderTXT::read_point_default()
+bool LASreaderTXT::read_point_default()
 {
   if (p_count)
   {
@@ -891,7 +891,7 @@ ByteStreamIn* LASreaderTXT::get_stream() const
   return 0;
 }
 
-void LASreaderTXT::close(BOOL close_stream)
+void LASreaderTXT::close(bool close_stream)
 {
   if (file)
   {
@@ -901,7 +901,7 @@ void LASreaderTXT::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderTXT::reopen(const char* file_name)
+bool LASreaderTXT::reopen(const char* file_name)
 {
   int i;
 
@@ -1008,7 +1008,7 @@ LASreaderTXT::~LASreaderTXT()
   }
 }
 
-BOOL LASreaderTXT::parse_attribute(const char* l, I32 index)
+bool LASreaderTXT::parse_attribute(const char* l, I32 index)
 {
   if (index >= header.number_attributes)
   {
@@ -1175,7 +1175,7 @@ BOOL LASreaderTXT::parse_attribute(const char* l, I32 index)
   return TRUE;
 }
 
-BOOL LASreaderTXT::parse(const char* parse_string)
+bool LASreaderTXT::parse(const char* parse_string)
 {
   I32 temp_i;
   F32 temp_f;
@@ -1400,7 +1400,7 @@ BOOL LASreaderTXT::parse(const char* parse_string)
   return TRUE;
 }
 
-BOOL LASreaderTXT::check_parse_string(const char* parse_string)
+bool LASreaderTXT::check_parse_string(const char* parse_string)
 {
   const char* p = parse_string;
   while (p[0])
@@ -1594,7 +1594,7 @@ LASreaderTXTrescale::LASreaderTXTrescale(F64 x_scale_factor, F64 y_scale_factor,
   scale_factor[2] = z_scale_factor;
 }
 
-BOOL LASreaderTXTrescale::open(const char* file_name, const char* parse_string, I32 skip_lines, BOOL populate_header)
+bool LASreaderTXTrescale::open(const char* file_name, const char* parse_string, I32 skip_lines, bool populate_header)
 {
   if (!LASreaderTXT::open(file_name, parse_string, skip_lines, populate_header)) return FALSE;
   // do we need to change anything
@@ -1620,7 +1620,7 @@ LASreaderTXTreoffset::LASreaderTXTreoffset(F64 x_offset, F64 y_offset, F64 z_off
   this->offset[2] = z_offset;
 }
 
-BOOL LASreaderTXTreoffset::open(const char* file_name, const char* parse_string, I32 skip_lines, BOOL populate_header)
+bool LASreaderTXTreoffset::open(const char* file_name, const char* parse_string, I32 skip_lines, bool populate_header)
 {
   if (!LASreaderTXT::open(file_name, parse_string, skip_lines, populate_header)) return FALSE;
   // do we need to change anything
@@ -1643,7 +1643,7 @@ LASreaderTXTrescalereoffset::LASreaderTXTrescalereoffset(F64 x_scale_factor, F64
 {
 }
 
-BOOL LASreaderTXTrescalereoffset::open(const char* file_name, const char* parse_string, I32 skip_lines, BOOL populate_header)
+bool LASreaderTXTrescalereoffset::open(const char* file_name, const char* parse_string, I32 skip_lines, bool populate_header)
 {
   if (!LASreaderTXT::open(file_name, parse_string, skip_lines, populate_header)) return FALSE;
   // do we need to change anything

--- a/LASlib/src/lasreaderbuffered.cpp
+++ b/LASlib/src/lasreaderbuffered.cpp
@@ -85,13 +85,13 @@ void LASreaderBuffered::set_skip_lines(I32 skip_lines)
   lasreadopener_neighbors.set_skip_lines(skip_lines);
 }
 
-void LASreaderBuffered::set_populate_header(BOOL populate_header)
+void LASreaderBuffered::set_populate_header(bool populate_header)
 {
   lasreadopener.set_populate_header(populate_header);
   lasreadopener_neighbors.set_populate_header(populate_header);
 }
 
-BOOL LASreaderBuffered::set_file_name(const char* file_name)
+bool LASreaderBuffered::set_file_name(const char* file_name)
 {
   // do we have a file name
   if (file_name == 0)
@@ -112,7 +112,7 @@ BOOL LASreaderBuffered::set_file_name(const char* file_name)
   return TRUE;
 }
 
-BOOL LASreaderBuffered::add_neighbor_file_name(const char* file_name)
+bool LASreaderBuffered::add_neighbor_file_name(const char* file_name)
 {
   // do we have a file name
   if (file_name == 0)
@@ -138,7 +138,7 @@ void LASreaderBuffered::set_buffer_size(const F32 buffer_size)
   this->buffer_size = buffer_size;
 }
 
-BOOL LASreaderBuffered::open()
+bool LASreaderBuffered::open()
 {
   if (!lasreadopener.active())
   {
@@ -360,7 +360,7 @@ BOOL LASreaderBuffered::open()
   return TRUE;
 }
 
-BOOL LASreaderBuffered::reopen()
+bool LASreaderBuffered::reopen()
 {
   p_count = 0;
   point_count = 0;
@@ -371,7 +371,7 @@ BOOL LASreaderBuffered::reopen()
   return FALSE;
 }
 
-BOOL LASreaderBuffered::remove_buffer()
+bool LASreaderBuffered::remove_buffer()
 {
   clean_buffer();
   if (header.vlr_lasoriginal) npoints = header.vlr_lasoriginal->number_of_point_records;
@@ -400,7 +400,7 @@ void LASreaderBuffered::set_transform(LAStransform* transform)
   this->transform = transform;
 }
 
-BOOL LASreaderBuffered::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
+bool LASreaderBuffered::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
 {
   inside = 1;
   t_ll_x = ll_x;
@@ -415,7 +415,7 @@ BOOL LASreaderBuffered::inside_tile(const F32 ll_x, const F32 ll_y, const F32 si
   return TRUE;
 }
 
-BOOL LASreaderBuffered::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
+bool LASreaderBuffered::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
 {
   inside = 2;
   c_center_x = center_x;
@@ -429,7 +429,7 @@ BOOL LASreaderBuffered::inside_circle(const F64 center_x, const F64 center_y, co
   return TRUE;
 }
 
-BOOL LASreaderBuffered::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
+bool LASreaderBuffered::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
 {
   inside = 3;
   r_min_x = min_x;
@@ -448,7 +448,7 @@ I32 LASreaderBuffered::get_format() const
   return lasreader->get_format();
 }
 
-BOOL LASreaderBuffered::read_point_default()
+bool LASreaderBuffered::read_point_default()
 {
   while (true)
   {
@@ -470,7 +470,7 @@ BOOL LASreaderBuffered::read_point_default()
   }
 }
 
-void LASreaderBuffered::close(BOOL close_stream)
+void LASreaderBuffered::close(bool close_stream)
 {
   if (lasreader) 
   {
@@ -511,7 +511,7 @@ void LASreaderBuffered::clean_buffer()
   point_count = 0;
 }
 
-BOOL LASreaderBuffered::copy_point_to_buffer()
+bool LASreaderBuffered::copy_point_to_buffer()
 {
   U32 point_count_in_buffer = (buffered_points % points_per_buffer);
   if (point_count_in_buffer == 0)
@@ -536,7 +536,7 @@ BOOL LASreaderBuffered::copy_point_to_buffer()
   return TRUE;
 }
 
-BOOL LASreaderBuffered::copy_point_from_buffer()
+bool LASreaderBuffered::copy_point_from_buffer()
 {
   if (point_count >= buffered_points)
   {

--- a/LASlib/src/lasreadermerged.cpp
+++ b/LASlib/src/lasreadermerged.cpp
@@ -42,7 +42,7 @@ void LASreaderMerged::set_io_ibuffer_size(I32 io_ibuffer_size)
   this->io_ibuffer_size = io_ibuffer_size;
 }
 
-BOOL LASreaderMerged::add_file_name(const char* file_name)
+bool LASreaderMerged::add_file_name(const char* file_name)
 {
   // do we have a file name
   if (file_name == 0)
@@ -450,7 +450,7 @@ void LASreaderMerged::set_offset(const F64* offset)
   }
 }
 
-void LASreaderMerged::set_files_are_flightlines(BOOL files_are_flightlines)
+void LASreaderMerged::set_files_are_flightlines(bool files_are_flightlines)
 {
   this->files_are_flightlines = files_are_flightlines;
   // when merging multiple flightlines the merged header must have a file source ID of 0
@@ -460,7 +460,7 @@ void LASreaderMerged::set_files_are_flightlines(BOOL files_are_flightlines)
   }
 }
 
-void LASreaderMerged::set_apply_file_source_ID(BOOL apply_file_source_ID)
+void LASreaderMerged::set_apply_file_source_ID(bool apply_file_source_ID)
 {
   this->apply_file_source_ID = apply_file_source_ID;
   // when merging multiple flightlines the merged header must have a file source ID of 0
@@ -508,17 +508,17 @@ void LASreaderMerged::set_skip_lines(I32 skip_lines)
   this->skip_lines = skip_lines;
 }
 
-void LASreaderMerged::set_populate_header(BOOL populate_header)
+void LASreaderMerged::set_populate_header(bool populate_header)
 {
   this->populate_header = populate_header;
 }
 
-void LASreaderMerged::set_keep_lastiling(BOOL keep_lastiling)
+void LASreaderMerged::set_keep_lastiling(bool keep_lastiling)
 {
   this->keep_lastiling = keep_lastiling;
 }
 
-BOOL LASreaderMerged::open()
+bool LASreaderMerged::open()
 {
   if (file_name_number == 0)
   {
@@ -536,7 +536,7 @@ BOOL LASreaderMerged::open()
   // combine all headers
 
   U32 i,j;
-  BOOL first = TRUE;
+  bool first = TRUE;
 
   for (i = 0; i < file_name_number; i++)
   {
@@ -1060,7 +1060,7 @@ void LASreaderMerged::set_transform(LAStransform* transform)
   this->transform = transform;
 }
 
-BOOL LASreaderMerged::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
+bool LASreaderMerged::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
 {
   inside = 1;
   t_ll_x = ll_x;
@@ -1079,7 +1079,7 @@ BOOL LASreaderMerged::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size
   return TRUE;
 }
 
-BOOL LASreaderMerged::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
+bool LASreaderMerged::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
 {
   inside = 2;
   c_center_x = center_x;
@@ -1097,7 +1097,7 @@ BOOL LASreaderMerged::inside_circle(const F64 center_x, const F64 center_y, cons
   return TRUE;
 }
 
-BOOL LASreaderMerged::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
+bool LASreaderMerged::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
 {
   inside = 3;
   r_min_x = min_x;
@@ -1120,7 +1120,7 @@ I32 LASreaderMerged::get_format() const
   return lasreader->get_format();
 }
 
-BOOL LASreaderMerged::read_point_default()
+bool LASreaderMerged::read_point_default()
 {
   if (file_name_current == 0)
   {
@@ -1174,7 +1174,7 @@ BOOL LASreaderMerged::read_point_default()
   return FALSE;
 }
 
-void LASreaderMerged::close(BOOL close_stream)
+void LASreaderMerged::close(bool close_stream)
 {
   if (lasreader) 
   {
@@ -1182,7 +1182,7 @@ void LASreaderMerged::close(BOOL close_stream)
   }
 }
 
-BOOL LASreaderMerged::reopen()
+bool LASreaderMerged::reopen()
 {
   p_count = 0;
   file_name_current = 0;
@@ -1282,7 +1282,7 @@ LASreaderMerged::~LASreaderMerged()
   clean();
 }
 
-BOOL LASreaderMerged::open_next_file()
+bool LASreaderMerged::open_next_file()
 {
   while (file_name_current < file_name_number)
   {

--- a/LASlib/src/lasreaderpipeon.cpp
+++ b/LASlib/src/lasreaderpipeon.cpp
@@ -39,7 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-BOOL LASreaderPipeOn::open(LASreader* lasreader)
+bool LASreaderPipeOn::open(LASreader* lasreader)
 {
   if (lasreader == 0)
   {
@@ -128,17 +128,17 @@ void LASreaderPipeOn::set_transform(LAStransform* transform)
   if (lasreader) lasreader->set_transform(transform);
 }
 
-BOOL LASreaderPipeOn::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
+bool LASreaderPipeOn::inside_tile(const F32 ll_x, const F32 ll_y, const F32 size)
 {
   return (lasreader ? lasreader->inside_tile(ll_x, ll_y, size) : FALSE);
 }
 
-BOOL LASreaderPipeOn::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
+bool LASreaderPipeOn::inside_circle(const F64 center_x, const F64 center_y, const F64 radius)
 {
   return (lasreader ? lasreader->inside_circle(center_x, center_y, radius) : FALSE);
 }
 
-BOOL LASreaderPipeOn::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
+bool LASreaderPipeOn::inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y)
 {
   return (lasreader ? lasreader->inside_rectangle(min_x, min_y, max_x, max_y) : FALSE);
 }
@@ -148,7 +148,7 @@ I32 LASreaderPipeOn::get_format() const
   return (lasreader ? lasreader->get_format() : LAS_TOOLS_FORMAT_DEFAULT);
 }
 
-BOOL LASreaderPipeOn::read_point_default()
+bool LASreaderPipeOn::read_point_default()
 {
   while (true)
   {
@@ -173,7 +173,7 @@ BOOL LASreaderPipeOn::read_point_default()
   }
 }
 
-void LASreaderPipeOn::close(BOOL close_stream)
+void LASreaderPipeOn::close(bool close_stream)
 {
   if (lasreader) 
   {

--- a/LASlib/src/lastransform.cpp
+++ b/LASlib/src/lastransform.cpp
@@ -1210,7 +1210,7 @@ void LAStransform::usage() const
   fprintf(stderr,"  -copy_R_into_NIR -copy_G_into_NIR -copy_B_into_NIR\n");
 }
 
-BOOL LAStransform::parse(int argc, char* argv[])
+bool LAStransform::parse(int argc, char* argv[])
 {
   int i;
 
@@ -2029,7 +2029,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
   return TRUE;
 }
 
-BOOL LAStransform::parse(CHAR* string)
+bool LAStransform::parse(CHAR* string)
 {
   int p = 0;
   int argc = 1;

--- a/LASlib/src/lasutility.cpp
+++ b/LASlib/src/lasutility.cpp
@@ -45,7 +45,7 @@ LASinventory::LASinventory()
   first = TRUE;
 }
 
-BOOL LASinventory::init(const LASheader* header)
+bool LASinventory::init(const LASheader* header)
 {
   if (header)
   {
@@ -66,7 +66,7 @@ BOOL LASinventory::init(const LASheader* header)
   return FALSE;
 }
 
-BOOL LASinventory::add(const LASpoint* point)
+bool LASinventory::add(const LASpoint* point)
 {
   extended_number_of_point_records++;
   if (point->extended_point_type)
@@ -96,7 +96,7 @@ BOOL LASinventory::add(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASinventory::update_header(LASheader* header) const
+bool LASinventory::update_header(LASheader* header) const
 {
   if (header)
   {
@@ -175,7 +175,7 @@ LASsummary::LASsummary()
   first = TRUE;
 }
 
-BOOL LASsummary::add(const LASpoint* point)
+bool LASsummary::add(const LASpoint* point)
 {
   number_of_point_records++;
   if (point->extended_point_type)
@@ -868,7 +868,7 @@ LAShistogram::~LAShistogram()
   if (return_map_bin_intensity) delete return_map_bin_intensity;
 }
 
-BOOL LAShistogram::parse(int argc, char* argv[])
+bool LAShistogram::parse(int argc, char* argv[])
 {
   int i;
   for (i = 1; i < argc; i++)
@@ -937,7 +937,7 @@ I32 LAShistogram::unparse(CHAR* string) const
   return n;
 }
 
-BOOL LAShistogram::histo(const CHAR* name, F32 step)
+bool LAShistogram::histo(const CHAR* name, F32 step)
 {
   if (strcmp(name, "x") == 0)
     x_bin = new LASbin(step);
@@ -1000,7 +1000,7 @@ BOOL LAShistogram::histo(const CHAR* name, F32 step)
   return TRUE;
 }
 
-BOOL LAShistogram::histo_avg(const CHAR* name, F32 step, const CHAR* name_avg)
+bool LAShistogram::histo_avg(const CHAR* name, F32 step, const CHAR* name_avg)
 {
   if (strcmp(name, "classification") == 0)
   {
@@ -1184,7 +1184,7 @@ void LAShistogram::reset()
   if (return_map_bin_intensity) return_map_bin_intensity->reset();
 }
 
-BOOL LASoccupancyGrid::add(const LASpoint* point)
+bool LASoccupancyGrid::add(const LASpoint* point)
 {
   I32 pos_x, pos_y;
   if (grid_spacing < 0)
@@ -1206,7 +1206,7 @@ BOOL LASoccupancyGrid::add(const LASpoint* point)
   return add_internal(pos_x, pos_y);
 }
 
-BOOL LASoccupancyGrid::add(I32 pos_x, I32 pos_y)
+bool LASoccupancyGrid::add(I32 pos_x, I32 pos_y)
 {
   if (grid_spacing < 0)
   {
@@ -1223,10 +1223,10 @@ BOOL LASoccupancyGrid::add(I32 pos_x, I32 pos_y)
   return add_internal(pos_x, pos_y);
 }
 
-BOOL LASoccupancyGrid::add_internal(I32 pos_x, I32 pos_y)
+bool LASoccupancyGrid::add_internal(I32 pos_x, I32 pos_y)
 {
   pos_y = pos_y - anker;
-  BOOL no_x_anker = FALSE;
+  bool no_x_anker = FALSE;
   U32* array_size;
   I32** ankers;
   U32*** array;
@@ -1343,14 +1343,14 @@ BOOL LASoccupancyGrid::add_internal(I32 pos_x, I32 pos_y)
   return TRUE;
 }
 
-BOOL LASoccupancyGrid::occupied(const LASpoint* point) const
+bool LASoccupancyGrid::occupied(const LASpoint* point) const
 {
   I32 pos_x = I32_FLOOR(point->get_x() / grid_spacing);
   I32 pos_y = I32_FLOOR(point->get_y() / grid_spacing);
   return occupied(pos_x, pos_y);
 }
 
-BOOL LASoccupancyGrid::occupied(I32 pos_x, I32 pos_y) const
+bool LASoccupancyGrid::occupied(I32 pos_x, I32 pos_y) const
 {
   if (grid_spacing < 0)
   {
@@ -1428,7 +1428,7 @@ BOOL LASoccupancyGrid::occupied(I32 pos_x, I32 pos_y) const
   return FALSE;
 }
 
-BOOL LASoccupancyGrid::active() const
+bool LASoccupancyGrid::active() const
 {
   if (grid_spacing < 0) return FALSE;
   return TRUE;
@@ -1481,7 +1481,7 @@ void LASoccupancyGrid::reset()
   num_occupied = 0;
 }
 
-BOOL LASoccupancyGrid::write_asc_grid(const CHAR* file_name) const
+bool LASoccupancyGrid::write_asc_grid(const CHAR* file_name) const
 {
   FILE* file = fopen(file_name, "w");
   if (file == 0) return FALSE;

--- a/LASlib/src/laswaveform13reader.cpp
+++ b/LASlib/src/laswaveform13reader.cpp
@@ -72,12 +72,12 @@ LASwaveform13reader::~LASwaveform13reader()
   if (dec) delete dec;
 }
 
-BOOL LASwaveform13reader::is_compressed() const
+bool LASwaveform13reader::is_compressed() const
 {
   return compressed;
 }
 
-BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data_packet_record, const LASvlr_wave_packet_descr * const * wave_packet_descr)
+bool LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data_packet_record, const LASvlr_wave_packet_descr * const * wave_packet_descr)
 {
   if (file_name == 0)
   {
@@ -254,7 +254,7 @@ BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data
   return TRUE;
 }
 
-BOOL LASwaveform13reader::read_waveform(const LASpoint* point)
+bool LASwaveform13reader::read_waveform(const LASpoint* point)
 {
   U32 index = point->wavepacket.getIndex();
   if (index == 0)
@@ -350,7 +350,7 @@ BOOL LASwaveform13reader::read_waveform(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwaveform13reader::get_samples()
+bool LASwaveform13reader::get_samples()
 {
   if (nbits == 8)
   {
@@ -376,7 +376,7 @@ BOOL LASwaveform13reader::get_samples()
   return (s_count < nsamples);
 }
 
-BOOL LASwaveform13reader::has_samples()
+bool LASwaveform13reader::has_samples()
 {
   if (s_count < nsamples)
   {
@@ -394,7 +394,7 @@ BOOL LASwaveform13reader::has_samples()
   return FALSE;
 }
 
-BOOL LASwaveform13reader::get_samples_xyz()
+bool LASwaveform13reader::get_samples_xyz()
 {
   if (nbits == 8)
   {
@@ -420,7 +420,7 @@ BOOL LASwaveform13reader::get_samples_xyz()
   return (s_count < nsamples);
 }
 
-BOOL LASwaveform13reader::has_samples_xyz()
+bool LASwaveform13reader::has_samples_xyz()
 {
   if (s_count < nsamples)
   {

--- a/LASlib/src/laswaveform13writer.cpp
+++ b/LASlib/src/laswaveform13writer.cpp
@@ -69,7 +69,7 @@ LASwaveform13writer::~LASwaveform13writer()
 }
 
 
-BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_descr * const * wave_packet_descr)
+bool LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_descr * const * wave_packet_descr)
 {
   if (file_name == 0)
   {
@@ -86,7 +86,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
   // copy relevant wave packet descriptions and check if compressed or not
 
   U16 i, number = 0;
-  BOOL compressed = FALSE;
+  bool compressed = FALSE;
 
   if (waveforms == 0)
   {
@@ -249,7 +249,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
   return TRUE;
 }
 
-BOOL LASwaveform13writer::write_waveform(LASpoint* point, U8* samples)
+bool LASwaveform13writer::write_waveform(LASpoint* point, U8* samples)
 {
   U32 index = point->wavepacket.getIndex();
   if (index == 0)

--- a/LASlib/src/laswriter.cpp
+++ b/LASlib/src/laswriter.cpp
@@ -45,7 +45,7 @@
 #define DIRECTORY_SLASH '/'
 #endif
 
-BOOL LASwriteOpener::is_piped() const
+bool LASwriteOpener::is_piped() const
 {
   return ((file_name == 0) && use_stdout);
 }
@@ -233,7 +233,7 @@ void LASwriteOpener::usage() const
   fprintf(stderr,"  -nil    (pipe to NULL)\n");
 }
 
-BOOL LASwriteOpener::parse(int argc, char* argv[])
+bool LASwriteOpener::parse(int argc, char* argv[])
 {
   int i;
   for (i = 1; i < argc; i++)
@@ -501,7 +501,7 @@ void LASwriteOpener::set_cut(U32 cut)
   if (cut && file_name) cut_characters();
 }
 
-BOOL LASwriteOpener::set_format(I32 format)
+bool LASwriteOpener::set_format(I32 format)
 {
   if ((format < LAS_TOOLS_FORMAT_DEFAULT) || (format > LAS_TOOLS_FORMAT_TXT))
   {
@@ -566,7 +566,7 @@ BOOL LASwriteOpener::set_format(I32 format)
   return TRUE;
 }
 
-BOOL LASwriteOpener::set_format(const CHAR* format)
+bool LASwriteOpener::set_format(const CHAR* format)
 {
   if (format)
   {
@@ -603,7 +603,7 @@ BOOL LASwriteOpener::set_format(const CHAR* format)
   return TRUE;
 }
 
-void LASwriteOpener::set_force(BOOL force)
+void LASwriteOpener::set_force(bool force)
 {
   this->force = force;
 }
@@ -863,7 +863,7 @@ U32 LASwriteOpener::get_cut() const
   return cut;
 }
 
-BOOL LASwriteOpener::format_was_specified() const
+bool LASwriteOpener::format_was_specified() const
 {
   return specified;
 }
@@ -941,7 +941,7 @@ void LASwriteOpener::set_scale_rgb(F32 scale_rgb)
   this->scale_rgb = scale_rgb;
 }
 
-BOOL LASwriteOpener::active() const
+bool LASwriteOpener::active() const
 {
   return (file_name != 0 || use_stdout || use_nil);
 }

--- a/LASlib/src/laswriter_bin.cpp
+++ b/LASlib/src/laswriter_bin.cpp
@@ -78,14 +78,14 @@ struct TSheader
   I32 rgb;
 };
 
-BOOL LASwriterBIN::refile(FILE* file)
+bool LASwriterBIN::refile(FILE* file)
 {
   if (stream == 0) return FALSE;
   if (this->file) this->file = file;
   return ((ByteStreamOutFile*)stream)->refile(file);
 }
 
-BOOL LASwriterBIN::open(const char* file_name, const LASheader* header, const char* version, U32 io_buffer_size)
+bool LASwriterBIN::open(const char* file_name, const LASheader* header, const char* version, U32 io_buffer_size)
 {
   if (file_name == 0)
   {
@@ -115,7 +115,7 @@ BOOL LASwriterBIN::open(const char* file_name, const LASheader* header, const ch
   return open(out, header, version);
 }
 
-BOOL LASwriterBIN::open(FILE* file, const LASheader* header, const char* version)
+bool LASwriterBIN::open(FILE* file, const LASheader* header, const char* version)
 {
   if (file == 0)
   {
@@ -142,7 +142,7 @@ BOOL LASwriterBIN::open(FILE* file, const LASheader* header, const char* version
   return open(out, header, version);
 }
 
-BOOL LASwriterBIN::open(ByteStreamOut* stream, const LASheader* header, const char* version)
+bool LASwriterBIN::open(ByteStreamOut* stream, const LASheader* header, const char* version)
 {
   if (stream == 0)
   {
@@ -185,7 +185,7 @@ BOOL LASwriterBIN::open(ByteStreamOut* stream, const LASheader* header, const ch
   return stream->putBytes((U8*)&tsheader, sizeof(TSheader));
 }
 
-BOOL LASwriterBIN::write_point(const LASpoint* point)
+bool LASwriterBIN::write_point(const LASpoint* point)
 {
   U16 echo;
 
@@ -242,12 +242,12 @@ BOOL LASwriterBIN::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterBIN::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterBIN::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return TRUE;
 }
 
-I64 LASwriterBIN::close(BOOL update_header)
+I64 LASwriterBIN::close(bool update_header)
 {
   I64 bytes = 0;
   

--- a/LASlib/src/laswriter_las.cpp
+++ b/LASlib/src/laswriter_las.cpp
@@ -43,20 +43,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-BOOL LASwriterLAS::refile(FILE* file)
+bool LASwriterLAS::refile(FILE* file)
 {
   if (stream == 0) return FALSE;
   if (this->file) this->file = file;
   return ((ByteStreamOutFile*)stream)->refile(file);
 }
 
-BOOL LASwriterLAS::open(const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
+bool LASwriterLAS::open(const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
 {
   ByteStreamOut* out = new ByteStreamOutNil();
   return open(out, header, compressor, requested_version, chunk_size);
 }
 
-BOOL LASwriterLAS::open(const char* file_name, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size, I32 io_buffer_size)
+bool LASwriterLAS::open(const char* file_name, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size, I32 io_buffer_size)
 {
   if (file_name == 0)
   {
@@ -85,7 +85,7 @@ BOOL LASwriterLAS::open(const char* file_name, const LASheader* header, U32 comp
   return open(out, header, compressor, requested_version, chunk_size);
 }
 
-BOOL LASwriterLAS::open(FILE* file, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
+bool LASwriterLAS::open(FILE* file, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
 {
   if (file == 0)
   {
@@ -112,7 +112,7 @@ BOOL LASwriterLAS::open(FILE* file, const LASheader* header, U32 compressor, I32
   return open(out, header, compressor, requested_version, chunk_size);
 }
 
-BOOL LASwriterLAS::open(ostream& stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
+bool LASwriterLAS::open(ostream& stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
 {
   ByteStreamOut* out;
   if (IS_LITTLE_ENDIAN())
@@ -123,7 +123,7 @@ BOOL LASwriterLAS::open(ostream& stream, const LASheader* header, U32 compressor
   return open(out, header, compressor, requested_version, chunk_size);
 }
 
-BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
+bool LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 compressor, I32 requested_version, I32 chunk_size)
 {
   U32 i, j;
 
@@ -157,7 +157,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
   LASpoint point;
   U8 point_data_format;
   U16 point_data_record_length;
-  BOOL point_is_standard = TRUE;
+  bool point_is_standard = TRUE;
 
   if (header->laszip)
   {
@@ -891,18 +891,18 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
   return TRUE;
 }
 
-BOOL LASwriterLAS::write_point(const LASpoint* point)
+bool LASwriterLAS::write_point(const LASpoint* point)
 {
   p_count++;
   return writer->write(point->point);
 }
 
-BOOL LASwriterLAS::chunk()
+bool LASwriterLAS::chunk()
 {
   return writer->chunk();
 }
 
-BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterLAS::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   I32 i;
   if (header == 0)
@@ -1206,7 +1206,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
   return TRUE;
 }
 
-I64 LASwriterLAS::close(BOOL update_header)
+I64 LASwriterLAS::close(bool update_header)
 {
   I64 bytes = 0;
 

--- a/LASlib/src/laswriter_qfit.cpp
+++ b/LASlib/src/laswriter_qfit.cpp
@@ -40,14 +40,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-BOOL LASwriterQFIT::refile(FILE* file)
+bool LASwriterQFIT::refile(FILE* file)
 {
   if (stream == 0) return FALSE;
   if (this->file) this->file = file;
   return ((ByteStreamOutFile*)stream)->refile(file);
 }
 
-BOOL LASwriterQFIT::open(const char* file_name, const LASheader* header, I32 version, U32 io_buffer_size)
+bool LASwriterQFIT::open(const char* file_name, const LASheader* header, I32 version, U32 io_buffer_size)
 {
   if (file_name == 0)
   {
@@ -71,7 +71,7 @@ BOOL LASwriterQFIT::open(const char* file_name, const LASheader* header, I32 ver
   return open(file, header, version);
 }
 
-BOOL LASwriterQFIT::open(FILE* file, const LASheader* header, I32 version)
+bool LASwriterQFIT::open(FILE* file, const LASheader* header, I32 version)
 {
   if (file == 0)
   {
@@ -104,7 +104,7 @@ BOOL LASwriterQFIT::open(FILE* file, const LASheader* header, I32 version)
   return open(out, header, version);
 }
 
-BOOL LASwriterQFIT::open(ByteStreamOut* stream, const LASheader* header, I32 version)
+bool LASwriterQFIT::open(ByteStreamOut* stream, const LASheader* header, I32 version)
 {
   if (stream == 0)
   {
@@ -220,7 +220,7 @@ BOOL LASwriterQFIT::open(ByteStreamOut* stream, const LASheader* header, I32 ver
   return TRUE;
 }
 
-BOOL LASwriterQFIT::write_point(const LASpoint* point)
+bool LASwriterQFIT::write_point(const LASpoint* point)
 {
   buffer[0] = I32_QUANTIZE(point->gps_time / 0.001);
   if (buffer[0] < 0) buffer[0] *= -1;
@@ -264,12 +264,12 @@ BOOL LASwriterQFIT::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterQFIT::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterQFIT::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return TRUE;
 }
 
-I64 LASwriterQFIT::close(BOOL update_header)
+I64 LASwriterQFIT::close(bool update_header)
 {
   I64 bytes = 0;
   

--- a/LASlib/src/laswriter_txt.cpp
+++ b/LASlib/src/laswriter_txt.cpp
@@ -33,18 +33,18 @@
 #include <stdlib.h>
 #include <string.h>
 
-BOOL LASwriterTXT::refile(FILE* file)
+bool LASwriterTXT::refile(FILE* file)
 {
   this->file = file;
   return TRUE;
 }
 
-void LASwriterTXT::set_pts(BOOL pts)
+void LASwriterTXT::set_pts(bool pts)
 {
   this->opts = pts;
 }
 
-void LASwriterTXT::set_ptx(BOOL ptx)
+void LASwriterTXT::set_ptx(bool ptx)
 {
   this->optx = ptx;
 }
@@ -54,7 +54,7 @@ void LASwriterTXT::set_scale_rgb(F32 scale_rgb)
   this->scale_rgb = scale_rgb;
 }
 
-BOOL LASwriterTXT::open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string, const CHAR* separator)
+bool LASwriterTXT::open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string, const CHAR* separator)
 {
   if (file_name == 0)
   {
@@ -75,7 +75,7 @@ BOOL LASwriterTXT::open(const CHAR* file_name, const LASheader* header, const CH
   return open(file, header, parse_string, separator);
 }
 
-BOOL LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_string, const CHAR* separator)
+bool LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_string, const CHAR* separator)
 {
   if (file == 0)
   {
@@ -299,7 +299,7 @@ static void lidardouble2string(CHAR* string, double value, double precision)
     lidardouble2string(string, value);
 }
 
-BOOL LASwriterTXT::unparse_attribute(const LASpoint* point, I32 index)
+bool LASwriterTXT::unparse_attribute(const LASpoint* point, I32 index)
 {
   if (index >= header->number_attributes)
   {
@@ -425,7 +425,7 @@ BOOL LASwriterTXT::unparse_attribute(const LASpoint* point, I32 index)
   return TRUE;
 }
 
-BOOL LASwriterTXT::write_point(const LASpoint* point)
+bool LASwriterTXT::write_point(const LASpoint* point)
 {
   p_count++;
   int i = 0;
@@ -548,12 +548,12 @@ BOOL LASwriterTXT::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterTXT::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterTXT::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return TRUE;
 }
 
-I64 LASwriterTXT::close(BOOL update_header)
+I64 LASwriterTXT::close(bool update_header)
 {
   U32 bytes = (U32)ftell(file);
 
@@ -594,7 +594,7 @@ LASwriterTXT::~LASwriterTXT()
   if (file) close();
 }
 
-BOOL LASwriterTXT::check_parse_string(const CHAR* parse_string)
+bool LASwriterTXT::check_parse_string(const CHAR* parse_string)
 {
   const CHAR* p = parse_string;
   while (p[0])

--- a/LASlib/src/laswriter_wrl.cpp
+++ b/LASlib/src/laswriter_wrl.cpp
@@ -34,7 +34,7 @@
 #include <string.h>
 
 
-BOOL LASwriterWRL::open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string)
+bool LASwriterWRL::open(const CHAR* file_name, const LASheader* header, const CHAR* parse_string)
 {
   if (file_name == 0)
   {
@@ -55,7 +55,7 @@ BOOL LASwriterWRL::open(const CHAR* file_name, const LASheader* header, const CH
   return open(file, header, parse_string);
 }
 
-BOOL LASwriterWRL::open(FILE* file, const LASheader* header, const CHAR* parse_string)
+bool LASwriterWRL::open(FILE* file, const LASheader* header, const CHAR* parse_string)
 {
   if (file == 0)
   {
@@ -159,7 +159,7 @@ static void lidardouble2string(CHAR* string, double value, double precision)
     lidardouble2string(string, value);
 }
 
-BOOL LASwriterWRL::write_point(const LASpoint* point)
+bool LASwriterWRL::write_point(const LASpoint* point)
 {
   lidardouble2string(printstring, header->get_x(point->get_X()), header->x_scale_factor); fprintf(file, "%s ", printstring);
   lidardouble2string(printstring, header->get_y(point->get_Y()), header->y_scale_factor); fprintf(file, "%s ", printstring);
@@ -188,12 +188,12 @@ BOOL LASwriterWRL::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterWRL::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterWRL::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return TRUE;
 }
 
-I64 LASwriterWRL::close(BOOL update_header)
+I64 LASwriterWRL::close(bool update_header)
 {
   if (file == 0)
   {

--- a/LASlib/src/laswritercompatible.cpp
+++ b/LASlib/src/laswritercompatible.cpp
@@ -33,7 +33,7 @@
 #include "bytestreamout_array.hpp"
 #include "bytestreamin_array.hpp"
 
-BOOL LASwriterCompatibleDown::open(LASheader* header, LASwriteOpener* laswriteopener, BOOL moveCRSfromEVLRtoVLR, BOOL moveEVLRtoVLR)
+bool LASwriterCompatibleDown::open(LASheader* header, LASwriteOpener* laswriteopener, bool moveCRSfromEVLRtoVLR, bool moveEVLRtoVLR)
 {
   U32 i;
 
@@ -288,7 +288,7 @@ BOOL LASwriterCompatibleDown::open(LASheader* header, LASwriteOpener* laswriteop
   return TRUE;
 }
 
-BOOL LASwriterCompatibleDown::write_point(const LASpoint* point)
+bool LASwriterCompatibleDown::write_point(const LASpoint* point)
 {
   I32 scan_angle_remainder;
   I32 number_of_returns_increment;
@@ -369,12 +369,12 @@ BOOL LASwriterCompatibleDown::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterCompatibleDown::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterCompatibleDown::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return writer->update_header(header, use_inventory, update_extra_bytes);
 }
 
-I64 LASwriterCompatibleDown::close(BOOL update_header)
+I64 LASwriterCompatibleDown::close(bool update_header)
 {
   I64 bytes = writer->close(update_header);
 
@@ -399,7 +399,7 @@ LASwriterCompatibleDown::~LASwriterCompatibleDown()
 {
 }
 
-BOOL LASwriterCompatibleUp::open(LASheader* header, LASwriteOpener* laswriteopener)
+bool LASwriterCompatibleUp::open(LASheader* header, LASwriteOpener* laswriteopener)
 {
   U32 i;
 
@@ -592,7 +592,7 @@ BOOL LASwriterCompatibleUp::open(LASheader* header, LASwriteOpener* laswriteopen
   return TRUE;
 }
 
-BOOL LASwriterCompatibleUp::write_point(const LASpoint* point)
+bool LASwriterCompatibleUp::write_point(const LASpoint* point)
 {
   I16 scan_angle;
   U8 extended_returns;
@@ -631,12 +631,12 @@ BOOL LASwriterCompatibleUp::write_point(const LASpoint* point)
   return TRUE;
 }
 
-BOOL LASwriterCompatibleUp::update_header(const LASheader* header, BOOL use_inventory, BOOL update_extra_bytes)
+bool LASwriterCompatibleUp::update_header(const LASheader* header, bool use_inventory, bool update_extra_bytes)
 {
   return writer->update_header(header, use_inventory, update_extra_bytes);
 }
 
-I64 LASwriterCompatibleUp::close(BOOL update_header)
+I64 LASwriterCompatibleUp::close(bool update_header)
 {
   I64 bytes = writer->close(update_header);
 

--- a/LASzip/src/arithmeticdecoder.cpp
+++ b/LASzip/src/arithmeticdecoder.cpp
@@ -79,7 +79,7 @@ ArithmeticDecoder::ArithmeticDecoder()
   instream = 0;
 }
 
-BOOL ArithmeticDecoder::init(ByteStreamIn* instream)
+bool ArithmeticDecoder::init(ByteStreamIn* instream)
 {
   if (instream == 0) return FALSE;
   this->instream = instream;

--- a/LASzip/src/arithmeticdecoder.hpp
+++ b/LASzip/src/arithmeticdecoder.hpp
@@ -51,7 +51,7 @@ public:
   ~ArithmeticDecoder();
 
 /* Manage decoding                                           */
-  BOOL init(ByteStreamIn* instream);
+  bool init(ByteStreamIn* instream);
   void done();
 
 /* Manage an entropy model for a single bit                  */

--- a/LASzip/src/arithmeticencoder.cpp
+++ b/LASzip/src/arithmeticencoder.cpp
@@ -91,7 +91,7 @@ ArithmeticEncoder::~ArithmeticEncoder()
   free(outbuffer);
 }
 
-BOOL ArithmeticEncoder::init(ByteStreamOut* outstream)
+bool ArithmeticEncoder::init(ByteStreamOut* outstream)
 {
   if (outstream == 0) return FALSE;
   this->outstream = outstream;
@@ -105,7 +105,7 @@ BOOL ArithmeticEncoder::init(ByteStreamOut* outstream)
 void ArithmeticEncoder::done()
 {
   U32 init_base = base;                 // done encoding: set final data bytes
-  BOOL another_byte = TRUE;
+  bool another_byte = TRUE;
 
   if (length > 2 * AC__MinLength) {
     base  += AC__MinLength;                                     // base offset

--- a/LASzip/src/arithmeticencoder.hpp
+++ b/LASzip/src/arithmeticencoder.hpp
@@ -50,7 +50,7 @@ public:
   ~ArithmeticEncoder();
 
 /* Manage encoding                                           */
-  BOOL init(ByteStreamOut* outstream);
+  bool init(ByteStreamOut* outstream);
   void done();
 
 /* Manage an entropy model for a single bit                  */

--- a/LASzip/src/arithmeticmodel.cpp
+++ b/LASzip/src/arithmeticmodel.cpp
@@ -72,7 +72,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-ArithmeticModel::ArithmeticModel(U32 symbols, BOOL compress)
+ArithmeticModel::ArithmeticModel(U32 symbols, bool compress)
 {
   this->symbols = symbols;
   this->compress = compress;

--- a/LASzip/src/arithmeticmodel.hpp
+++ b/LASzip/src/arithmeticmodel.hpp
@@ -57,7 +57,7 @@ const U32 DM__MaxCount    = 1 << DM__LengthShift;  // for adaptive models
 class ArithmeticModel
 {
 public:
-  ArithmeticModel(U32 symbols, BOOL compress);
+  ArithmeticModel(U32 symbols, bool compress);
   ~ArithmeticModel();
 
   I32 init(U32* table=0);
@@ -67,7 +67,7 @@ private:
   U32 * distribution, * symbol_count, * decoder_table;
   U32 total_count, update_cycle, symbols_until_update;
   U32 symbols, last_symbol, table_size, table_shift;
-  BOOL compress;
+  bool compress;
   friend class ArithmeticEncoder;
   friend class ArithmeticDecoder;
 };

--- a/LASzip/src/bytestreamin.hpp
+++ b/LASzip/src/bytestreamin.hpp
@@ -71,13 +71,13 @@ public:
 /* read 64 bit big-endian field                              */
   virtual void get64bitsBE(U8* bytes) = 0;
 /* is the stream seekable (e.g. stdin is not)                */
-  virtual BOOL isSeekable() const = 0;
+  virtual bool isSeekable() const = 0;
 /* get current position of stream                            */
   virtual I64 tell() const = 0;
 /* seek to this position in the stream                       */
-  virtual BOOL seek(const I64 position) = 0;
+  virtual bool seek(const I64 position) = 0;
 /* seek to the end of the file                               */
-  virtual BOOL seekEnd(const I64 distance=0) = 0;
+  virtual bool seekEnd(const I64 distance=0) = 0;
 /* constructor                                               */
   inline ByteStreamIn() { bit_buffer = 0; num_buffer = 0; };
 /* destructor                                                */

--- a/LASzip/src/bytestreamin_array.hpp
+++ b/LASzip/src/bytestreamin_array.hpp
@@ -41,13 +41,13 @@ public:
 /* read an array of bytes                                    */
   void getBytes(U8* bytes, const U32 num_bytes);
 /* is the stream seekable (e.g. stdin is not)                */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the stream                             */
-  BOOL seekEnd(const I64 distance=0);
+  bool seekEnd(const I64 distance=0);
 /* destructor                                                */
   ~ByteStreamInArray(){};
 protected:
@@ -124,7 +124,7 @@ inline void ByteStreamInArray::getBytes(U8* bytes, const U32 num_bytes)
   curr += num_bytes;
 }
 
-inline BOOL ByteStreamInArray::isSeekable() const
+inline bool ByteStreamInArray::isSeekable() const
 {
   return TRUE;
 }
@@ -134,7 +134,7 @@ inline I64 ByteStreamInArray::tell() const
   return curr;
 }
 
-inline BOOL ByteStreamInArray::seek(const I64 position)
+inline bool ByteStreamInArray::seek(const I64 position)
 {
   if ((0 <= position) && (position <= size))
   {
@@ -144,7 +144,7 @@ inline BOOL ByteStreamInArray::seek(const I64 position)
   return FALSE;
 }
 
-inline BOOL ByteStreamInArray::seekEnd(const I64 distance)
+inline bool ByteStreamInArray::seekEnd(const I64 distance)
 {
   if ((0 <= distance) && (distance <= size))
   {

--- a/LASzip/src/bytestreamin_file.hpp
+++ b/LASzip/src/bytestreamin_file.hpp
@@ -51,13 +51,13 @@ public:
 /* read an array of bytes                                    */
   void getBytes(U8* bytes, const U32 num_bytes);
 /* is the stream seekable (e.g. stdin is not)                */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd(const I64 distance=0);
+  bool seekEnd(const I64 distance=0);
 /* destructor                                                */
   ~ByteStreamInFile(){};
 protected:
@@ -127,7 +127,7 @@ inline void ByteStreamInFile::getBytes(U8* bytes, const U32 num_bytes)
   }
 }
 
-inline BOOL ByteStreamInFile::isSeekable() const
+inline bool ByteStreamInFile::isSeekable() const
 {
   return (file != stdin);
 }
@@ -143,7 +143,7 @@ inline I64 ByteStreamInFile::tell() const
 #endif
 }
 
-inline BOOL ByteStreamInFile::seek(const I64 position)
+inline bool ByteStreamInFile::seek(const I64 position)
 {
   if (tell() != position)
   {
@@ -158,7 +158,7 @@ inline BOOL ByteStreamInFile::seek(const I64 position)
   return TRUE;
 }
 
-inline BOOL ByteStreamInFile::seekEnd(const I64 distance)
+inline bool ByteStreamInFile::seekEnd(const I64 distance)
 {
 #if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, -distance, SEEK_END));

--- a/LASzip/src/bytestreamin_istream.hpp
+++ b/LASzip/src/bytestreamin_istream.hpp
@@ -52,13 +52,13 @@ public:
 /* read an array of bytes                                    */
   void getBytes(U8* bytes, const U32 num_bytes);
 /* is the stream seekable (e.g. standard in is not)          */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd(const I64 distance=0);
+  bool seekEnd(const I64 distance=0);
 /* destructor                                                */
   ~ByteStreamInIstream(){};
 protected:
@@ -129,7 +129,7 @@ inline void ByteStreamInIstream::getBytes(U8* bytes, const U32 num_bytes)
   }
 }
 
-inline BOOL ByteStreamInIstream::isSeekable() const
+inline bool ByteStreamInIstream::isSeekable() const
 {
   return !!(static_cast<ifstream&>(stream));
 }
@@ -139,7 +139,7 @@ inline I64 ByteStreamInIstream::tell() const
   return (I64)stream.tellg();
 }
 
-inline BOOL ByteStreamInIstream::seek(const I64 position)
+inline bool ByteStreamInIstream::seek(const I64 position)
 {
   if (tell() != position)
   {
@@ -149,7 +149,7 @@ inline BOOL ByteStreamInIstream::seek(const I64 position)
   return TRUE;
 }
 
-inline BOOL ByteStreamInIstream::seekEnd(const I64 distance)
+inline bool ByteStreamInIstream::seekEnd(const I64 distance)
 {
   stream.seekg(static_cast<streamoff>(-distance), ios::end);
   return stream.good();

--- a/LASzip/src/bytestreamout.hpp
+++ b/LASzip/src/bytestreamout.hpp
@@ -40,7 +40,7 @@ class ByteStreamOut
 {
 public:
 /* write single bits                                         */
-  inline BOOL putBits(U32 bits, U32 num_bits)
+  inline bool putBits(U32 bits, U32 num_bits)
   {
     U64 new_bits = bits;
     bit_buffer |= (new_bits << num_buffer);
@@ -55,7 +55,7 @@ public:
     return TRUE;
   };
 /* called after writing bits before closing or writing bytes */
-  inline BOOL flushBits()
+  inline bool flushBits()
   {
     if (num_buffer)
     {
@@ -68,29 +68,29 @@ public:
     return TRUE;
   };
 /* write a single byte                                       */
-  virtual BOOL putByte(U8 byte) = 0;
+  virtual bool putByte(U8 byte) = 0;
 /* write an array of bytes                                   */
-  virtual BOOL putBytes(const U8* bytes, U32 num_bytes) = 0;
+  virtual bool putBytes(const U8* bytes, U32 num_bytes) = 0;
 /* write 16 bit low-endian field                             */
-  virtual BOOL put16bitsLE(const U8* bytes) = 0;
+  virtual bool put16bitsLE(const U8* bytes) = 0;
 /* write 32 bit low-endian field                             */
-  virtual BOOL put32bitsLE(const U8* bytes) = 0;
+  virtual bool put32bitsLE(const U8* bytes) = 0;
 /* write 64 bit low-endian field                             */
-  virtual BOOL put64bitsLE(const U8* bytes) = 0;
+  virtual bool put64bitsLE(const U8* bytes) = 0;
 /* write 16 bit big-endian field                             */
-  virtual BOOL put16bitsBE(const U8* bytes) = 0;
+  virtual bool put16bitsBE(const U8* bytes) = 0;
 /* write 32 bit big-endian field                             */
-  virtual BOOL put32bitsBE(const U8* bytes) = 0;
+  virtual bool put32bitsBE(const U8* bytes) = 0;
 /* write 64 bit big-endian field                             */
-  virtual BOOL put64bitsBE(const U8* bytes) = 0;
+  virtual bool put64bitsBE(const U8* bytes) = 0;
 /* is the stream seekable (e.g. standard out is not)         */
-  virtual BOOL isSeekable() const = 0;
+  virtual bool isSeekable() const = 0;
 /* get current position of stream                            */
   virtual I64 tell() const = 0;
 /* seek to this position in the stream                       */
-  virtual BOOL seek(const I64 position) = 0;
+  virtual bool seek(const I64 position) = 0;
 /* seek to the end of the file                               */
-  virtual BOOL seekEnd() = 0;
+  virtual bool seekEnd() = 0;
 /* constructor                                               */
   inline ByteStreamOut() { bit_buffer = 0; num_buffer = 0; };
 /* destructor                                                */

--- a/LASzip/src/bytestreamout_array.hpp
+++ b/LASzip/src/bytestreamout_array.hpp
@@ -40,17 +40,17 @@ class ByteStreamOutArray : public ByteStreamOut
 public:
   ByteStreamOutArray(I64 alloc=1024);
 /* write a single byte                                       */
-  BOOL putByte(U8 byte);
+  bool putByte(U8 byte);
 /* write an array of bytes                                   */
-  BOOL putBytes(const U8* bytes, U32 num_bytes);
+  bool putBytes(const U8* bytes, U32 num_bytes);
 /* is the stream seekable (e.g. standard out is not)         */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd();
+  bool seekEnd();
 /* destructor                                                */
   ~ByteStreamOutArray(){};
 /* get access to data                                        */
@@ -69,17 +69,17 @@ class ByteStreamOutArrayLE : public ByteStreamOutArray
 public:
   ByteStreamOutArrayLE(I64 alloc=1024);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -89,17 +89,17 @@ class ByteStreamOutArrayBE : public ByteStreamOutArray
 public:
   ByteStreamOutArrayBE(I64 alloc=1024);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -112,7 +112,7 @@ inline ByteStreamOutArray::ByteStreamOutArray(I64 alloc)
   this->curr = 0;
 }
 
-inline BOOL ByteStreamOutArray::putByte(U8 byte)
+inline bool ByteStreamOutArray::putByte(U8 byte)
 {
   if (curr == alloc)
   {
@@ -129,7 +129,7 @@ inline BOOL ByteStreamOutArray::putByte(U8 byte)
   return TRUE;
 }
 
-inline BOOL ByteStreamOutArray::putBytes(const U8* bytes, U32 num_bytes)
+inline bool ByteStreamOutArray::putBytes(const U8* bytes, U32 num_bytes)
 {
   if ((curr+num_bytes) > alloc)
   {
@@ -146,7 +146,7 @@ inline BOOL ByteStreamOutArray::putBytes(const U8* bytes, U32 num_bytes)
   return TRUE;
 }
 
-inline BOOL ByteStreamOutArray::isSeekable() const
+inline bool ByteStreamOutArray::isSeekable() const
 {
   return TRUE;
 }
@@ -156,7 +156,7 @@ inline I64 ByteStreamOutArray::tell() const
   return curr;
 }
 
-inline BOOL ByteStreamOutArray::seek(I64 position)
+inline bool ByteStreamOutArray::seek(I64 position)
 {
   if ((0 <= position) && (position <= size))
   {
@@ -166,7 +166,7 @@ inline BOOL ByteStreamOutArray::seek(I64 position)
   return FALSE;
 }
 
-inline BOOL ByteStreamOutArray::seekEnd()
+inline bool ByteStreamOutArray::seekEnd()
 {
   curr = size;
   return TRUE;
@@ -185,29 +185,29 @@ inline ByteStreamOutArrayLE::ByteStreamOutArrayLE(I64 alloc) : ByteStreamOutArra
 {
 }
 
-inline BOOL ByteStreamOutArrayLE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put16bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutArrayLE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put32bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutArrayLE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put64bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }
 
-inline BOOL ByteStreamOutArrayLE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put16bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutArrayLE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put32bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -216,7 +216,7 @@ inline BOOL ByteStreamOutArrayLE::put32bitsBE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutArrayLE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayLE::put64bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -233,14 +233,14 @@ inline ByteStreamOutArrayBE::ByteStreamOutArrayBE(I64 alloc) : ByteStreamOutArra
 {
 }
 
-inline BOOL ByteStreamOutArrayBE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put16bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutArrayBE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put32bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -249,7 +249,7 @@ inline BOOL ByteStreamOutArrayBE::put32bitsLE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutArrayBE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put64bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -262,17 +262,17 @@ inline BOOL ByteStreamOutArrayBE::put64bitsLE(const U8* bytes)
   return putBytes(swapped, 8);
 }
 
-inline BOOL ByteStreamOutArrayBE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put16bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutArrayBE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put32bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutArrayBE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutArrayBE::put64bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }

--- a/LASzip/src/bytestreamout_file.hpp
+++ b/LASzip/src/bytestreamout_file.hpp
@@ -47,19 +47,19 @@ class ByteStreamOutFile : public ByteStreamOut
 public:
   ByteStreamOutFile(FILE* file);
 /* replace a closed FILE* with a reopened FILE* in "ab" mode */
-  BOOL refile(FILE* file);
+  bool refile(FILE* file);
 /* write a single byte                                       */
-  BOOL putByte(U8 byte);
+  bool putByte(U8 byte);
 /* write an array of bytes                                   */
-  BOOL putBytes(const U8* bytes, U32 num_bytes);
+  bool putBytes(const U8* bytes, U32 num_bytes);
 /* is the stream seekable (e.g. standard out is not)         */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd();
+  bool seekEnd();
 /* destructor                                                */
   ~ByteStreamOutFile(){};
 protected:
@@ -71,17 +71,17 @@ class ByteStreamOutFileLE : public ByteStreamOutFile
 public:
   ByteStreamOutFileLE(FILE* file);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -91,17 +91,17 @@ class ByteStreamOutFileBE : public ByteStreamOutFile
 public:
   ByteStreamOutFileBE(FILE* file);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -111,24 +111,24 @@ inline ByteStreamOutFile::ByteStreamOutFile(FILE* file)
   this->file = file;
 }
 
-inline BOOL ByteStreamOutFile::refile(FILE* file)
+inline bool ByteStreamOutFile::refile(FILE* file)
 {
   if (file == 0) return FALSE;
   this->file = file;
   return TRUE;
 }
 
-inline BOOL ByteStreamOutFile::putByte(U8 byte)
+inline bool ByteStreamOutFile::putByte(U8 byte)
 {
   return (fputc(byte, file) == byte);
 }
 
-inline BOOL ByteStreamOutFile::putBytes(const U8* bytes, U32 num_bytes)
+inline bool ByteStreamOutFile::putBytes(const U8* bytes, U32 num_bytes)
 {
   return (fwrite(bytes, 1, num_bytes, file) == num_bytes);
 }
 
-inline BOOL ByteStreamOutFile::isSeekable() const
+inline bool ByteStreamOutFile::isSeekable() const
 {
   return (file != stdout);
 }
@@ -144,7 +144,7 @@ inline I64 ByteStreamOutFile::tell() const
 #endif
 }
 
-inline BOOL ByteStreamOutFile::seek(I64 position)
+inline bool ByteStreamOutFile::seek(I64 position)
 {
 #if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, position, SEEK_SET));
@@ -155,7 +155,7 @@ inline BOOL ByteStreamOutFile::seek(I64 position)
 #endif
 }
 
-inline BOOL ByteStreamOutFile::seekEnd()
+inline bool ByteStreamOutFile::seekEnd()
 {
 #if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, 0, SEEK_END));
@@ -170,29 +170,29 @@ inline ByteStreamOutFileLE::ByteStreamOutFileLE(FILE* file) : ByteStreamOutFile(
 {
 }
 
-inline BOOL ByteStreamOutFileLE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put16bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutFileLE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put32bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutFileLE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put64bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }
 
-inline BOOL ByteStreamOutFileLE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put16bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutFileLE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put32bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -201,7 +201,7 @@ inline BOOL ByteStreamOutFileLE::put32bitsBE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutFileLE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileLE::put64bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -218,14 +218,14 @@ inline ByteStreamOutFileBE::ByteStreamOutFileBE(FILE* file) : ByteStreamOutFile(
 {
 }
 
-inline BOOL ByteStreamOutFileBE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put16bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutFileBE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put32bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -234,7 +234,7 @@ inline BOOL ByteStreamOutFileBE::put32bitsLE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutFileBE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put64bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -247,17 +247,17 @@ inline BOOL ByteStreamOutFileBE::put64bitsLE(const U8* bytes)
   return putBytes(swapped, 8);
 }
 
-inline BOOL ByteStreamOutFileBE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put16bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutFileBE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put32bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutFileBE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutFileBE::put64bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }

--- a/LASzip/src/bytestreamout_nil.hpp
+++ b/LASzip/src/bytestreamout_nil.hpp
@@ -42,29 +42,29 @@ class ByteStreamOutNil : public ByteStreamOut
 public:
   ByteStreamOutNil();
 /* write a single byte                                       */
-  BOOL putByte(U8 byte);
+  bool putByte(U8 byte);
 /* write an array of bytes                                   */
-  BOOL putBytes(const U8* bytes, U32 num_bytes);
+  bool putBytes(const U8* bytes, U32 num_bytes);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 /* is the stream seekable (e.g. standard out is not)         */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd();
+  bool seekEnd();
 /* destructor                                                */
   ~ByteStreamOutNil(){};
 private:
@@ -76,49 +76,49 @@ inline ByteStreamOutNil::ByteStreamOutNil()
   num_bytes = 0;
 }
 
-inline BOOL ByteStreamOutNil::putByte(U8 byte)
+inline bool ByteStreamOutNil::putByte(U8 byte)
 {
   num_bytes++;
   return TRUE;
 }
 
-inline BOOL ByteStreamOutNil::putBytes(const U8* bytes, U32 num_bytes)
+inline bool ByteStreamOutNil::putBytes(const U8* bytes, U32 num_bytes)
 {
   this->num_bytes += num_bytes;
   return TRUE;
 }
 
-inline BOOL ByteStreamOutNil::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutNil::put16bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutNil::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutNil::put32bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutNil::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutNil::put64bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }
 
-inline BOOL ByteStreamOutNil::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutNil::put16bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutNil::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutNil::put32bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutNil::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutNil::put64bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }
 
-inline BOOL ByteStreamOutNil::isSeekable() const
+inline bool ByteStreamOutNil::isSeekable() const
 {
   return TRUE;
 }
@@ -128,12 +128,12 @@ inline I64 ByteStreamOutNil::tell() const
   return num_bytes;
 }
 
-inline BOOL ByteStreamOutNil::seek(I64 position)
+inline bool ByteStreamOutNil::seek(I64 position)
 {
   return TRUE;
 }
 
-inline BOOL ByteStreamOutNil::seekEnd()
+inline bool ByteStreamOutNil::seekEnd()
 {
   return TRUE;
 }

--- a/LASzip/src/bytestreamout_ostream.hpp
+++ b/LASzip/src/bytestreamout_ostream.hpp
@@ -46,17 +46,17 @@ class ByteStreamOutOstream : public ByteStreamOut
 public:
   ByteStreamOutOstream(ostream& stream);
 /* write a single byte                                       */
-  BOOL putByte(U8 byte);
+  bool putByte(U8 byte);
 /* write an array of bytes                                   */
-  BOOL putBytes(const U8* bytes, U32 num_bytes);
+  bool putBytes(const U8* bytes, U32 num_bytes);
 /* is the stream seekable (e.g. standard out is not)         */
-  BOOL isSeekable() const;
+  bool isSeekable() const;
 /* get current position of stream                            */
   I64 tell() const;
 /* seek to this position in the stream                       */
-  BOOL seek(const I64 position);
+  bool seek(const I64 position);
 /* seek to the end of the file                               */
-  BOOL seekEnd();
+  bool seekEnd();
 /* destructor                                                */
   ~ByteStreamOutOstream(){};
 protected:
@@ -68,17 +68,17 @@ class ByteStreamOutOstreamLE : public ByteStreamOutOstream
 public:
   ByteStreamOutOstreamLE(ostream& stream);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -88,17 +88,17 @@ class ByteStreamOutOstreamBE : public ByteStreamOutOstream
 public:
   ByteStreamOutOstreamBE(ostream& stream);
 /* write 16 bit low-endian field                             */
-  BOOL put16bitsLE(const U8* bytes);
+  bool put16bitsLE(const U8* bytes);
 /* write 32 bit low-endian field                             */
-  BOOL put32bitsLE(const U8* bytes);
+  bool put32bitsLE(const U8* bytes);
 /* write 64 bit low-endian field                             */
-  BOOL put64bitsLE(const U8* bytes);
+  bool put64bitsLE(const U8* bytes);
 /* write 16 bit big-endian field                             */
-  BOOL put16bitsBE(const U8* bytes);
+  bool put16bitsBE(const U8* bytes);
 /* write 32 bit big-endian field                             */
-  BOOL put32bitsBE(const U8* bytes);
+  bool put32bitsBE(const U8* bytes);
 /* write 64 bit big-endian field                             */
-  BOOL put64bitsBE(const U8* bytes);
+  bool put64bitsBE(const U8* bytes);
 private:
   U8 swapped[8];
 };
@@ -108,19 +108,19 @@ inline ByteStreamOutOstream::ByteStreamOutOstream(ostream& stream_param) :
 {
 }
 
-inline BOOL ByteStreamOutOstream::putByte(U8 byte)
+inline bool ByteStreamOutOstream::putByte(U8 byte)
 {
   stream.put(byte);
   return stream.good();
 }
 
-inline BOOL ByteStreamOutOstream::putBytes(const U8* bytes, U32 num_bytes)
+inline bool ByteStreamOutOstream::putBytes(const U8* bytes, U32 num_bytes)
 {
   stream.write((const char*)bytes, num_bytes);
   return stream.good();
 }
 
-inline BOOL ByteStreamOutOstream::isSeekable() const
+inline bool ByteStreamOutOstream::isSeekable() const
 {
   return !!(static_cast<ofstream&>(stream));
 }
@@ -130,13 +130,13 @@ inline I64 ByteStreamOutOstream::tell() const
   return (I64)stream.tellp();
 }
 
-inline BOOL ByteStreamOutOstream::seek(I64 position)
+inline bool ByteStreamOutOstream::seek(I64 position)
 {
   stream.seekp(static_cast<streamoff>(position));
   return stream.good();
 }
 
-inline BOOL ByteStreamOutOstream::seekEnd()
+inline bool ByteStreamOutOstream::seekEnd()
 {
   stream.seekp(0, ios::end);
   return stream.good();
@@ -146,29 +146,29 @@ inline ByteStreamOutOstreamLE::ByteStreamOutOstreamLE(ostream& stream) : ByteStr
 {
 }
 
-inline BOOL ByteStreamOutOstreamLE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put16bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutOstreamLE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put32bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutOstreamLE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put64bitsLE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }
 
-inline BOOL ByteStreamOutOstreamLE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put16bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutOstreamLE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put32bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -177,7 +177,7 @@ inline BOOL ByteStreamOutOstreamLE::put32bitsBE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutOstreamLE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamLE::put64bitsBE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -194,14 +194,14 @@ inline ByteStreamOutOstreamBE::ByteStreamOutOstreamBE(ostream& stream) : ByteStr
 {
 }
 
-inline BOOL ByteStreamOutOstreamBE::put16bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put16bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[1];
   swapped[1] = bytes[0];
   return putBytes(swapped, 2);
 }
 
-inline BOOL ByteStreamOutOstreamBE::put32bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put32bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[3];
   swapped[1] = bytes[2];
@@ -210,7 +210,7 @@ inline BOOL ByteStreamOutOstreamBE::put32bitsLE(const U8* bytes)
   return putBytes(swapped, 4);
 }
 
-inline BOOL ByteStreamOutOstreamBE::put64bitsLE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put64bitsLE(const U8* bytes)
 {
   swapped[0] = bytes[7];
   swapped[1] = bytes[6];
@@ -223,17 +223,17 @@ inline BOOL ByteStreamOutOstreamBE::put64bitsLE(const U8* bytes)
   return putBytes(swapped, 8);
 }
 
-inline BOOL ByteStreamOutOstreamBE::put16bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put16bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 2);
 }
 
-inline BOOL ByteStreamOutOstreamBE::put32bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put32bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 4);
 }
 
-inline BOOL ByteStreamOutOstreamBE::put64bitsBE(const U8* bytes)
+inline bool ByteStreamOutOstreamBE::put64bitsBE(const U8* bytes)
 {
   return putBytes(bytes, 8);
 }

--- a/LASzip/src/lasattributer.hpp
+++ b/LASzip/src/lasattributer.hpp
@@ -80,51 +80,51 @@ public:
     if (description) strncpy(this->description, description, 32);
   };
 
-  inline BOOL set_no_data(U8 no_data, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(I8 no_data, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(U16 no_data, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(I16 no_data, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(U32 no_data, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(I32 no_data, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(U64 no_data, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(I64 no_data, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(F32 no_data, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->no_data[dim].f64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
-  inline BOOL set_no_data(F64 no_data, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->no_data[dim].f64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(U8 no_data, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(I8 no_data, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(U16 no_data, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(I16 no_data, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(U32 no_data, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(I32 no_data, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(U64 no_data, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->no_data[dim].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(I64 no_data, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->no_data[dim].i64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(F32 no_data, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->no_data[dim].f64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
+  inline bool set_no_data(F64 no_data, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->no_data[dim].f64 = no_data; options |= 0x01; return TRUE; } return FALSE; };
 
   inline void set_min(U8* min, I32 dim=0) { this->min[dim] = cast(min); options |= 0x02; };
   inline void update_min(U8* min, I32 dim=0) { this->min[dim] = smallest(cast(min), this->min[dim]); };
-  inline BOOL set_min(U8 min, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(I8 min, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(U16 min, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(I16 min, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(U32 min, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(I32 min, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(U64 min, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(I64 min, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(F32 min, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->min[dim].f64 = min; options |= 0x02; return TRUE; } return FALSE; };
-  inline BOOL set_min(F64 min, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->min[dim].f64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(U8 min, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(I8 min, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(U16 min, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(I16 min, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(U32 min, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(I32 min, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(U64 min, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->min[dim].u64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(I64 min, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->min[dim].i64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(F32 min, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->min[dim].f64 = min; options |= 0x02; return TRUE; } return FALSE; };
+  inline bool set_min(F64 min, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->min[dim].f64 = min; options |= 0x02; return TRUE; } return FALSE; };
 
   inline void set_max(U8* max, I32 dim=0) { this->max[dim] = cast(max); options |= 0x04; };
   inline void update_max(U8* max, I32 dim=0) { this->max[dim] = biggest(cast(max), this->max[dim]); };
-  inline BOOL set_max(U8 max, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(I8 max, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(U16 max, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(I16 max, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(U32 max, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(I32 max, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(U64 max, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(I64 max, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(F32 max, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->max[dim].f64 = max; options |= 0x04; return TRUE; } return FALSE; };
-  inline BOOL set_max(F64 max, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->max[dim].f64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(U8 max, I32 dim=0) { if ((0 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(I8 max, I32 dim=0) { if ((1 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(U16 max, I32 dim=0) { if ((2 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(I16 max, I32 dim=0) { if ((3 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(U32 max, I32 dim=0) { if ((4 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(I32 max, I32 dim=0) { if ((5 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(U64 max, I32 dim=0) { if ((6 == get_type()) && (dim < get_dim())) { this->max[dim].u64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(I64 max, I32 dim=0) { if ((7 == get_type()) && (dim < get_dim())) { this->max[dim].i64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(F32 max, I32 dim=0) { if ((8 == get_type()) && (dim < get_dim())) { this->max[dim].f64 = max; options |= 0x04; return TRUE; } return FALSE; };
+  inline bool set_max(F64 max, I32 dim=0) { if ((9 == get_type()) && (dim < get_dim())) { this->max[dim].f64 = max; options |= 0x04; return TRUE; } return FALSE; };
 
-  inline BOOL set_scale(F64 scale, I32 dim=0) { if (data_type) { this->scale[dim] = scale; options |= 0x08; return TRUE; } return FALSE; };
-  inline BOOL set_offset(F64 offset, I32 dim=0) { if (data_type) { this->offset[dim] = offset; options |= 0x10; return TRUE; } return FALSE; };
+  inline bool set_scale(F64 scale, I32 dim=0) { if (data_type) { this->scale[dim] = scale; options |= 0x08; return TRUE; } return FALSE; };
+  inline bool set_offset(F64 offset, I32 dim=0) { if (data_type) { this->offset[dim] = offset; options |= 0x10; return TRUE; } return FALSE; };
 
-  inline BOOL has_no_data() const { return options & 0x01; };
-  inline BOOL has_min() const { return options & 0x02; };
-  inline BOOL has_max() const { return options & 0x04; };
-  inline BOOL has_scale() const { return options & 0x08; };
-  inline BOOL has_offset() const { return options & 0x10; };
+  inline bool has_no_data() const { return options & 0x01; };
+  inline bool has_min() const { return options & 0x02; };
+  inline bool has_max() const { return options & 0x04; };
+  inline bool has_scale() const { return options & 0x08; };
+  inline bool has_offset() const { return options & 0x10; };
 
   inline U32 get_size() const
   {
@@ -269,7 +269,7 @@ public:
     }
   };
 
-  BOOL init_attributes(U32 number_attributes, LASattribute* attributes)
+  bool init_attributes(U32 number_attributes, LASattribute* attributes)
   {
     U32 i;
     clean_attributes();
@@ -402,7 +402,7 @@ public:
     return -1;
   }
 
-  BOOL remove_attribute(I32 index)
+  bool remove_attribute(I32 index)
   {
     if (index < 0 || index >= number_attributes)
     {
@@ -437,7 +437,7 @@ public:
     return TRUE;
   }
 
-  BOOL remove_attribute(const CHAR* name)
+  bool remove_attribute(const CHAR* name)
   {
     I32 index = get_attribute_index(name);
     if (index != -1)

--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -87,13 +87,13 @@ void LASindex::prepare(LASquadtree* spatial, I32 threshold)
   this->interval = new LASinterval(threshold);
 }
 
-BOOL LASindex::add(const F64 x, const F64 y, const U32 p_index)
+bool LASindex::add(const F64 x, const F64 y, const U32 p_index)
 {
   I32 cell = spatial->get_cell_index(x, y);
   return interval->add(p_index, cell);
 }
 
-void LASindex::complete(U32 minimum_points, I32 maximum_intervals, const BOOL verbose)
+void LASindex::complete(U32 minimum_points, I32 maximum_intervals, const bool verbose)
 {
   if (verbose)
   {
@@ -115,7 +115,7 @@ void LASindex::complete(U32 minimum_points, I32 maximum_intervals, const BOOL ve
       I32 hash2 = (hash1+1)%2;
       cell_hash[hash2].clear();
       // coarsen if a coarser cell will still have fewer than minimum_points (and points in all subcells)
-      BOOL coarsened = FALSE;
+      bool coarsened = FALSE;
       U32 i, full;
       I32 coarser_index;
       U32 num_indices;
@@ -188,7 +188,7 @@ void LASindex::complete(U32 minimum_points, I32 maximum_intervals, const BOOL ve
   }
 }
 
-void LASindex::print(BOOL verbose)
+void LASindex::print(bool verbose)
 {
   U32 total_cells = 0;
   U32 total_full = 0;
@@ -229,7 +229,7 @@ LASinterval* LASindex::get_interval() const
   return interval;
 }
 
-BOOL LASindex::intersect_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y)
+bool LASindex::intersect_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y)
 {
   have_interval = FALSE;
   cells = spatial->intersect_rectangle(r_min_x, r_min_y, r_max_x, r_max_y);
@@ -239,7 +239,7 @@ BOOL LASindex::intersect_rectangle(const F64 r_min_x, const F64 r_min_y, const F
   return FALSE;
 }
 
-BOOL LASindex::intersect_tile(const F32 ll_x, const F32 ll_y, const F32 size)
+bool LASindex::intersect_tile(const F32 ll_x, const F32 ll_y, const F32 size)
 {
   have_interval = FALSE;
   cells = spatial->intersect_tile(ll_x, ll_y, size);
@@ -249,7 +249,7 @@ BOOL LASindex::intersect_tile(const F32 ll_x, const F32 ll_y, const F32 size)
   return FALSE;
 }
 
-BOOL LASindex::intersect_circle(const F64 center_x, const F64 center_y, const F64 radius)
+bool LASindex::intersect_circle(const F64 center_x, const F64 center_y, const F64 radius)
 {
   have_interval = FALSE;
   cells = spatial->intersect_circle(center_x, center_y, radius);
@@ -259,13 +259,13 @@ BOOL LASindex::intersect_circle(const F64 center_x, const F64 center_y, const F6
   return FALSE;
 }
 
-BOOL LASindex::get_intervals()
+bool LASindex::get_intervals()
 {
   have_interval = FALSE;
   return interval->get_merged_cell();
 }
 
-BOOL LASindex::has_intervals()
+bool LASindex::has_intervals()
 {
   if (interval->has_intervals())
   {
@@ -279,7 +279,7 @@ BOOL LASindex::has_intervals()
   return FALSE;
 }
 
-BOOL LASindex::read(const char* file_name)
+bool LASindex::read(const char* file_name)
 {
   if (file_name == 0) return FALSE;
   char* name = strdup(file_name);
@@ -320,7 +320,7 @@ BOOL LASindex::read(const char* file_name)
   return TRUE;
 }
 
-BOOL LASindex::append(const char* file_name) const
+bool LASindex::append(const char* file_name) const
 {
 #ifdef LASZIPDLL_EXPORTS
   return FALSE;
@@ -459,7 +459,7 @@ BOOL LASindex::append(const char* file_name) const
 #endif
 }
 
-BOOL LASindex::write(const char* file_name) const
+bool LASindex::write(const char* file_name) const
 {
   if (file_name == 0) return FALSE;
   char* name = strdup(file_name);
@@ -503,7 +503,7 @@ BOOL LASindex::write(const char* file_name) const
   return TRUE;
 }
 
-BOOL LASindex::read(ByteStreamIn* stream)
+bool LASindex::read(ByteStreamIn* stream)
 {
   if (spatial)
   {
@@ -555,7 +555,7 @@ BOOL LASindex::read(ByteStreamIn* stream)
   return TRUE;
 }
 
-BOOL LASindex::write(ByteStreamOut* stream) const
+bool LASindex::write(ByteStreamOut* stream) const
 {
   if (!stream->putBytes((U8*)"LASX", 4))
   {
@@ -586,7 +586,7 @@ BOOL LASindex::write(ByteStreamOut* stream) const
 // seek to next interval point
 
 #ifdef LASZIPDLL_EXPORTS
-BOOL LASindex::seek_next(LASreadPoint* reader, I64 &p_count)
+bool LASindex::seek_next(LASreadPoint* reader, I64 &p_count)
 {
   if (!have_interval)
   {
@@ -601,7 +601,7 @@ BOOL LASindex::seek_next(LASreadPoint* reader, I64 &p_count)
   return TRUE;
 }
 #else
-BOOL LASindex::seek_next(LASreader* lasreader)
+bool LASindex::seek_next(LASreader* lasreader)
 {
   if (!have_interval)
   {
@@ -617,7 +617,7 @@ BOOL LASindex::seek_next(LASreader* lasreader)
 #endif
 
 // merge the intervals of non-empty cells
-BOOL LASindex::merge_intervals()
+bool LASindex::merge_intervals()
 {
   if (spatial->get_intersected_cells())
   {
@@ -633,7 +633,7 @@ BOOL LASindex::merge_intervals()
 //    fprintf(stderr,"LASindex: used %d cells of total %d\n", used_cells, interval->get_number_cells());
     if (used_cells)
     {
-      BOOL r = interval->merge();
+      bool r = interval->merge();
       full = interval->full;
       total = interval->total;
       interval->clear_merge_cell_set();

--- a/LASzip/src/lasindex.hpp
+++ b/LASzip/src/lasindex.hpp
@@ -57,24 +57,24 @@ public:
 
   // create spatial index
   void prepare(LASquadtree* spatial, I32 threshold=1000);
-  BOOL add(const F64 x, const F64 y, const U32 index);
-  void complete(U32 minimum_points=100000, I32 maximum_intervals=-1, const BOOL verbose=TRUE);
+  bool add(const F64 x, const F64 y, const U32 index);
+  void complete(U32 minimum_points=100000, I32 maximum_intervals=-1, const bool verbose=TRUE);
 
   // read from file or write to file
-  BOOL read(const char* file_name);
-  BOOL append(const char* file_name) const;
-  BOOL write(const char* file_name) const;
-  BOOL read(ByteStreamIn* stream);
-  BOOL write(ByteStreamOut* stream) const;
+  bool read(const char* file_name);
+  bool append(const char* file_name) const;
+  bool write(const char* file_name) const;
+  bool read(ByteStreamIn* stream);
+  bool write(ByteStreamOut* stream) const;
 
   // intersect
-  BOOL intersect_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y);
-  BOOL intersect_tile(const F32 ll_x, const F32 ll_y, const F32 size);
-  BOOL intersect_circle(const F64 center_x, const F64 center_y, const F64 radius);
+  bool intersect_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y);
+  bool intersect_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+  bool intersect_circle(const F64 center_x, const F64 center_y, const F64 radius);
 
   // access the intersected intervals
-  BOOL get_intervals();
-  BOOL has_intervals();
+  bool get_intervals();
+  bool has_intervals();
 
   U32 start;
   U32 end;
@@ -84,24 +84,24 @@ public:
 
   // seek to next interval
 #ifdef LASZIPDLL_EXPORTS
-  BOOL seek_next(LASreadPoint* reader, I64 &p_count);
+  bool seek_next(LASreadPoint* reader, I64 &p_count);
 #else
-  BOOL seek_next(LASreader* lasreader);
+  bool seek_next(LASreader* lasreader);
 #endif
 
   // for debugging
-  void print(BOOL verbose);
+  void print(bool verbose);
 
   // for visualization
   LASquadtree* get_spatial() const;
   LASinterval* get_interval() const;
 
 private:
-  BOOL merge_intervals();
+  bool merge_intervals();
 
   LASquadtree* spatial;
   LASinterval* interval;
-  BOOL have_interval;
+  bool have_interval;
 };
 
 #endif

--- a/LASzip/src/lasinterval.cpp
+++ b/LASzip/src/lasinterval.cpp
@@ -95,7 +95,7 @@ LASintervalStartCell::LASintervalStartCell(const U32 p_index) : LASintervalCell(
   last = 0;
 }
 
-BOOL LASintervalStartCell::add(const U32 p_index, const U32 threshold)
+bool LASintervalStartCell::add(const U32 p_index, const U32 threshold)
 {
   U32 current_end = (last ? last->end : end);
   assert(p_index > current_end);
@@ -128,7 +128,7 @@ BOOL LASintervalStartCell::add(const U32 p_index, const U32 threshold)
   return FALSE; // added to interval
 }
 
-BOOL LASinterval::add(const U32 p_index, const I32 c_index)
+bool LASinterval::add(const U32 p_index, const I32 c_index)
 {
   if (last_cell == 0 || last_index != c_index)
   {
@@ -164,7 +164,7 @@ U32 LASinterval::get_number_intervals() const
 }
 
 // merge cells (and their intervals) into one cell
-BOOL LASinterval::merge_cells(const U32 num_indices, const I32* indices, const I32 new_index)
+bool LASinterval::merge_cells(const U32 num_indices, const I32* indices, const I32 new_index)
 {
   U32 i;
   if (num_indices == 1)
@@ -192,7 +192,7 @@ BOOL LASinterval::merge_cells(const U32 num_indices, const I32* indices, const I
 }
 
 // merge adjacent intervals with small gaps in cells to reduce total interval number to maximum
-void LASinterval::merge_intervals(U32 maximum_intervals, const BOOL verbose)
+void LASinterval::merge_intervals(U32 maximum_intervals, const bool verbose)
 {
   U32 diff;
   LASintervalCell* cell;
@@ -303,7 +303,7 @@ void LASinterval::get_cells()
   current_cell = 0;
 }
 
-BOOL LASinterval::has_cells()
+bool LASinterval::has_cells()
 {
   my_cell_hash::iterator hash_element;
   if (last_index == I32_MIN)
@@ -329,7 +329,7 @@ BOOL LASinterval::has_cells()
   return TRUE;
 }
 
-BOOL LASinterval::get_cell(const I32 c_index)
+bool LASinterval::get_cell(const I32 c_index)
 {
   my_cell_hash::iterator hash_element = ((my_cell_hash*)cells)->find(c_index);
   if (hash_element == ((my_cell_hash*)cells)->end())
@@ -344,7 +344,7 @@ BOOL LASinterval::get_cell(const I32 c_index)
   return TRUE;
 }
 
-BOOL LASinterval::add_current_cell_to_merge_cell_set()
+bool LASinterval::add_current_cell_to_merge_cell_set()
 {
   if (current_cell == 0)
   {
@@ -358,7 +358,7 @@ BOOL LASinterval::add_current_cell_to_merge_cell_set()
   return TRUE;
 }
 
-BOOL LASinterval::add_cell_to_merge_cell_set(const I32 c_index, const BOOL erase)
+bool LASinterval::add_cell_to_merge_cell_set(const I32 c_index, const bool erase)
 {
   my_cell_hash::iterator hash_element = ((my_cell_hash*)cells)->find(c_index);
   if (hash_element == ((my_cell_hash*)cells)->end())
@@ -374,7 +374,7 @@ BOOL LASinterval::add_cell_to_merge_cell_set(const I32 c_index, const BOOL erase
   return TRUE;
 }
 
-BOOL LASinterval::merge(const BOOL erase)
+bool LASinterval::merge(const bool erase)
 {
   // maybe delete temporary merge cells from the previous merge
   if (merged_cells)
@@ -474,7 +474,7 @@ void LASinterval::clear_merge_cell_set()
   }
 }
 
-BOOL LASinterval::get_merged_cell()
+bool LASinterval::get_merged_cell()
 {
   if (merged_cells)
   {
@@ -486,7 +486,7 @@ BOOL LASinterval::get_merged_cell()
   return FALSE;
 }
 
-BOOL LASinterval::has_intervals()
+bool LASinterval::has_intervals()
 {
   if (current_cell)
   {
@@ -549,7 +549,7 @@ LASinterval::~LASinterval()
   if (cells_to_merge) delete ((my_cell_set*)cells_to_merge);
 }
 
-BOOL LASinterval::read(ByteStreamIn* stream)
+bool LASinterval::read(ByteStreamIn* stream)
 {
   char signature[4];
   try { stream->getBytes((U8*)signature, 4); } catch (...)
@@ -633,7 +633,7 @@ BOOL LASinterval::read(ByteStreamIn* stream)
   return TRUE;
 }
 
-BOOL LASinterval::write(ByteStreamOut* stream) const
+bool LASinterval::write(ByteStreamOut* stream) const
 {
   if (!stream->putBytes((U8*)"LASV", 4))
   {

--- a/LASzip/src/lasinterval.hpp
+++ b/LASzip/src/lasinterval.hpp
@@ -56,7 +56,7 @@ public:
   LASintervalCell* last;
   LASintervalStartCell();
   LASintervalStartCell(const U32 p_index);
-  BOOL add(const U32 p_index, const U32 threshold=1000);
+  bool add(const U32 p_index, const U32 threshold=1000);
 };
 
 class LASinterval
@@ -66,7 +66,7 @@ public:
   ~LASinterval();
 
   // add points and create cells with intervals
-  BOOL add(const U32 p_index, const I32 c_index);
+  bool add(const U32 p_index, const I32 c_index);
 
   // get total number of cells
   U32 get_number_cells() const;
@@ -75,31 +75,31 @@ public:
   U32 get_number_intervals() const;
 
   // merge cells (and their intervals) into one cell
-  BOOL merge_cells(const U32 num_indices, const I32* indices, const I32 new_index);
+  bool merge_cells(const U32 num_indices, const I32* indices, const I32 new_index);
 
   // merge adjacent intervals with small gaps in cells to reduce total interval number to maximum
-  void merge_intervals(U32 maximum, const BOOL verbose=TRUE);
+  void merge_intervals(U32 maximum, const bool verbose=TRUE);
 
   // read from file or write to file
-  BOOL read(ByteStreamIn* stream);
-  BOOL write(ByteStreamOut* stream) const;
+  bool read(ByteStreamIn* stream);
+  bool write(ByteStreamOut* stream) const;
 
   // get one cell after the other
   void get_cells();
-  BOOL has_cells();
+  bool has_cells();
 
   // get a particular cell
-  BOOL get_cell(const I32 c_index);
+  bool get_cell(const I32 c_index);
 
   // add cell's intervals to those that will be merged 
-  BOOL add_current_cell_to_merge_cell_set();
-  BOOL add_cell_to_merge_cell_set(const I32 c_index, const BOOL erase=FALSE);
-  BOOL merge(const BOOL erase=FALSE);
+  bool add_current_cell_to_merge_cell_set();
+  bool add_cell_to_merge_cell_set(const I32 c_index, const bool erase=FALSE);
+  bool merge(const bool erase=FALSE);
   void clear_merge_cell_set();
-  BOOL get_merged_cell();
+  bool get_merged_cell();
 
   // iterate intervals of current cell (or over merged intervals)
-  BOOL has_intervals();
+  bool has_intervals();
 
   I32 index;
   U32 start;
@@ -116,7 +116,7 @@ private:
   LASintervalStartCell* last_cell;
   LASintervalCell* current_cell;
   LASintervalStartCell* merged_cells;
-  BOOL merged_cells_temporary;
+  bool merged_cells_temporary;
 };
 
 #endif

--- a/LASzip/src/laspoint.hpp
+++ b/LASzip/src/laspoint.hpp
@@ -117,10 +117,10 @@ public:
 
 // these fields describe the point format LAS specific
 
-  BOOL have_gps_time;
-  BOOL have_rgb;
-  BOOL have_nir;
-  BOOL have_wavepacket;
+  bool have_gps_time;
+  bool have_rgb;
+  bool have_nir;
+  bool have_wavepacket;
   I32 extra_bytes_number;
   U32 total_point_size;
 
@@ -223,7 +223,7 @@ public:
 
 // these functions set the desired point format (and maybe add on attributes in extra bytes)
 
-  BOOL init(const LASquantizer* quantizer, const U8 point_type, const U16 point_size, const LASattributer* attributer=0)
+  bool init(const LASquantizer* quantizer, const U8 point_type, const U16 point_size, const LASattributer* attributer=0)
   {
     // clean the point
 
@@ -281,7 +281,7 @@ public:
     return TRUE;
   };
 
-  BOOL init(const LASquantizer* quantizer, const U32 num_items, const LASitem* items, const LASattributer* attributer=0)
+  bool init(const LASquantizer* quantizer, const U32 num_items, const LASitem* items, const LASattributer* attributer=0)
   {
     U32 i;
 
@@ -337,7 +337,7 @@ public:
     return TRUE;
   };
 
-  BOOL inside_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y) const
+  bool inside_rectangle(const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y) const
   {
     F64 xy;
     xy = get_x();
@@ -347,7 +347,7 @@ public:
     return TRUE;
   }
 
-  BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 ur_x, const F32 ur_y) const
+  bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 ur_x, const F32 ur_y) const
   {
     F64 xy;
     xy = get_x();
@@ -357,14 +357,14 @@ public:
     return TRUE;
   }
 
-  BOOL inside_circle(const F64 center_x, const F64 center_y, F64 squared_radius) const
+  bool inside_circle(const F64 center_x, const F64 center_y, F64 squared_radius) const
   {
     F64 dx = center_x - get_x();
     F64 dy = center_y - get_y();
     return ((dx*dx+dy*dy) < squared_radius);
   }
 
-  BOOL inside_box(const F64 min_x, const F64 min_y, const F64 min_z, const F64 max_x, const F64 max_y, const F64 max_z) const
+  bool inside_box(const F64 min_x, const F64 min_y, const F64 min_z, const F64 max_x, const F64 max_y, const F64 max_z) const
   {
     F64 xyz;
     xyz = get_x();
@@ -376,7 +376,7 @@ public:
     return TRUE;
   }
 
-  BOOL inside_bounding_box(const F64 min_x, const F64 min_y, const F64 min_z, const F64 max_x, const F64 max_y, const F64 max_z) const
+  bool inside_bounding_box(const F64 min_x, const F64 min_y, const F64 min_z, const F64 max_x, const F64 max_y, const F64 max_z) const
   {
     F64 xyz;
     xyz = get_x();
@@ -388,7 +388,7 @@ public:
     return TRUE;
   }
 
-  BOOL is_zero() const
+  bool is_zero() const
   {
     if (((U32*)&(this->X))[0] || ((U32*)&(this->X))[1] || ((U32*)&(this->X))[2] || ((U32*)&(this->X))[3] || ((U32*)&(this->X))[4])
     {
@@ -489,13 +489,13 @@ public:
     clean();
   };
 
-  inline BOOL is_first() const { return get_return_number() <= 1; };
-  inline BOOL is_intermediate() const { return (!is_first() && !is_last()); };
-  inline BOOL is_last() const { return get_return_number() >= get_number_of_returns(); };
-  inline BOOL is_single() const { return get_number_of_returns() <= 1; };
+  inline bool is_first() const { return get_return_number() <= 1; };
+  inline bool is_intermediate() const { return (!is_first() && !is_last()); };
+  inline bool is_last() const { return get_return_number() >= get_number_of_returns(); };
+  inline bool is_single() const { return get_number_of_returns() <= 1; };
 
-  inline BOOL is_first_of_many() const { return !is_single() && is_first(); };
-  inline BOOL is_last_of_many() const { return !is_single() && is_last(); };
+  inline bool is_first_of_many() const { return !is_single() && is_first(); };
+  inline bool is_last_of_many() const { return !is_single() && is_last(); };
 
   inline I32 get_X() const { return X; };
   inline I32 get_Y() const { return Y; };
@@ -592,7 +592,7 @@ public:
 
   // generic functions for attributes in extra bytes
 
-  inline BOOL has_attribute(I32 index) const
+  inline bool has_attribute(I32 index) const
   {
     if (attributer)
     {
@@ -604,7 +604,7 @@ public:
     return FALSE;
   };
 
-  inline BOOL get_attribute(I32 index, U8* data) const
+  inline bool get_attribute(I32 index, U8* data) const
   {
     if (has_attribute(index))
     {
@@ -614,7 +614,7 @@ public:
     return FALSE;
   };
 
-  inline BOOL set_attribute(I32 index, const U8* data) 
+  inline bool set_attribute(I32 index, const U8* data) 
   {
     if (has_attribute(index))
     {

--- a/LASzip/src/lasquadtree.cpp
+++ b/LASzip/src/lasquadtree.cpp
@@ -405,7 +405,7 @@ U32 LASquadtree::get_cell_index(const F64 x, const F64 y) const
 }
 
 // returns the indices of parent and siblings for the specified cell index
-BOOL LASquadtree::coarsen(const I32 cell_index, I32* coarser_cell_index, U32* num_cell_indices, I32** cell_indices) const
+bool LASquadtree::coarsen(const I32 cell_index, I32* coarser_cell_index, U32* num_cell_indices, I32** cell_indices) const
 {
   if (cell_index < 0) return FALSE;
   U32 level = get_level((U32)cell_index);
@@ -497,7 +497,7 @@ U32 LASquadtree::get_max_cell_index() const
 }
 
 // recursively does the actual rastering of the occupancy
-void LASquadtree::raster_occupancy(BOOL(*does_cell_exist)(I32), U32* data, U32 min_x, U32 min_y, U32 level_index, U32 level, U32 stop_level) const
+void LASquadtree::raster_occupancy(bool(*does_cell_exist)(I32), U32* data, U32 min_x, U32 min_y, U32 level_index, U32 level, U32 stop_level) const
 {
   U32 cell_index = get_cell_index(level_index, level);
   U32 adaptive_pos = cell_index/32;
@@ -554,7 +554,7 @@ void LASquadtree::raster_occupancy(BOOL(*does_cell_exist)(I32), U32* data, U32 m
 }
 
 // rasters the occupancy to a simple binary raster at depth level
-U32* LASquadtree::raster_occupancy(BOOL(*does_cell_exist)(I32), U32 level) const
+U32* LASquadtree::raster_occupancy(bool(*does_cell_exist)(I32), U32 level) const
 {
   U32 size_xy = (1<<level);
   U32 temp_size = (size_xy*size_xy)/32 + ((size_xy*size_xy) % 32 ? 1 : 0);
@@ -568,13 +568,13 @@ U32* LASquadtree::raster_occupancy(BOOL(*does_cell_exist)(I32), U32 level) const
 }
 
 // rasters the occupancy to a simple binary raster at depth levels
-U32* LASquadtree::raster_occupancy(BOOL(*does_cell_exist)(I32)) const
+U32* LASquadtree::raster_occupancy(bool(*does_cell_exist)(I32)) const
 {
   return raster_occupancy(does_cell_exist, levels);
 }
 
 // read from file
-BOOL LASquadtree::read(ByteStreamIn* stream)
+bool LASquadtree::read(ByteStreamIn* stream)
 {
   // read data in the following order
   //     U32  levels          4 bytes 
@@ -668,7 +668,7 @@ BOOL LASquadtree::read(ByteStreamIn* stream)
   return TRUE;
 }
 
-BOOL LASquadtree::write(ByteStreamOut* stream) const
+bool LASquadtree::write(ByteStreamOut* stream) const
 {
   // which totals 28 bytes
   //     U32  levels          4 bytes 
@@ -747,7 +747,7 @@ BOOL LASquadtree::write(ByteStreamOut* stream) const
 }
 
 // create or finalize the cell (in the spatial hierarchy) 
-BOOL LASquadtree::manage_cell(const U32 cell_index, const BOOL finalize)
+bool LASquadtree::manage_cell(const U32 cell_index, const bool finalize)
 {
   U32 adaptive_pos = cell_index/32;
   U32 adaptive_bit = ((U32)1) << (cell_index%32);
@@ -784,7 +784,7 @@ BOOL LASquadtree::manage_cell(const U32 cell_index, const BOOL finalize)
 }
 
 // check whether the x & y coordinates fall into the tiling
-BOOL LASquadtree::inside(const F64 x, const F64 y) const
+bool LASquadtree::inside(const F64 x, const F64 y) const
 {
   return ((min_x <= x) && (x < max_x) && (min_y <= y) && (y < max_y));
 }
@@ -1409,7 +1409,7 @@ void LASquadtree::intersect_circle_with_cells_adaptive(const F64 center_x, const
   }
 }
 
-BOOL LASquadtree::intersect_circle_with_rectangle(const F64 center_x, const F64 center_y, const F64 radius, const F32 r_min_x, const F32 r_max_x, const F32 r_min_y, const F32 r_max_y)
+bool LASquadtree::intersect_circle_with_rectangle(const F64 center_x, const F64 center_y, const F64 radius, const F32 r_min_x, const F32 r_max_x, const F32 r_min_y, const F32 r_max_y)
 {
   F64 r_diff_x, r_diff_y;
   F64 radius_squared = radius * radius;
@@ -1468,13 +1468,13 @@ BOOL LASquadtree::intersect_circle_with_rectangle(const F64 center_x, const F64 
   }
 }
 
-BOOL LASquadtree::get_all_cells()
+bool LASquadtree::get_all_cells()
 {
   intersect_rectangle(min_x, min_y, max_x, max_y);
   return get_intersected_cells();
 }
 
-BOOL LASquadtree::get_intersected_cells()
+bool LASquadtree::get_intersected_cells()
 {
   next_cell_index = 0;
   if (current_cells == 0)
@@ -1488,7 +1488,7 @@ BOOL LASquadtree::get_intersected_cells()
   return TRUE;
 }
 
-BOOL LASquadtree::has_more_cells()
+bool LASquadtree::has_more_cells()
 {
   if (current_cells == 0)
   {
@@ -1510,7 +1510,7 @@ BOOL LASquadtree::has_more_cells()
   return TRUE;
 }
 
-BOOL LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size)
+bool LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size)
 {
   this->cell_size = cell_size;
   this->sub_level = 0;
@@ -1561,7 +1561,7 @@ BOOL LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, 
   return TRUE;
 }
 
-BOOL LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size, F32 offset_x, F32 offset_y)
+bool LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size, F32 offset_x, F32 offset_y)
 {
   this->cell_size = cell_size;
   this->sub_level = 0;
@@ -1612,7 +1612,7 @@ BOOL LASquadtree::setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, 
   return TRUE;
 }
 
-BOOL LASquadtree::tiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 levels)
+bool LASquadtree::tiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 levels)
 {
   this->min_x = min_x;
   this->max_x = max_x;
@@ -1624,7 +1624,7 @@ BOOL LASquadtree::tiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 l
   return TRUE;
 }
 
-BOOL LASquadtree::subtiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 sub_level, U32 sub_level_index, U32 levels)
+bool LASquadtree::subtiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 sub_level, U32 sub_level_index, U32 levels)
 {
   this->min_x = min_x;
   this->max_x = max_x;

--- a/LASzip/src/lasquadtree.hpp
+++ b/LASzip/src/lasquadtree.hpp
@@ -49,18 +49,18 @@ public:
   ~LASquadtree();
 
   // read from file or write to file
-  BOOL read(ByteStreamIn* stream);
-  BOOL write(ByteStreamOut* stream) const;
+  bool read(ByteStreamIn* stream);
+  bool write(ByteStreamOut* stream) const;
 
   // create or finalize the cell (in the spatial hierarchy) 
-  BOOL manage_cell(const U32 cell_index, const BOOL finalize=FALSE);
+  bool manage_cell(const U32 cell_index, const bool finalize=FALSE);
 
   // map points to cells
-  BOOL inside(const F64 x, const F64 y) const;
+  bool inside(const F64 x, const F64 y) const;
   U32 get_cell_index(const F64 x, const F64 y) const;
 
   // map cells to coarser cells
-  BOOL coarsen(const I32 cell_index, I32* coarser_cell_index, U32* num_cell_indices, I32** cell_indices) const;
+  bool coarsen(const I32 cell_index, I32* coarser_cell_index, U32* num_cell_indices, I32** cell_indices) const;
 
   // describe cells
   void get_cell_bounding_box(const I32 cell_index, F32* min, F32* max) const;
@@ -78,15 +78,15 @@ public:
   U32 intersect_circle(const F64 center_x, const F64 center_y, const F64 radius);
 
   // iterate over cells
-  BOOL get_all_cells();
-  BOOL get_intersected_cells();
-  BOOL has_more_cells();
+  bool get_all_cells();
+  bool get_intersected_cells();
+  bool has_more_cells();
 
   // for LASquadtree
-  BOOL setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size = 1000.0f);
-  BOOL setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size, F32 offset_x, F32 offset_y);
-  BOOL tiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 levels);
-  BOOL subtiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 sub_level, U32 sub_level_index, U32 levels);
+  bool setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size = 1000.0f);
+  bool setup(F64 bb_min_x, F64 bb_max_x, F64 bb_min_y, F64 bb_max_y, F32 cell_size, F32 offset_x, F32 offset_y);
+  bool tiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 levels);
+  bool subtiling_setup(F32 min_x, F32 max_x, F32 min_y, F32 max_y, U32 sub_level, U32 sub_level_index, U32 levels);
 
   // additional index queries
   U32 get_level_index(const F64 x, const F64 y, U32 level) const;
@@ -118,8 +118,8 @@ public:
   U32 get_max_cell_index(U32 level) const;
   U32 get_max_cell_index() const;
 
-  U32* raster_occupancy(BOOL(*does_cell_exist)(I32), U32 level) const;
-  U32* raster_occupancy(BOOL(*does_cell_exist)(I32)) const;
+  U32* raster_occupancy(bool(*does_cell_exist)(I32), U32 level) const;
+  U32* raster_occupancy(bool(*does_cell_exist)(I32)) const;
 
   U32 levels;
   F32 cell_size;
@@ -151,8 +151,8 @@ private:
   void intersect_tile_with_cells_adaptive(const F32 ll_x, const F32 ll_y, const F32 ur_x, const F32 ur_y, const F32 cell_min_x, const F32 cell_max_x, const F32 cell_min_y, const F32 cell_max_y, U32 level, U32 level_index);
   void intersect_circle_with_cells(const F64 center_x, const F64 center_y, const F64 radius, const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y, const F32 cell_min_x, const F32 cell_max_x, const F32 cell_min_y, const F32 cell_max_y, U32 level, U32 level_index);
   void intersect_circle_with_cells_adaptive(const F64 center_x, const F64 center_y, const F64 radius, const F64 r_min_x, const F64 r_min_y, const F64 r_max_x, const F64 r_max_y, const F32 cell_min_x, const F32 cell_max_x, const F32 cell_min_y, const F32 cell_max_y, U32 level, U32 level_index);
-  BOOL intersect_circle_with_rectangle(const F64 center_x, const F64 center_y, const F64 radius, const F32 r_min_x, const F32 r_max_x, const F32 r_min_y, const F32 r_max_y);
-  void raster_occupancy(BOOL(*does_cell_exist)(I32), U32* data, U32 min_x, U32 min_y, U32 level_index, U32 level, U32 stop_level) const;
+  bool intersect_circle_with_rectangle(const F64 center_x, const F64 center_y, const F64 radius, const F32 r_min_x, const F32 r_max_x, const F32 r_min_y, const F32 r_max_y);
+  void raster_occupancy(bool(*does_cell_exist)(I32), U32* data, U32 min_x, U32 min_y, U32 level_index, U32 level, U32 stop_level) const;
   void* current_cells;
   U32 next_cell_index;
 };

--- a/LASzip/src/lasreaditem.hpp
+++ b/LASzip/src/lasreaditem.hpp
@@ -51,7 +51,7 @@ public:
   {
     instream = 0;
   };
-  BOOL init(ByteStreamIn* instream)
+  bool init(ByteStreamIn* instream)
   {
     if (!instream) return FALSE;
     this->instream = instream;
@@ -65,7 +65,7 @@ protected:
 class LASreadItemCompressed : public LASreadItem
 {
 public:
-  virtual BOOL init(const U8* item)=0;
+  virtual bool init(const U8* item)=0;
 
   virtual ~LASreadItemCompressed(){};
 };

--- a/LASzip/src/lasreaditemcompressed_v1.cpp
+++ b/LASzip/src/lasreaditemcompressed_v1.cpp
@@ -100,7 +100,7 @@ LASreadItemCompressed_POINT10_v1::~LASreadItemCompressed_POINT10_v1()
   }
 }
 
-BOOL LASreadItemCompressed_POINT10_v1::init(const U8* item)
+bool LASreadItemCompressed_POINT10_v1::init(const U8* item)
 {
   U32 i;
 
@@ -276,7 +276,7 @@ LASreadItemCompressed_GPSTIME11_v1::~LASreadItemCompressed_GPSTIME11_v1()
   delete ic_gpstime;
 }
 
-BOOL LASreadItemCompressed_GPSTIME11_v1::init(const U8* item)
+bool LASreadItemCompressed_GPSTIME11_v1::init(const U8* item)
 {
   /* init state */
   last_gpstime_diff = 0;
@@ -389,7 +389,7 @@ LASreadItemCompressed_RGB12_v1::~LASreadItemCompressed_RGB12_v1()
   delete [] last_item;
 }
 
-BOOL LASreadItemCompressed_RGB12_v1::init(const U8* item)
+bool LASreadItemCompressed_RGB12_v1::init(const U8* item)
 {
   /* init state */
 
@@ -461,7 +461,7 @@ LASreadItemCompressed_WAVEPACKET13_v1::~LASreadItemCompressed_WAVEPACKET13_v1()
   delete [] last_item;
 }
 
-BOOL LASreadItemCompressed_WAVEPACKET13_v1::init(const U8* item)
+bool LASreadItemCompressed_WAVEPACKET13_v1::init(const U8* item)
 {
   /* init state */
   last_diff_32 = 0;
@@ -550,7 +550,7 @@ LASreadItemCompressed_BYTE_v1::~LASreadItemCompressed_BYTE_v1()
   delete [] last_item;
 }
 
-BOOL LASreadItemCompressed_BYTE_v1::init(const U8* item)
+bool LASreadItemCompressed_BYTE_v1::init(const U8* item)
 {
   /* init state */
 

--- a/LASzip/src/lasreaditemcompressed_v1.hpp
+++ b/LASzip/src/lasreaditemcompressed_v1.hpp
@@ -43,7 +43,7 @@ public:
 
   LASreadItemCompressed_POINT10_v1(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_POINT10_v1();
@@ -73,7 +73,7 @@ public:
 
   LASreadItemCompressed_GPSTIME11_v1(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_GPSTIME11_v1();
@@ -95,7 +95,7 @@ public:
 
   LASreadItemCompressed_RGB12_v1(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_RGB12_v1();
@@ -114,7 +114,7 @@ public:
 
   LASreadItemCompressed_WAVEPACKET13_v1(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_WAVEPACKET13_v1();
@@ -139,7 +139,7 @@ public:
 
   LASreadItemCompressed_BYTE_v1(ArithmeticDecoder* dec, U32 number);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_BYTE_v1();

--- a/LASzip/src/lasreaditemcompressed_v2.cpp
+++ b/LASzip/src/lasreaditemcompressed_v2.cpp
@@ -95,7 +95,7 @@ LASreadItemCompressed_POINT10_v2::~LASreadItemCompressed_POINT10_v2()
   delete ic_z;
 }
 
-BOOL LASreadItemCompressed_POINT10_v2::init(const U8* item)
+bool LASreadItemCompressed_POINT10_v2::init(const U8* item)
 {
   U32 i;
 
@@ -268,7 +268,7 @@ LASreadItemCompressed_GPSTIME11_v2::~LASreadItemCompressed_GPSTIME11_v2()
   delete ic_gpstime;
 }
 
-BOOL LASreadItemCompressed_GPSTIME11_v2::init(const U8* item)
+bool LASreadItemCompressed_GPSTIME11_v2::init(const U8* item)
 {
   /* init state */
   last = 0, next = 0;
@@ -432,7 +432,7 @@ LASreadItemCompressed_RGB12_v2::~LASreadItemCompressed_RGB12_v2()
   dec->destroySymbolModel(m_rgb_diff_5);
 }
 
-BOOL LASreadItemCompressed_RGB12_v2::init(const U8* item)
+bool LASreadItemCompressed_RGB12_v2::init(const U8* item)
 {
   /* init state */
 
@@ -562,7 +562,7 @@ LASreadItemCompressed_BYTE_v2::~LASreadItemCompressed_BYTE_v2()
   delete [] last_item;
 }
 
-BOOL LASreadItemCompressed_BYTE_v2::init(const U8* item)
+bool LASreadItemCompressed_BYTE_v2::init(const U8* item)
 {
   U32 i;
   /* init state */

--- a/LASzip/src/lasreaditemcompressed_v2.hpp
+++ b/LASzip/src/lasreaditemcompressed_v2.hpp
@@ -44,7 +44,7 @@ public:
 
   LASreadItemCompressed_POINT10_v2(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_POINT10_v2();
@@ -75,7 +75,7 @@ public:
 
   LASreadItemCompressed_GPSTIME11_v2(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_GPSTIME11_v2();
@@ -98,7 +98,7 @@ public:
 
   LASreadItemCompressed_RGB12_v2(ArithmeticDecoder* dec);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_RGB12_v2();
@@ -122,7 +122,7 @@ public:
 
   LASreadItemCompressed_BYTE_v2(ArithmeticDecoder* dec, U32 number);
 
-  BOOL init(const U8* item);
+  bool init(const U8* item);
   void read(U8* item);
 
   ~LASreadItemCompressed_BYTE_v2();

--- a/LASzip/src/lasreadpoint.cpp
+++ b/LASzip/src/lasreadpoint.cpp
@@ -65,7 +65,7 @@ LASreadPoint::LASreadPoint()
   last_warning = 0;
 }
 
-BOOL LASreadPoint::setup(U32 num_items, const LASitem* items, const LASzip* laszip)
+bool LASreadPoint::setup(U32 num_items, const LASitem* items, const LASzip* laszip)
 {
   U32 i;
 
@@ -222,7 +222,7 @@ BOOL LASreadPoint::setup(U32 num_items, const LASitem* items, const LASzip* lasz
   return TRUE;
 }
 
-BOOL LASreadPoint::init(ByteStreamIn* instream)
+bool LASreadPoint::init(ByteStreamIn* instream)
 {
   if (!instream) return FALSE;
   this->instream = instream;
@@ -248,7 +248,7 @@ BOOL LASreadPoint::init(ByteStreamIn* instream)
   return TRUE;
 }
 
-BOOL LASreadPoint::seek(const U32 current, const U32 target)
+bool LASreadPoint::seek(const U32 current, const U32 target)
 {
   if (!instream->isSeekable()) return FALSE;
   U32 delta = 0;
@@ -325,7 +325,7 @@ BOOL LASreadPoint::seek(const U32 current, const U32 target)
   return TRUE;
 }
 
-BOOL LASreadPoint::read(U8* const * point)
+bool LASreadPoint::read(U8* const * point)
 {
   U32 i;
 
@@ -431,7 +431,7 @@ BOOL LASreadPoint::read(U8* const * point)
   return TRUE;
 }
 
-BOOL LASreadPoint::check_end()
+bool LASreadPoint::check_end()
 {
   if (readers == readers_compressed)
   {
@@ -457,13 +457,13 @@ BOOL LASreadPoint::check_end()
   return TRUE;
 }
 
-BOOL LASreadPoint::done()
+bool LASreadPoint::done()
 {
   instream = 0;
   return TRUE;
 }
 
-BOOL LASreadPoint::init_dec()
+bool LASreadPoint::init_dec()
 {
   // maybe read chunk table (only if chunking enabled)
 
@@ -483,7 +483,7 @@ BOOL LASreadPoint::init_dec()
   return TRUE;
 }
 
-BOOL LASreadPoint::read_chunk_table()
+bool LASreadPoint::read_chunk_table()
 {
   // read the 8 bytes that store the location of the chunk table
   I64 chunk_table_start_position;

--- a/LASzip/src/lasreadpoint.hpp
+++ b/LASzip/src/lasreadpoint.hpp
@@ -54,13 +54,13 @@ public:
   ~LASreadPoint();
 
   // should only be called *once*
-  BOOL setup(const U32 num_items, const LASitem* items, const LASzip* laszip=0);
+  bool setup(const U32 num_items, const LASitem* items, const LASzip* laszip=0);
 
-  BOOL init(ByteStreamIn* instream);
-  BOOL seek(const U32 current, const U32 target);
-  BOOL read(U8* const * point);
-  BOOL check_end();
-  BOOL done();
+  bool init(ByteStreamIn* instream);
+  bool seek(const U32 current, const U32 target);
+  bool read(U8* const * point);
+  bool check_end();
+  bool done();
 
   inline const CHAR* error() const { return last_error; };
   inline const CHAR* warning() const { return last_warning; };
@@ -80,8 +80,8 @@ private:
   U32 tabled_chunks;
   I64* chunk_starts;
   U32* chunk_totals;
-  BOOL init_dec();
-  BOOL read_chunk_table();
+  bool init_dec();
+  bool read_chunk_table();
   U32 search_chunk_table(const U32 index, const U32 lower, const U32 upper);
   // used for seeking
   I64 point_start;

--- a/LASzip/src/lasunzipper.cpp
+++ b/LASzip/src/lasunzipper.cpp
@@ -94,7 +94,7 @@ bool LASunzipper::read(unsigned char * const * point)
 
 bool LASunzipper::close()
 {
-  BOOL done = TRUE;
+  bool done = TRUE;
   if (reader)
   {
     done = reader->done();

--- a/LASzip/src/laswriteitem.hpp
+++ b/LASzip/src/laswriteitem.hpp
@@ -39,7 +39,7 @@ class ByteStreamOut;
 class LASwriteItem
 {
 public:
-  virtual BOOL write(const U8* item)=0;
+  virtual bool write(const U8* item)=0;
 
   virtual ~LASwriteItem(){};
 };
@@ -51,7 +51,7 @@ public:
   {
     outstream = 0;
   };
-  BOOL init(ByteStreamOut* outstream)
+  bool init(ByteStreamOut* outstream)
   {
     if (!outstream) return FALSE;
     this->outstream = outstream;
@@ -65,7 +65,7 @@ protected:
 class LASwriteItemCompressed : public LASwriteItem
 {
 public:
-  virtual BOOL init(const U8* item)=0;
+  virtual bool init(const U8* item)=0;
 
   virtual ~LASwriteItemCompressed(){};
 };

--- a/LASzip/src/laswriteitemcompressed_v1.cpp
+++ b/LASzip/src/laswriteitemcompressed_v1.cpp
@@ -99,7 +99,7 @@ LASwriteItemCompressed_POINT10_v1::~LASwriteItemCompressed_POINT10_v1()
   }
 }
 
-BOOL LASwriteItemCompressed_POINT10_v1::init(const U8* item)
+bool LASwriteItemCompressed_POINT10_v1::init(const U8* item)
 {
   U32 i;
 
@@ -129,7 +129,7 @@ BOOL LASwriteItemCompressed_POINT10_v1::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_POINT10_v1::write(const U8* item)
+inline bool LASwriteItemCompressed_POINT10_v1::write(const U8* item)
 {
   // find median difference for x and y from 3 preceding differences
   I32 median_x;
@@ -281,7 +281,7 @@ LASwriteItemCompressed_GPSTIME11_v1::~LASwriteItemCompressed_GPSTIME11_v1()
   delete ic_gpstime;
 }
 
-BOOL LASwriteItemCompressed_GPSTIME11_v1::init(const U8* item)
+bool LASwriteItemCompressed_GPSTIME11_v1::init(const U8* item)
 {
   /* init state */
   last_gpstime_diff = 0;
@@ -297,7 +297,7 @@ BOOL LASwriteItemCompressed_GPSTIME11_v1::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_GPSTIME11_v1::write(const U8* item)
+inline bool LASwriteItemCompressed_GPSTIME11_v1::write(const U8* item)
 {
   U64I64F64 this_gpstime;
   this_gpstime.i64 = *((I64*)item);
@@ -438,7 +438,7 @@ LASwriteItemCompressed_RGB12_v1::~LASwriteItemCompressed_RGB12_v1()
   delete [] last_item;
 }
 
-BOOL LASwriteItemCompressed_RGB12_v1::init(const U8* item)
+bool LASwriteItemCompressed_RGB12_v1::init(const U8* item)
 {
   /* init state */
 
@@ -451,7 +451,7 @@ BOOL LASwriteItemCompressed_RGB12_v1::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_RGB12_v1::write(const U8* item)
+inline bool LASwriteItemCompressed_RGB12_v1::write(const U8* item)
 {
   U32 sym = ((((U16*)last_item)[0]&0x00FF) != (((U16*)item)[0]&0x00FF)) << 0;
   sym |= ((((U16*)last_item)[0]&0xFF00) != (((U16*)item)[0]&0xFF00)) << 1;
@@ -511,7 +511,7 @@ LASwriteItemCompressed_WAVEPACKET13_v1::~LASwriteItemCompressed_WAVEPACKET13_v1(
   delete [] last_item;
 }
 
-BOOL LASwriteItemCompressed_WAVEPACKET13_v1::init(const U8* item)
+bool LASwriteItemCompressed_WAVEPACKET13_v1::init(const U8* item)
 {
   /* init state */
   last_diff_32 = 0;
@@ -534,7 +534,7 @@ BOOL LASwriteItemCompressed_WAVEPACKET13_v1::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_WAVEPACKET13_v1::write(const U8* item)
+inline bool LASwriteItemCompressed_WAVEPACKET13_v1::write(const U8* item)
 {
   enc->encodeSymbol(m_packet_index, (U32)(item[0]));
   item++;
@@ -612,7 +612,7 @@ LASwriteItemCompressed_BYTE_v1::~LASwriteItemCompressed_BYTE_v1()
   delete [] last_item;
 }
 
-BOOL LASwriteItemCompressed_BYTE_v1::init(const U8* item)
+bool LASwriteItemCompressed_BYTE_v1::init(const U8* item)
 {
   /* init state */
 
@@ -624,7 +624,7 @@ BOOL LASwriteItemCompressed_BYTE_v1::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_BYTE_v1::write(const U8* item)
+inline bool LASwriteItemCompressed_BYTE_v1::write(const U8* item)
 {
   U32 i;
   for (i = 0; i < number; i++)

--- a/LASzip/src/laswriteitemcompressed_v1.hpp
+++ b/LASzip/src/laswriteitemcompressed_v1.hpp
@@ -43,8 +43,8 @@ public:
 
   LASwriteItemCompressed_POINT10_v1(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_POINT10_v1();
 
@@ -73,8 +73,8 @@ public:
 
   LASwriteItemCompressed_GPSTIME11_v1(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_GPSTIME11_v1();
 
@@ -95,8 +95,8 @@ public:
 
   LASwriteItemCompressed_RGB12_v1(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_RGB12_v1();
 
@@ -114,8 +114,8 @@ public:
 
   LASwriteItemCompressed_WAVEPACKET13_v1(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_WAVEPACKET13_v1();
 
@@ -139,8 +139,8 @@ public:
 
   LASwriteItemCompressed_BYTE_v1(ArithmeticEncoder* enc, U32 number);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_BYTE_v1();
 

--- a/LASzip/src/laswriteitemcompressed_v2.cpp
+++ b/LASzip/src/laswriteitemcompressed_v2.cpp
@@ -101,7 +101,7 @@ LASwriteItemCompressed_POINT10_v2::~LASwriteItemCompressed_POINT10_v2()
   delete ic_z;
 }
 
-BOOL LASwriteItemCompressed_POINT10_v2::init(const U8* item)
+bool LASwriteItemCompressed_POINT10_v2::init(const U8* item)
 {
   U32 i;
 
@@ -136,7 +136,7 @@ BOOL LASwriteItemCompressed_POINT10_v2::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_POINT10_v2::write(const U8* item)
+inline bool LASwriteItemCompressed_POINT10_v2::write(const U8* item)
 {
   U32 r = ((LASpoint10*)item)->return_number;
   U32 n = ((LASpoint10*)item)->number_of_returns_of_given_pulse;
@@ -261,7 +261,7 @@ LASwriteItemCompressed_GPSTIME11_v2::~LASwriteItemCompressed_GPSTIME11_v2()
   delete ic_gpstime;
 }
 
-BOOL LASwriteItemCompressed_GPSTIME11_v2::init(const U8* item)
+bool LASwriteItemCompressed_GPSTIME11_v2::init(const U8* item)
 {
   /* init state */
   last = 0, next = 0;
@@ -287,7 +287,7 @@ BOOL LASwriteItemCompressed_GPSTIME11_v2::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_GPSTIME11_v2::write(const U8* item)
+inline bool LASwriteItemCompressed_GPSTIME11_v2::write(const U8* item)
 {
   U64I64F64 this_gpstime;
   this_gpstime.i64 = *((I64*)item);
@@ -482,7 +482,7 @@ LASwriteItemCompressed_RGB12_v2::~LASwriteItemCompressed_RGB12_v2()
   enc->destroySymbolModel(m_rgb_diff_5);
 }
 
-BOOL LASwriteItemCompressed_RGB12_v2::init(const U8* item)
+bool LASwriteItemCompressed_RGB12_v2::init(const U8* item)
 {
   /* init state */
 
@@ -500,7 +500,7 @@ BOOL LASwriteItemCompressed_RGB12_v2::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_RGB12_v2::write(const U8* item)
+inline bool LASwriteItemCompressed_RGB12_v2::write(const U8* item)
 {
   I32 diff_l = 0;
   I32 diff_h = 0;
@@ -590,7 +590,7 @@ LASwriteItemCompressed_BYTE_v2::~LASwriteItemCompressed_BYTE_v2()
   delete [] last_item;
 }
 
-BOOL LASwriteItemCompressed_BYTE_v2::init(const U8* item)
+bool LASwriteItemCompressed_BYTE_v2::init(const U8* item)
 {
   U32 i;
   /* init state */
@@ -606,7 +606,7 @@ BOOL LASwriteItemCompressed_BYTE_v2::init(const U8* item)
   return TRUE;
 }
 
-inline BOOL LASwriteItemCompressed_BYTE_v2::write(const U8* item)
+inline bool LASwriteItemCompressed_BYTE_v2::write(const U8* item)
 {
   U32 i;
   I32 diff;

--- a/LASzip/src/laswriteitemcompressed_v2.hpp
+++ b/LASzip/src/laswriteitemcompressed_v2.hpp
@@ -44,8 +44,8 @@ public:
 
   LASwriteItemCompressed_POINT10_v2(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_POINT10_v2();
 
@@ -75,8 +75,8 @@ public:
 
   LASwriteItemCompressed_GPSTIME11_v2(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_GPSTIME11_v2();
 
@@ -98,8 +98,8 @@ public:
 
   LASwriteItemCompressed_RGB12_v2(ArithmeticEncoder* enc);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_RGB12_v2();
 
@@ -122,8 +122,8 @@ public:
 
   LASwriteItemCompressed_BYTE_v2(ArithmeticEncoder* enc, U32 number);
 
-  BOOL init(const U8* item);
-  BOOL write(const U8* item);
+  bool init(const U8* item);
+  bool write(const U8* item);
 
   ~LASwriteItemCompressed_BYTE_v2();
 

--- a/LASzip/src/laswriteitemraw.hpp
+++ b/LASzip/src/laswriteitemraw.hpp
@@ -41,7 +41,7 @@ class LASwriteItemRaw_POINT10_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_POINT10_LE(){};
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, 20);
   };
@@ -51,7 +51,7 @@ class LASwriteItemRaw_POINT10_BE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_POINT10_BE(){};
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     ENDIAN_SWAP_32(&item[ 0], &swapped[ 0]);    // x
     ENDIAN_SWAP_32(&item[ 4], &swapped[ 4]);    // y
@@ -69,7 +69,7 @@ class LASwriteItemRaw_GPSTIME11_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_GPSTIME11_LE() {};
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, 8);
   };
@@ -79,7 +79,7 @@ class LASwriteItemRaw_GPSTIME11_BE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_GPSTIME11_BE() {};
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     ENDIAN_SWAP_64(item, swapped);
     return outstream->putBytes(swapped, 8);
@@ -92,7 +92,7 @@ class LASwriteItemRaw_RGB12_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_RGB12_LE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, 6);
   };
@@ -102,7 +102,7 @@ class LASwriteItemRaw_RGB12_BE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_RGB12_BE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     ENDIAN_SWAP_32(&item[ 0], &swapped[ 0]); // R
     ENDIAN_SWAP_32(&item[ 2], &swapped[ 2]); // G
@@ -117,7 +117,7 @@ class LASwriteItemRaw_WAVEPACKET13_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_WAVEPACKET13_LE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, 29);
   };
@@ -127,7 +127,7 @@ class LASwriteItemRaw_WAVEPACKET13_BE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_WAVEPACKET13_BE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     swapped[0] = item[0];                    // wavepacket descriptor index
     ENDIAN_SWAP_64(&item[ 1], &swapped[ 1]); // byte offset to waveform data
@@ -149,7 +149,7 @@ public:
   {
     this->number = number;
   }
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, number);
   };
@@ -214,7 +214,7 @@ class LASwriteItemRaw_POINT14_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_POINT14_LE(){};
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     ((LAStempWritePoint14*)buffer)->X = ((LAStempWritePoint10*)item)->X;
     ((LAStempWritePoint14*)buffer)->Y = ((LAStempWritePoint10*)item)->Y;
@@ -255,7 +255,7 @@ class LASwriteItemRaw_RGBNIR14_LE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_RGBNIR14_LE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     return outstream->putBytes(item, 8);
   };
@@ -265,7 +265,7 @@ class LASwriteItemRaw_RGBNIR14_BE : public LASwriteItemRaw
 {
 public:
   LASwriteItemRaw_RGBNIR14_BE(){}
-  inline BOOL write(const U8* item)
+  inline bool write(const U8* item)
   {
     ENDIAN_SWAP_32(&item[ 0], &swapped[ 0]); // R
     ENDIAN_SWAP_32(&item[ 2], &swapped[ 2]); // G

--- a/LASzip/src/laswritepoint.cpp
+++ b/LASzip/src/laswritepoint.cpp
@@ -58,7 +58,7 @@ LASwritePoint::LASwritePoint()
   chunk_start_position = 0;
 }
 
-BOOL LASwritePoint::setup(const U32 num_items, const LASitem* items, const LASzip* laszip)
+bool LASwritePoint::setup(const U32 num_items, const LASitem* items, const LASzip* laszip)
 {
   U32 i;
 
@@ -203,7 +203,7 @@ BOOL LASwritePoint::setup(const U32 num_items, const LASitem* items, const LASzi
   return TRUE;
 }
 
-BOOL LASwritePoint::init(ByteStreamOut* outstream)
+bool LASwritePoint::init(ByteStreamOut* outstream)
 {
   if (!outstream) return FALSE;
   this->outstream = outstream;
@@ -242,7 +242,7 @@ BOOL LASwritePoint::init(ByteStreamOut* outstream)
   return TRUE;
 }
 
-BOOL LASwritePoint::write(const U8 * const * point)
+bool LASwritePoint::write(const U8 * const * point)
 {
   U32 i;
 
@@ -275,7 +275,7 @@ BOOL LASwritePoint::write(const U8 * const * point)
   return TRUE;
 }
 
-BOOL LASwritePoint::chunk()
+bool LASwritePoint::chunk()
 {
   if (chunk_start_position == 0 || chunk_size != U32_MAX)
   {
@@ -288,7 +288,7 @@ BOOL LASwritePoint::chunk()
   return TRUE;
 }
 
-BOOL LASwritePoint::done()
+bool LASwritePoint::done()
 {
   if (writers == writers_compressed)
   {
@@ -310,7 +310,7 @@ BOOL LASwritePoint::done()
   return TRUE;
 }
 
-BOOL LASwritePoint::add_chunk_to_table()
+bool LASwritePoint::add_chunk_to_table()
 {
   if (number_chunks == alloced_chunks)
   {
@@ -337,7 +337,7 @@ BOOL LASwritePoint::add_chunk_to_table()
   return TRUE;
 }
 
-BOOL LASwritePoint::write_chunk_table()
+bool LASwritePoint::write_chunk_table()
 {
   U32 i;
   I64 position = outstream->tell();

--- a/LASzip/src/laswritepoint.hpp
+++ b/LASzip/src/laswritepoint.hpp
@@ -53,12 +53,12 @@ public:
   ~LASwritePoint();
 
   // should only be called *once*
-  BOOL setup(const U32 num_items, const LASitem* items, const LASzip* laszip=0);
+  bool setup(const U32 num_items, const LASitem* items, const LASzip* laszip=0);
 
-  BOOL init(ByteStreamOut* outstream);
-  BOOL write(const U8 * const * point);
-  BOOL chunk();
-  BOOL done();
+  bool init(ByteStreamOut* outstream);
+  bool write(const U8 * const * point);
+  bool chunk();
+  bool done();
 
 private:
   ByteStreamOut* outstream;
@@ -76,8 +76,8 @@ private:
   U32* chunk_bytes;
   I64 chunk_start_position;
   I64 chunk_table_start_position;
-  BOOL add_chunk_to_table();
-  BOOL write_chunk_table();
+  bool add_chunk_to_table();
+  bool write_chunk_table();
 };
 
 #endif

--- a/LASzip/src/laszip.cpp
+++ b/LASzip/src/laszip.cpp
@@ -344,12 +344,12 @@ bool LASzip::setup(const U16 num_items, const LASitem* items, const U16 compress
 
 bool LASzip::setup(U16* num_items, LASitem** items, const U8 point_type, const U16 point_size, const U16 compressor)
 {
-  BOOL compatible = FALSE;
-  BOOL have_point14 = FALSE;
-  BOOL have_gps_time = FALSE;
-  BOOL have_rgb = FALSE;
-  BOOL have_nir = FALSE;
-  BOOL have_wavepacket = FALSE;
+  bool compatible = FALSE;
+  bool have_point14 = FALSE;
+  bool have_gps_time = FALSE;
+  bool have_rgb = FALSE;
+  bool have_nir = FALSE;
+  bool have_wavepacket = FALSE;
   I32 extra_bytes_number = 0;
 
   // turns on LAS 1.4 compatibility mode 

--- a/LASzip/src/laszip_common_v2.hpp
+++ b/LASzip/src/laszip_common_v2.hpp
@@ -36,7 +36,7 @@ class StreamingMedian5
 {
 public:
   I32 values[5];
-  BOOL high;
+  bool high;
   void init()
   {
     values[0] = values[1] = values[2] = values[3] = values[4] = 0;

--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -52,7 +52,7 @@
 class laszip_dll_inventory
 {
 public:
-  BOOL active() const { return (first == FALSE); }; 
+  bool active() const { return (first == FALSE); }; 
   U32 number_of_point_records;
   U32 number_of_points_by_return[16];
   I32 max_X;
@@ -100,7 +100,7 @@ public:
     first = TRUE;
   }
 private:
-  BOOL first;
+  bool first;
 };
 
 typedef struct laszip_dll {
@@ -123,12 +123,12 @@ typedef struct laszip_dll {
   F64 lax_r_max_x;
   F64 lax_r_max_y;
   CHAR* lax_file_name;
-  BOOL lax_create;
-  BOOL lax_append;
-  BOOL lax_exploit;
-  BOOL preserve_generating_software;
-  BOOL request_compatibility_mode;
-  BOOL compatibility_mode;
+  bool lax_create;
+  bool lax_append;
+  bool lax_exploit;
+  bool preserve_generating_software;
+  bool request_compatibility_mode;
+  bool compatibility_mode;
   I32 start_scan_angle;
   I32 start_extended_returns;
   I32 start_classification;

--- a/LASzip/src/laszipper.cpp
+++ b/LASzip/src/laszipper.cpp
@@ -88,7 +88,7 @@ bool LASzipper::chunk()
 
 bool LASzipper::close()
 {
-  BOOL done = TRUE;
+  bool done = TRUE;
   if (writer)
   {
     done = writer->done();

--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -66,12 +66,6 @@ typedef long long          I64;
 typedef float              F32;
 typedef double             F64;
 
-#if defined(_MSC_VER) && (_MSC_VER < 1300) || defined (__MINGW32__)
-typedef int                BOOL;
-#else
-typedef bool               BOOL;
-#endif
-
 typedef union U32I32F32 { U32 u32; I32 i32; F32 f32; } U32I32F32;
 typedef union U64I64F64 { U64 u64; I64 i64; F64 f64; } U64I64F64;
 
@@ -167,7 +161,7 @@ typedef union U64I64F64 { U64 u64; I64 i64; F64 f64; } U64I64F64;
 #define NULL    0
 #endif
 
-inline BOOL IS_LITTLE_ENDIAN()
+inline bool IS_LITTLE_ENDIAN()
 {
   const U32 i = 1;
   return (*((U8*)&i) == 1);

--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -428,7 +428,7 @@ int main(int argc, char *argv[])
     usage(true, argc==1);
   }
   
-  BOOL extra_pass = laswriteopener.is_piped();
+  bool extra_pass = laswriteopener.is_piped();
 
   // for piped output we need an extra pass
 
@@ -867,7 +867,7 @@ int main(int argc, char *argv[])
 
     // do we need an extra pass
 
-    BOOL extra_pass = laswriteopener.is_piped();
+    bool extra_pass = laswriteopener.is_piped();
 
     // for piped output we need an extra pass
 

--- a/src/lasindex.cpp
+++ b/src/lasindex.cpp
@@ -18,9 +18,9 @@
      also available to users of the LASlib API. The LASreader class has three new
      functions called
 
-     BOOL inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
-     BOOL inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
-     BOOL inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
+     bool inside_tile(const F32 ll_x, const F32 ll_y, const F32 size);
+     bool inside_circle(const F64 center_x, const F64 center_y, const F64 radius);
+     bool inside_rectangle(const F64 min_x, const F64 min_y, const F64 max_x, const F64 max_y);
 
      if any of these functions is called the LASreader will only return the points
      that fall inside the specified region and use - when available - the spatial
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
   U32 threshold = 1000;
   U32 minimum_points = 100000;
   I32 maximum_intervals = -20;
-  BOOL append = FALSE;
+  bool append = FALSE;
   F64 start_time = 0.0;
   F64 total_start_time = 0.0;
 

--- a/src/lasoptimize.cpp
+++ b/src/lasoptimize.cpp
@@ -86,17 +86,17 @@ int main(int argc, char *argv[])
 {
   int i;
 #ifdef COMPILE_WITH_GUI
-  BOOL gui = FALSE;
+  bool gui = FALSE;
 #endif
 #ifdef COMPILE_WITH_MULTI_CORE
   I32 cores = 1;
 #endif
-  BOOL verbose = FALSE;
+  bool verbose = FALSE;
   bool report_file_size = false;
   bool projection_was_set = false;
   bool format_not_specified = false;
-  BOOL append = FALSE;
-  BOOL rearrange = FALSE;
+  bool append = FALSE;
+  bool rearrange = FALSE;
   F32 bucket_size = -1.0f;
   U32 tile_size = 100;
   U32 threshold = 1000;

--- a/src/laszip.cpp
+++ b/src/laszip.cpp
@@ -115,14 +115,14 @@ extern int laszip_multi_core(int argc, char *argv[], GeoProjectionConverter* geo
 int main(int argc, char *argv[])
 {
   int i;
-  BOOL dry = FALSE;
+  bool dry = FALSE;
 #ifdef COMPILE_WITH_GUI
-  BOOL gui = FALSE;
+  bool gui = FALSE;
 #endif
 #ifdef COMPILE_WITH_MULTI_CORE
   I32 cores = 1;
 #endif
-  BOOL verbose = FALSE;
+  bool verbose = FALSE;
   bool waveform = false;
   bool waveform_with_map = false;
   bool report_file_size = false;
@@ -130,11 +130,11 @@ int main(int argc, char *argv[])
   I32 end_of_points = -1;
   bool projection_was_set = false;
   bool format_not_specified = false;
-  BOOL lax = FALSE;
-  BOOL append = FALSE;
-  BOOL remain_compatible = FALSE;
-  BOOL move_CRS = FALSE;
-  BOOL move_all = FALSE;
+  bool lax = FALSE;
+  bool append = FALSE;
+  bool remain_compatible = FALSE;
+  bool move_CRS = FALSE;
+  bool move_all = FALSE;
   F32 tile_size = 100.0f;
   U32 threshold = 1000;
   U32 minimum_points = 100000;


### PR DESCRIPTION
It is always hard to compile LASTools with a modern compiler. As far as I can see examples of LASlib are already using `bool` instead of `BOOL`. So I assume Visual Studio 6 is already supporting `bool`(?). So we should switch to default datatype of compiler, to avoid everyone has to follow [this guide](https://groups.google.com/forum/#!topic/lastools/zDfLAcbSR7o) to get a working library.