### PR TITLE
Fix unordered found

### DIFF
--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -56,7 +56,7 @@
 #  ifdef HAVE_UNORDERED_MAP
 #     include <unordered_map>
       using namespace std;
-#  elif UNORDERED_FOUND
+#  elif defined(UNORDERED_FOUND)
 #    include <tr1/unordered_map>
     using namespace std;
     using namespace tr1;

--- a/LASzip/src/lasinterval.cpp
+++ b/LASzip/src/lasinterval.cpp
@@ -55,7 +55,7 @@ using namespace std;
 #  ifdef HAVE_UNORDERED_MAP
 #     include <unordered_map>
       using namespace std;
-#  elif UNORDERED_FOUND
+#  elif defined(UNORDERED_FOUND)
 #    include <tr1/unordered_map>
     using namespace std;
     using namespace tr1;


### PR DESCRIPTION
Attempting to fix a compiler error reported to occur when compiling with GCC 4.9.2 and Centos 7. I don't have access to this compiler, so this is an untested commit. Still, I'm pretty sure it works.