### PR TITLE
Adding CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+project("LAStools")
+
+add_compile_options(-O3 -Wall -Wno-strict-aliasing)
+
+add_subdirectory(LASlib/src)
+add_subdirectory(LASlib/example)
+add_subdirectory(LASzip/example)
+add_subdirectory(src)
+

--- a/LASlib/example/CMakeLists.txt
+++ b/LASlib/example/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_compile_options(-Wno-unused-result)
+
+include_directories(../../LASzip/src ../inc)
+
+set(TARGETS
+	lasexample
+	lasexample_write_only
+	lasexample_add_rgb
+	lasexample_simple_classification
+	lasexample_write_only_with_extra_bytes)
+
+foreach(TARGET ${TARGETS})
+	add_executable(${TARGET} ${TARGET}.cpp)
+	target_link_libraries(${TARGET} LASlib)
+	set_target_properties(${TARGET} PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endforeach(TARGET)

--- a/LASlib/lib/.gitignore
+++ b/LASlib/lib/.gitignore
@@ -1,2 +1,3 @@
 LASlib.lib
 LASlibD.lib
+libLASlib.a

--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -1,0 +1,68 @@
+add_compile_options(-Wno-deprecated -Wno-write-strings -Wno-unused-result -std=c++11)
+add_definitions(-DNDEBUG -DUNORDERED -DHAVE_UNORDERED_MAP)
+
+include_directories(../../LASzip/src)
+include_directories(../inc)
+
+set(LAS_SRC
+	lasreader.cpp
+	laswriter.cpp
+	lasreader_las.cpp
+	lasreader_bin.cpp
+	lasreader_qfit.cpp
+	lasreader_shp.cpp
+	lasreader_asc.cpp
+	lasreader_bil.cpp
+	lasreader_dtm.cpp
+	lasreader_txt.cpp
+	lasreadermerged.cpp
+	lasreaderbuffered.cpp
+	lasreaderstored.cpp
+	lasreaderpipeon.cpp
+	laswriter_las.cpp
+	laswriter_bin.cpp
+	laswriter_qfit.cpp
+	laswriter_wrl.cpp
+	laswriter_txt.cpp
+	laswritercompatible.cpp
+	laswaveform13reader.cpp
+	laswaveform13writer.cpp
+	lasutility.cpp
+	lasfilter.cpp
+	lastransform.cpp
+	fopen_compressed.cpp
+)
+
+set(LAZ_SRC
+	laszip.cpp
+	lasreadpoint.cpp
+	lasreaditemcompressed_v1.cpp
+	lasreaditemcompressed_v2.cpp
+	lasreaditemcompressed_v3.cpp
+	lasreaditemcompressed_v4.cpp
+	laswritepoint.cpp
+	laswriteitemcompressed_v1.cpp
+	laswriteitemcompressed_v2.cpp
+	laswriteitemcompressed_v3.cpp
+	laswriteitemcompressed_v4.cpp
+	integercompressor.cpp
+	arithmeticdecoder.cpp
+	arithmeticencoder.cpp
+	arithmeticmodel.cpp
+	lasindex.cpp
+	lasquadtree.cpp
+	lasinterval.cpp
+)
+
+foreach(file ${LAZ_SRC})
+	list(APPEND LAZ_SRC_FULL ../../LASzip/src/${file})
+endforeach(file)
+
+add_library(LASlib STATIC ${LAS_SRC} ${LAZ_SRC_FULL})
+set_target_properties(LASlib PROPERTIES
+	ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib)
+
+install(DIRECTORY ../inc/ DESTINATION include/LASlib
+        FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY ../../LASzip/src/ DESTINATION include/LASlib
+        FILES_MATCHING PATTERN "*.hpp")

--- a/LASzip/example/CMakeLists.txt
+++ b/LASzip/example/CMakeLists.txt
@@ -1,0 +1,25 @@
+include_directories(../src)
+
+set(LASZIPPERTEST_SRC
+	laszippertest.cpp
+	../src/laszip.cpp
+	../src/laszipper.cpp
+	../src/lasunzipper.cpp
+	../src/lasreadpoint.cpp
+	../src/lasreaditemcompressed_v1.cpp
+	../src/lasreaditemcompressed_v2.cpp
+	../src/lasreaditemcompressed_v3.cpp
+	../src/lasreaditemcompressed_v4.cpp
+	../src/laswritepoint.cpp
+	../src/laswriteitemcompressed_v1.cpp
+	../src/laswriteitemcompressed_v2.cpp
+	../src/laswriteitemcompressed_v3.cpp
+	../src/laswriteitemcompressed_v4.cpp
+	../src/integercompressor.cpp
+	../src/arithmeticdecoder.cpp
+	../src/arithmeticencoder.cpp
+	../src/arithmeticmodel.cpp
+)
+add_executable(laszippertest ${LASZIPPERTEST_SRC})
+set_target_properties(laszippertest PROPERTIES
+	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/LASzip/lib/.gitignore
+++ b/LASzip/lib/.gitignore
@@ -1,0 +1,1 @@
+liblaszip.a

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_compile_options(-Wno-deprecated -Wno-write-strings -Wno-unused-result)
+add_definitions(-DNDEBUG )
+
+include_directories(../LASzip/src)
+include_directories(../LASlib/inc)
+
+set(GEOPROJECTION_TARGETS
+	laszip
+	lasinfo
+	lasprecision
+	txt2las
+	las2las
+	lasmerge
+)
+set(STANDALONE_TARGETS
+	las2txt
+	lasdiff
+	lasindex
+)
+set(ALL_TARGETS ${GEOPROJECTION_TARGETS} ${STANDALONE_TARGETS})
+
+add_library(geoprojectionconverter OBJECT geoprojectionconverter.cpp)
+
+foreach(TARGET ${GEOPROJECTION_TARGETS})
+	add_executable(${TARGET} ${TARGET}.cpp $<TARGET_OBJECTS:geoprojectionconverter>)
+endforeach(TARGET)
+
+foreach(TARGET ${STANDALONE_TARGETS})
+	add_executable(${TARGET} ${TARGET}.cpp)
+endforeach(TARGET)
+
+foreach(TARGET ${ALL_TARGETS})
+	target_link_libraries(${TARGET} LASlib)
+	set_target_properties(${TARGET} PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin)
+	install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+endforeach(TARGET)


### PR DESCRIPTION
Hi, I wanted to take a stab at https://github.com/LAStools/LAStools/issues/18 by implementing some CMake build files. I'm not sure what requirements you are looking for from the build system, but here is what I have working so far:

Running `make` after setting up cmake will:
- Compile the executables in `src/` to `bin/`
- Compile `LASlib/src/` to `LASlib/lib/libLASlib.a`
- Compile executables into `LASlib/example`
- Compile executables into `LASzip/example`

Running `make install` after setting up cmake will:
- Generate `/usr/local/lib/libLASlib.a`
- Copy `LASlib/inc/*.hpp` to `/usr/local/include/LASlib/*.hpp`
- Copy `LASzip/src/*.hpp` to `/usr/local/include/LASlib/*.hpp`

This way you should be able to statically link against `LASlib` and add `-ILASlib` to any other code you are compiling.

If necessary I can add wrappers to the main Makefile so that `make`, `make clean` and `make install` do what they are supposed to. Unfortunately I don't have access to a windows machine so I can't test whether it is fully cross-platform, or whether it plays nicely with visual studio. Let me know if you have any feedback, and I will be happy to try and address it.