### PR TITLE
fix #48 -Wformat-overflow

### DIFF
--- a/LASlib/src/laswriter_las.cpp
+++ b/LASlib/src/laswriter_las.cpp
@@ -718,7 +718,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (I32)record_length_after_header);
       return FALSE;
     }
-    CHAR description[32] = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+    CHAR description[33] = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
     sprintf(description, "tile %s buffer %s", (header->vlr_lastiling->buffer ? "with" : "without"), (header->vlr_lastiling->reversible ? ", reversible" : ""));
     if (!stream->putBytes((U8*)description, 32))
     {

--- a/LASzip/src/lasreadpoint.cpp
+++ b/LASzip/src/lasreadpoint.cpp
@@ -132,7 +132,7 @@ BOOL LASreadPoint::setup(U32 num_items, const LASitem* items, const LASzip* lasz
         readers_raw[i] = new LASreadItemRaw_GPSTIME11_LE();
       else
         readers_raw[i] = new LASreadItemRaw_GPSTIME11_BE();
-        break;
+       break;
     case LASitem::RGB12:
     case LASitem::RGB14:
       if (IS_LITTLE_ENDIAN())

--- a/LASzip/src/laszip.cpp
+++ b/LASzip/src/laszip.cpp
@@ -284,7 +284,7 @@ bool LASzip::check_items(const U16 num_items, const LASitem* items, const U16 po
   }
   if (point_size && (point_size != size))
   {
-    CHAR temp[64];
+    CHAR temp[66];
     sprintf(temp, "point has size of %d but items only add up to %d bytes", point_size, size);
     return return_error(temp);
   }


### PR DESCRIPTION
This fix the issue #48 compiling with gcc 7+.

`-Wformat-overflow` may be a potential source of segfaults
I also fixed a minor warning about bad indentation that the compiler disliked.