### PR TITLE
Suppress warning for VC++

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -58,6 +58,11 @@
 #include "laszip.hpp"
 #include "laspoint.hpp"
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable:4267)
+#endif
+
 #define LAS_TOOLS_FORMAT_DEFAULT 0
 #define LAS_TOOLS_FORMAT_LAS     1
 #define LAS_TOOLS_FORMAT_LAZ     2
@@ -900,5 +905,9 @@ public:
     clean();
   };
 };
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
This PR avoids the following warning:
`lastools\laslib\inc\lasdefinitions.hpp(814) : warning C4267: 'argument' : conversion from 'size_t' to 'const U16', possible loss of data`