### PR TITLE
add c++11 switch for liblas.a

### DIFF
--- a/LASlib/src/Makefile
+++ b/LASlib/src/Makefile
@@ -1,7 +1,7 @@
 # makefile for liblas.a
 #
 #COPTS    = -g -Wall
-COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -DNDEBUG -DUNORDERED
+COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -DNDEBUG -DUNORDERED -std=c++11
 COMPILER  = g++
 AR  = ar rc
 #BITS     = -64


### PR DESCRIPTION
I needed to add the c++11 switch to get the library to build.