### PR TITLE
Fix #54 memory unallocated

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -556,7 +556,7 @@ public:
     {
       number_of_variable_length_records = 1;
       offset_to_point_data += 54;
-      vlrs = (LASvlr*)malloc(sizeof(LASvlr)*number_of_variable_length_records);
+      vlrs = (LASvlr*)calloc(1, sizeof(LASvlr)*number_of_variable_length_records);
     }
     vlrs[i].reserved = 0; // used to be 0xAABB
     strncpy(vlrs[i].user_id, user_id, 16);

--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -556,7 +556,7 @@ public:
     {
       number_of_variable_length_records = 1;
       offset_to_point_data += 54;
-      vlrs = (LASvlr*)calloc(1, sizeof(LASvlr)*number_of_variable_length_records);
+      vlrs = (LASvlr*)calloc(number_of_variable_length_records, sizeof(LASvlr));
     }
     vlrs[i].reserved = 0; // used to be 0xAABB
     strncpy(vlrs[i].user_id, user_id, 16);


### PR DESCRIPTION
This fix the issue #54. Helped by valgrind I found unitialized memory. I changed `malloc` that don't initialize the memory by `calloc` that initialized the memory.

I ran a batch of unit tests based on my own tools that relies on `LASlib` which were successful.  But be careful and check twice yourself before to merge definitively.

**Edit**  this a more correct use of `calloc`. I added a commit.

```cpp
(LASvlr*)calloc(number_of_variable_length_records, sizeof(LASvlr));
```