### PR TITLE
Fix DLL Support and fix usage of unordered_map for VC++

### DIFF
--- a/LASlib/inc/lasutility.hpp
+++ b/LASlib/inc/lasutility.hpp
@@ -34,7 +34,7 @@
 
 #include "lasdefinitions.hpp"
 
-class LASinventory
+class LASLIB_DLL LASinventory
 {
 public:
   BOOL active() const { return (first == FALSE); }; 
@@ -54,7 +54,7 @@ private:
   BOOL first;
 };
 
-class LASsummary
+class LASLIB_DLL LASsummary
 {
 public:
   BOOL active() const { return (first == FALSE); }; 
@@ -118,7 +118,7 @@ private:
   F64* values_neg;
 };
 
-class LAShistogram
+class LASLIB_DLL LAShistogram
 {
 public:
   BOOL active() const { return is_active; }; 
@@ -169,7 +169,7 @@ private:
   LASbin* return_map_bin_intensity;
 };
 
-class LASoccupancyGrid
+class LASLIB_DLL LASoccupancyGrid
 {
 public:
   void reset();

--- a/LASlib/inc/laswaveform13reader.hpp
+++ b/LASlib/inc/laswaveform13reader.hpp
@@ -39,7 +39,7 @@ class LASwaveformDescription;
 class ArithmeticDecoder;
 class IntegerCompressor;
 
-class LASwaveform13reader
+class LASLIB_DLL LASwaveform13reader
 {
 public:
   U32 nbits;

--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -46,7 +46,7 @@
 
 #ifdef UNORDERED
   // Check if on OS X and using cland (unordered map isn't part of tr1 namespace)
-  #if defined(__APPLE__) && defined(__clang__)
+  #if (defined(__APPLE__) && defined(__clang__)) || ( _MSC_VER >= 1700 )
     #include <unordered_map>
     using namespace std;
   #else

--- a/LASzip/src/lasindex.hpp
+++ b/LASzip/src/lasindex.hpp
@@ -52,7 +52,7 @@ class LASreader;
 class ByteStreamIn;
 class ByteStreamOut;
 
-class LASindex
+class LASLIB_DLL LASindex
 {
 public:
   LASindex();

--- a/LASzip/src/lasinterval.cpp
+++ b/LASzip/src/lasinterval.cpp
@@ -44,7 +44,7 @@ using namespace std;
 
 #ifdef UNORDERED
   // Check if on OS X and using cland (unordered map isn't part of tr1 namespace)
-  #if defined(__APPLE__) && defined(__clang__)
+#if (defined(__APPLE__) && defined(__clang__)) || ( _MSC_VER >= 1700 )
     #include <unordered_map>
   #else
     #include <tr1/unordered_map>

--- a/LASzip/src/lasquadtree.hpp
+++ b/LASzip/src/lasquadtree.hpp
@@ -42,7 +42,7 @@ class ByteStreamOut;
 
 #define LAS_SPATIAL_QUAD_TREE 0
 
-class LASquadtree
+class LASLIB_DLL LASquadtree
 {
 public:
   LASquadtree();

--- a/LASzip/src/laszip.hpp
+++ b/LASzip/src/laszip.hpp
@@ -44,6 +44,8 @@
 #ifndef LASZIP_HPP
 #define LASZIP_HPP
 
+#include "mydefs.hpp"
+
 #if defined(_MSC_VER) && (_MSC_VER < 1300)
 #define LZ_WIN32_VC6
 typedef __int64   SIGNED_INT64;
@@ -78,7 +80,7 @@ typedef long long SIGNED_INT64;
 
 #define LASZIP_CHUNK_SIZE_DEFAULT           50000
 
-class LASitem
+class LASLIB_DLL LASitem
 {
 public:
   enum Type { BYTE = 0, SHORT, INT, LONG, FLOAT, DOUBLE, POINT10, GPSTIME11, RGB12, WAVEPACKET13, POINT14, RGBNIR14 } type;
@@ -88,7 +90,7 @@ public:
   const char* get_name() const;
 };
 
-class LASzip
+class LASLIB_DLL LASzip
 {
 public:
 


### PR DESCRIPTION
With the changes proposed all tools compile and link  (modulo the problem with the typdef for BOOL).