### PR TITLE
Fixed MSVC2013 C4258 warning about shadowed 'i' value in for loop

### DIFF
--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -3962,18 +3962,18 @@ laszip_read_header(
           }
           laszip_dll->header.extended_number_of_point_records = extended_number_of_point_records;
           U64 extended_number_of_points_by_return;
-          for (U32 i = 0; i < 15; i++)
+          for (U32 r = 0; r < 15; r++)
           {
             in->get64bitsLE((U8*)&extended_number_of_points_by_return);
-            if ((i < 5) && laszip_dll->header.number_of_points_by_return[i] != 0 && ((U64)(laszip_dll->header.number_of_points_by_return[i])) != extended_number_of_points_by_return)
+            if ((r < 5) && laszip_dll->header.number_of_points_by_return[r] != 0 && ((U64)(laszip_dll->header.number_of_points_by_return[r])) != extended_number_of_points_by_return)
             {
 #ifdef _WIN32
-              fprintf(stderr,"WARNING: number_of_points_by_return[%u] is %u. but extended_number_of_points_by_return[%u] is %I64u.\n", i, laszip_dll->header.number_of_points_by_return[i], i, extended_number_of_points_by_return);
+              fprintf(stderr,"WARNING: number_of_points_by_return[%u] is %u. but extended_number_of_points_by_return[%u] is %I64u.\n", r, laszip_dll->header.number_of_points_by_return[r], r, extended_number_of_points_by_return);
 #else
-              fprintf(stderr,"WARNING: number_of_points_by_return[%u] is %u. but extended_number_of_points_by_return[%u] is %llu.\n", i, laszip_dll->header.number_of_points_by_return[i], i, extended_number_of_points_by_return);
+              fprintf(stderr,"WARNING: number_of_points_by_return[%u] is %u. but extended_number_of_points_by_return[%u] is %llu.\n", r, laszip_dll->header.number_of_points_by_return[r], r, extended_number_of_points_by_return);
 #endif
             }
-            laszip_dll->header.extended_number_of_points_by_return[i] = extended_number_of_points_by_return;
+            laszip_dll->header.extended_number_of_points_by_return[r] = extended_number_of_points_by_return;
           }
           delete in;
 


### PR DESCRIPTION
Fixed a warning from my compiler about shadowing a previous definition of `i` in the nested for loops:
```
1>q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(4031): warning C4258: 'i' : definition from the for loop is ignored; the definition from the enclosing scope is used
1>          q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(3965) : definition of 'i' ignored
1>          q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(3280) : definition of 'i' used
1>q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(4033): warning C4258: 'i' : definition from the for loop is ignored; the definition from the enclosing scope is used
1>          q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(3965) : definition of 'i' ignored
1>          q:\dev\lib\lastools_github\laszip\src\laszip_dll.cpp(3280) : definition of 'i' used
```
Seemed worth fixing to avoid any confusion about the intended variable used in the for loop. Please let me know if I misunderstood your intent.