### PR TITLE
Add LASLIB_DLL

### DIFF
--- a/LASlib/inc/laswaveform13reader.hpp
+++ b/LASlib/inc/laswaveform13reader.hpp
@@ -39,7 +39,7 @@ class LASwaveformDescription;
 class ArithmeticDecoder;
 class IntegerCompressor;
 
-class LASwaveform13reader
+class LASLIB_DLL LASwaveform13reader
 {
 public:
   U32 nbits;


### PR DESCRIPTION
Otherwise las2txt.cpp (and I guess the other tools as well) has a linker error when building/using a dll