### PR TITLE
Replaced _strdup calls with the LASCopyString macro for platform compatibility

### DIFF
--- a/LASlib/inc/lasreader_bil.hpp
+++ b/LASlib/inc/lasreader_bil.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  lasreader_bil.hpp
-  
+
   CONTENTS:
-  
+
     Reads a binary BIL raster (*.bil + *.hdr) as if it was a LiDAR point cloud.
 
   PROGRAMMERS:
@@ -21,12 +21,13 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     20 June 2017 -- fixed reading of signed versus unsigned 16 and 8 bit intergers
      3 April 2012 -- created after joining the Spar Europe 2012 Advisory Board
-  
+
 ===============================================================================
 */
 #ifndef LAS_READER_BIL_HPP

--- a/LASlib/inc/lasreader_ply.hpp
+++ b/LASlib/inc/lasreader_ply.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  lasreader_ply.hpp
-  
+
   CONTENTS:
-  
+
     Reads LIDAR points from binary PLY format through on-the-fly conversion.
 
   PROGRAMMERS:
@@ -21,11 +21,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     4 September 2018 -- created after returning to Samara with locks changed
-  
+
 ===============================================================================
 */
 #ifndef LAS_READER_PLY_HPP

--- a/LASlib/inc/lasreader_txt.hpp
+++ b/LASlib/inc/lasreader_txt.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  lasreader_txt.hpp
-  
+
   CONTENTS:
-  
+
     Reads LIDAR points in LAS format through on-the-fly conversion from ASCII.
 
   PROGRAMMERS:
@@ -21,16 +21,17 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
    22 July 2018 -- bug fix for parsing classfication to point type 6 (or higher)
    11 January 2017 -- added with<h>eld and scanner channe<l> for the parse string
    11 January 2017 -- added 'k'eypoint and 'o'verlap flags for the parse string
    17 January 2016 -- pre-scaling and pre-offsetting of "extra bytes" attributes
     9 July 2014 -- allowing input from stdin after the 7:1 in the World Cup
     8 April 2011 -- created after starting a google group for LAStools users
-  
+
 ===============================================================================
 */
 #ifndef LAS_READER_TXT_HPP

--- a/LASlib/inc/lasreadermerged.hpp
+++ b/LASlib/inc/lasreadermerged.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  lasreadermerged.hpp
-  
+
   CONTENTS:
-  
+
     Reads LiDAR points from the LAS format from more than one file.
 
   PROGRAMMERS:
@@ -21,13 +21,14 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
      1 December 2017 -- support extra bytes during '-merged' operations
-     3 May 2015 -- header sets file source ID to 0 when merging flightlines 
+     3 May 2015 -- header sets file source ID to 0 when merging flightlines
     20 January 2011 -- created missing Livermore and my Extra Virgin Olive Oil
-  
+
 ===============================================================================
 */
 #ifndef LAS_READER_MERGED_HPP

--- a/LASlib/inc/laswaveform13reader.hpp
+++ b/LASlib/inc/laswaveform13reader.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswaveform13reader.hpp
-  
+
   CONTENTS:
-  
+
     Interface to read the Waveform Data Packets that are associated with points
     of type 4 and 5 in LAS 1.3.
 
@@ -22,11 +22,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     17 October 2011 -- created after bauarbeiter on the roof next door woke me
-  
+
 ===============================================================================
 */
 #ifndef LAS_WAVEFORM_13_READER_HPP

--- a/LASlib/inc/laswaveform13writer.hpp
+++ b/LASlib/inc/laswaveform13writer.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswaveform13writer.hpp
-  
+
   CONTENTS:
-  
+
     Interface to write the Waveform Data Packets that are associated with points
     of type 4 and 5 in LAS 1.3.
 
@@ -22,11 +22,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     17 October 2011 -- created after bauarbeiter on the roof next door woke me
-  
+
 ===============================================================================
 */
 #ifndef LAS_WAVEFORM_13_WRITER_HPP

--- a/LASlib/inc/laswriter.hpp
+++ b/LASlib/inc/laswriter.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswriter.hpp
-  
+
   CONTENTS:
-  
+
     Interface to write LIDAR points to the LAS format versions 1.0 - 1.4 and
     per on-the-fly conversion to simple ASCII files.
 
@@ -22,12 +22,13 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     17 August 2017 -- switch on "native LAS 1.4 extension". turns off with '-no_native'.
     29 March 2017 -- enable "native LAS 1.4 extension" for LASzip via '-native'
-    13 November 2016 -- return early FALSE when set_directory() will not succeed  
+    13 November 2016 -- return early FALSE when set_directory() will not succeed
     5 September 2011 -- support for writing Terrasolid's BIN format
     11 June 2011 -- billion point support: p_count & npoints are 64 bit counters
     8 May 2011 -- DO NOT USE option for variable chunking via chunk()
@@ -35,9 +36,9 @@
     24 January 2011 -- introduced LASwriteOpener
     21 January 2011 -- turned into abstract reader to support multiple files
     3 December 2010 -- updated to (somewhat) support LAS format 1.3
-    7 September 2008 -- updated to support LAS format 1.2 
+    7 September 2008 -- updated to support LAS format 1.2
     21 February 2007 -- created after eating Sarah's veggies with peanutsauce
-  
+
 ===============================================================================
 */
 #ifndef LAS_WRITER_HPP

--- a/LASlib/inc/laswriter_txt.hpp
+++ b/LASlib/inc/laswriter_txt.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswriter_txt.hpp
-  
+
   CONTENTS:
-  
+
     Writes LIDAR points to ASCII through on-the-fly conversion from LAS.
 
   PROGRAMMERS:
@@ -21,11 +21,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     10 April 2011 -- created after a sunny weekend of biking to/from Buergel
-  
+
 ===============================================================================
 */
 #ifndef LAS_WRITER_TXT_HPP

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  lasreader.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "lasreader.hpp"
@@ -79,7 +79,7 @@ LASreader::LASreader()
   orig_max_x = 0;
   orig_max_y = 0;
 }
-  
+
 LASreader::~LASreader()
 {
   if (index) delete index;
@@ -1662,7 +1662,7 @@ BOOL LASreadOpener::parse(int argc, char* argv[])
           return FALSE;
         }
         set_inside_tile((F32)atof(argv[i+1]), (F32)atof(argv[i+2]), (F32)atof(argv[i+3]));
-        *argv[i]='\0'; *argv[i+1]='\0'; *argv[i+2]='\0'; *argv[i+3]='\0'; i+=3; 
+        *argv[i]='\0'; *argv[i+1]='\0'; *argv[i+2]='\0'; *argv[i+3]='\0'; i+=3;
       }
       else if (strcmp(argv[i],"-inside_circle") == 0)
       {
@@ -1682,7 +1682,7 @@ BOOL LASreadOpener::parse(int argc, char* argv[])
           return FALSE;
         }
         set_inside_rectangle(atof(argv[i+1]), atof(argv[i+2]), atof(argv[i+3]), atof(argv[i+4]));
-        *argv[i]='\0'; *argv[i+1]='\0'; *argv[i+2]='\0'; *argv[i+3]='\0'; *argv[i+4]='\0'; i+=4; 
+        *argv[i]='\0'; *argv[i+1]='\0'; *argv[i+2]='\0'; *argv[i+3]='\0'; *argv[i+4]='\0'; i+=4;
       }
       else
       {
@@ -1940,7 +1940,7 @@ BOOL LASreadOpener::parse(int argc, char* argv[])
         fprintf(stderr,"ERROR: '%s' needs 1 argument: base name\n", argv[i]);
         return FALSE;
       }
-      temp_file_base = _strdup(argv[i+1]);
+      temp_file_base = LASCopyString(argv[i+1]);
       *argv[i]='\0'; *argv[i+1]='\0'; i+=1;
     }
     else if (strcmp(argv[i],"-neighbors") == 0)
@@ -1978,7 +1978,7 @@ BOOL LASreadOpener::parse(int argc, char* argv[])
       {
         // find end of line
         int len = strlen(line) - 1;
-        // remove extra white spaces and line return at the end 
+        // remove extra white spaces and line return at the end
         while (len > 0 && ((line[len] == '\n') || (line[len] == ' ') || (line[len] == '\t') || (line[len] == '\012')))
         {
           line[len] = '\0';
@@ -2326,7 +2326,7 @@ BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
       fprintf(stderr, "ERROR: alloc for file_names pointer array failed at %d\n", file_name_allocated);
     }
   }
-  file_names[file_name_number] = _strdup(file_name);
+  file_names[file_name_number] = LASCopyString(file_name);
   file_name_number++;
   return TRUE;
 }
@@ -2344,7 +2344,7 @@ BOOL LASreadOpener::add_list_of_files(const CHAR* list_of_files, BOOL unique)
   {
     // find end of line
     int len = strlen(line) - 1;
-    // remove extra white spaces and line return at the end 
+    // remove extra white spaces and line return at the end
     while (len > 0 && ((line[len] == '\n') || (line[len] == ' ') || (line[len] == '\t') || (line[len] == '\012')))
     {
       line[len] = '\0';
@@ -2452,7 +2452,7 @@ BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL 
       fprintf(stderr, "ERROR: alloc for neighbor_file_names pointer array failed at %d\n", neighbor_file_name_allocated);
     }
   }
-  neighbor_file_names[neighbor_file_name_number] = _strdup(neighbor_file_name);
+  neighbor_file_names[neighbor_file_name_number] = LASCopyString(neighbor_file_name);
   neighbor_file_name_number++;
   return TRUE;
 }
@@ -2472,7 +2472,7 @@ void LASreadOpener::set_parse_string(const CHAR* parse_string)
   if (this->parse_string) free(this->parse_string);
   if (parse_string)
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
   else
   {
@@ -2540,8 +2540,8 @@ void LASreadOpener::set_scale_scan_angle(F32 scale_scan_angle)
 void LASreadOpener::add_attribute(I32 data_type, const CHAR* name, const CHAR* description, F64 scale, F64 offset, F64 pre_scale, F64 pre_offset, F64 no_data)
 {
   attribute_data_types[number_attributes] = data_type;
-  attribute_names[number_attributes] = (name ? _strdup(name) : 0);
-  attribute_descriptions[number_attributes] = (description ? _strdup(description) : 0);
+  attribute_names[number_attributes] = (name ? LASCopyString(name) : 0);
+  attribute_descriptions[number_attributes] = (description ? LASCopyString(description) : 0);
   attribute_scales[number_attributes] = scale;
   attribute_offsets[number_attributes] = offset;
   attribute_pre_scales[number_attributes] = pre_scale;

--- a/LASlib/src/lasreader_bil.cpp
+++ b/LASlib/src/lasreader_bil.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  lasreader_bil.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "lasreader_bil.hpp"
@@ -348,7 +348,7 @@ BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
   // create *.hdr file name
 
   I32 len = strlen(file_name) - 3;
-  CHAR* file_name_hdr = _strdup(file_name);
+  CHAR* file_name_hdr = LASCopyString(file_name);
 
   while ((len > 0) && (file_name_hdr[len] != '.')) len--;
 
@@ -445,7 +445,7 @@ BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
       {
         floatpixels = TRUE;
       }
-      else if ((strcmp(pixeltype, "signedint") == 0) || (strcmp(pixeltype, "SIGNEDINT") == 0)) 
+      else if ((strcmp(pixeltype, "signedint") == 0) || (strcmp(pixeltype, "SIGNEDINT") == 0))
       {
         signedpixels = TRUE;
       }
@@ -521,7 +521,7 @@ BOOL LASreaderBIL::read_blw_file(const CHAR* file_name)
   // create *.blw file name
 
   I32 len = strlen(file_name) - 3;
-  CHAR* file_name_bwl = _strdup(file_name);
+  CHAR* file_name_bwl = LASCopyString(file_name);
 
   while ((len > 0) && (file_name_bwl[len] != '.')) len--;
 

--- a/LASlib/src/lasreader_ply.cpp
+++ b/LASlib/src/lasreader_ply.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  lasreader_ply.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "lasreader_ply.hpp"
@@ -92,7 +92,7 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     {
       I32 type = (attributes_data_types[i]-1)%10;
       I32 dim = (attributes_data_types[i]-1)/10 + 1;
-      try { 
+      try {
         LASattribute attribute(type, attribute_names[i], attribute_descriptions[i], dim);
         if (attribute_scales[i] != 1.0 || attribute_offsets[i] != 0.0)
         {
@@ -162,7 +162,7 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
 
   if (point_type)
   {
-    switch (point_type) 
+    switch (point_type)
     {
     case 1:
       header.point_data_record_length = 28;
@@ -263,7 +263,7 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
   point.init(&header, header.point_data_format, header.point_data_record_length, &header);
 
   // we do not know yet how many points to expect
-  
+
   npoints = 0;
 
   // should we perform an extra pass to fully populate the header
@@ -275,14 +275,14 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     char* parse_less;
     if (parse_string == 0)
     {
-      parse_less = _strdup("xyz");
+      parse_less = LASCopyString("xyz");
     }
     else
     {
-      parse_less = _strdup(parse_string);
+      parse_less = LASCopyString(parse_string);
       for (i = 0; i < (int)strlen(parse_string); i++)
       {
-        if (parse_less[i] != 'x' && parse_less[i] != 'y' && parse_less[i] != 'z' && parse_less[i] != 'r' && (parse_less[i] < '0' || parse_less[i] > '0')) 
+        if (parse_less[i] != 'x' && parse_less[i] != 'y' && parse_less[i] != 'z' && parse_less[i] != 'r' && (parse_less[i] < '0' || parse_less[i] > '0'))
         {
           parse_less[i] = 's';
         }
@@ -319,7 +319,7 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
       fprintf(stderr, "ERROR: could not parse any lines with '%s'\n", parse_less);
       fclose(file);
       file = 0;
-      free(parse_less);    
+      free(parse_less);
       return FALSE;
     }
 
@@ -409,9 +409,9 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     free(parse_less);
 
     // close the input file
-    
+
     fclose(file);
-    
+
     // populate scale and offset
 
     populate_scale_and_offset();
@@ -441,11 +441,11 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
 
   if (parse_string == 0)
   {
-    this->parse_string = _strdup("xyz");
+    this->parse_string = LASCopyString("xyz");
   }
   else
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
 
   // read the first line with full parse_string
@@ -477,7 +477,7 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     this->parse_string = 0;
     return FALSE;
   }
-  
+
   if (!populated_header)
   {
     // init the bounding box that we will incrementally compute
@@ -554,17 +554,17 @@ void LASreaderPLY::add_attribute(I32 data_type, const char* name, const char* de
   attributes_data_types[number_attributes] = data_type;
   if (name)
   {
-    attribute_names[number_attributes] = _strdup(name);
+    attribute_names[number_attributes] = LASCopyString(name);
   }
   else
   {
     char temp[32];
     sprintf(temp, "attribute %d", number_attributes);
-    attribute_names[number_attributes] = _strdup(temp);
+    attribute_names[number_attributes] = LASCopyString(temp);
   }
   if (description)
   {
-    attribute_descriptions[number_attributes] = _strdup(description);
+    attribute_descriptions[number_attributes] = LASCopyString(description);
   }
   else
   {
@@ -1299,10 +1299,10 @@ BOOL LASreaderPLY::parse(const char* parse_string)
       if (l[0] == 0) return FALSE;
       hex_string[0] = l[0]; hex_string[1] = l[1];
       sscanf(hex_string,"%x",&hex_value);
-      point.rgb[0] = hex_value; 
+      point.rgb[0] = hex_value;
       hex_string[0] = l[2]; hex_string[1] = l[3];
       sscanf(hex_string,"%x",&hex_value);
-      point.rgb[1] = hex_value; 
+      point.rgb[1] = hex_value;
       hex_string[0] = l[4]; hex_string[1] = l[5];
       sscanf(hex_string,"%x",&hex_value);
       point.rgb[2] = hex_value;
@@ -1465,7 +1465,7 @@ BOOL LASreaderPLY::parse_header(FILE* file)
   {
     // next line
     fgets(line, 512, file);
-    
+
     if (strncmp(line, "format", 6) == 0)
     {
       if (strncmp(&line[7], "binary_little_endian 1.0", 24) == 0)

--- a/LASlib/src/lasreader_txt.cpp
+++ b/LASlib/src/lasreader_txt.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  lasreader_txt.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "lasreader_txt.hpp"
@@ -92,7 +92,7 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     {
       I32 type = (attributes_data_types[i]-1)%10;
       I32 dim = (attributes_data_types[i]-1)/10 + 1;
-      try { 
+      try {
         LASattribute attribute(type, attribute_names[i], attribute_descriptions[i], dim);
         if (attribute_scales[i] != 1.0 || attribute_offsets[i] != 0.0)
         {
@@ -154,7 +154,7 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
 #endif
   if (point_type)
   {
-    switch (point_type) 
+    switch (point_type)
     {
     case 1:
       header.point_data_record_length = 28;
@@ -255,7 +255,7 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
   point.init(&header, header.point_data_format, header.point_data_record_length, &header);
 
   // we do not know yet how many points to expect
-  
+
   npoints = 0;
 
   // should we perform an extra pass to fully populate the header
@@ -267,14 +267,14 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     char* parse_less;
     if (parse_string == 0)
     {
-      parse_less = _strdup("xyz");
+      parse_less = LASCopyString("xyz");
     }
     else
     {
-      parse_less = _strdup(parse_string);
+      parse_less = LASCopyString(parse_string);
       for (i = 0; i < (int)strlen(parse_string); i++)
       {
-        if (parse_less[i] != 'x' && parse_less[i] != 'y' && parse_less[i] != 'z' && parse_less[i] != 'r' && (parse_less[i] < '0' || parse_less[i] > '0')) 
+        if (parse_less[i] != 'x' && parse_less[i] != 'y' && parse_less[i] != 'z' && parse_less[i] != 'r' && (parse_less[i] < '0' || parse_less[i] > '0'))
         {
           parse_less[i] = 's';
         }
@@ -315,7 +315,7 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
       fprintf(stderr, "ERROR: could not parse any lines with '%s'\n", parse_less);
       fclose(file);
       file = 0;
-      free(parse_less);    
+      free(parse_less);
       return FALSE;
     }
 
@@ -405,9 +405,9 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     free(parse_less);
 
     // close the input file
-    
+
     fclose(file);
-    
+
     // populate scale and offset
 
     populate_scale_and_offset();
@@ -437,11 +437,11 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
 
   if (parse_string == 0)
   {
-    this->parse_string = _strdup("xyz");
+    this->parse_string = LASCopyString("xyz");
   }
   else
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
 
   // skip lines if we have to
@@ -704,7 +704,7 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
     this->parse_string = 0;
     return FALSE;
   }
-  
+
   if (!populated_header)
   {
     // init the bounding box that we will incrementally compute
@@ -805,17 +805,17 @@ void LASreaderTXT::add_attribute(I32 data_type, const char* name, const char* de
   attributes_data_types[number_attributes] = data_type;
   if (name)
   {
-    attribute_names[number_attributes] = _strdup(name);
+    attribute_names[number_attributes] = LASCopyString(name);
   }
   else
   {
     char temp[32];
     sprintf(temp, "attribute %d", number_attributes);
-    attribute_names[number_attributes] = _strdup(temp);
+    attribute_names[number_attributes] = LASCopyString(temp);
   }
   if (description)
   {
-    attribute_descriptions[number_attributes] = _strdup(description);
+    attribute_descriptions[number_attributes] = LASCopyString(description);
   }
   else
   {
@@ -1558,10 +1558,10 @@ BOOL LASreaderTXT::parse(const char* parse_string)
       if (l[0] == 0) return FALSE;
       hex_string[0] = l[0]; hex_string[1] = l[1];
       sscanf(hex_string,"%x",&hex_value);
-      point.rgb[0] = hex_value; 
+      point.rgb[0] = hex_value;
       hex_string[0] = l[2]; hex_string[1] = l[3];
       sscanf(hex_string,"%x",&hex_value);
-      point.rgb[1] = hex_value; 
+      point.rgb[1] = hex_value;
       hex_string[0] = l[4]; hex_string[1] = l[5];
       sscanf(hex_string,"%x",&hex_value);
       point.rgb[2] = hex_value;

--- a/LASlib/src/lasreadermerged.cpp
+++ b/LASlib/src/lasreadermerged.cpp
@@ -2,17 +2,17 @@
 ===============================================================================
 
   FILE:  lasreadermerged.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2012, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "lasreadermerged.hpp"
@@ -413,7 +413,7 @@ BOOL LASreaderMerged::add_file_name(const char* file_name)
       return FALSE;
     }
   }
-  file_names[file_name_number] = _strdup(file_name);
+  file_names[file_name_number] = LASCopyString(file_name);
   file_name_number++;
   return TRUE;
 }
@@ -495,7 +495,7 @@ void LASreaderMerged::set_parse_string(const char* parse_string)
   if (this->parse_string) free(this->parse_string);
   if (parse_string)
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
   else
   {
@@ -692,7 +692,7 @@ BOOL LASreaderMerged::open()
         // have there not been any points before
         if (npoints == lasreader->npoints)
         {
-          // use the counters 
+          // use the counters
           header.number_of_point_records = lasreader->header.number_of_point_records;
           for (j = 0; j < 5; j++)
           {
@@ -728,7 +728,7 @@ BOOL LASreaderMerged::open()
         }
         else
         {
-          // increment point counters 
+          // increment point counters
           header.number_of_point_records += lasreader->header.number_of_point_records;
           for (j = 0; j < 5; j++)
           {
@@ -913,7 +913,7 @@ BOOL LASreaderMerged::open()
       reoffset = TRUE;
     }
   }
-    
+
   // check y
 
   if ((((header.max_y - header.y_offset) / header.y_scale_factor) > I32_MAX) || (((header.min_y - header.y_offset) / header.y_scale_factor) < I32_MIN))
@@ -939,7 +939,7 @@ BOOL LASreaderMerged::open()
       reoffset = TRUE;
     }
   }
-    
+
   // check z
 
   if ((((header.max_z - header.z_offset) / header.z_scale_factor) > I32_MAX) || (((header.min_z - header.z_offset) / header.z_scale_factor) < I32_MIN))
@@ -1196,7 +1196,7 @@ BOOL LASreaderMerged::read_point_default()
 
 void LASreaderMerged::close(BOOL close_stream)
 {
-  if (lasreader) 
+  if (lasreader)
   {
     lasreader->close(close_stream);
   }
@@ -1213,7 +1213,7 @@ BOOL LASreaderMerged::reopen()
 
 void LASreaderMerged::clean()
 {
-  if (lasreader) 
+  if (lasreader)
   {
     delete lasreader;
     lasreader = 0;

--- a/LASlib/src/laswaveform13reader.cpp
+++ b/LASlib/src/laswaveform13reader.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  laswaveform13reader.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "laswaveform13reader.hpp"
@@ -63,7 +63,7 @@ LASwaveform13reader::LASwaveform13reader()
   ic8 = 0;
   ic16 = 0;
 }
-  
+
 LASwaveform13reader::~LASwaveform13reader()
 {
   if (samples) delete [] samples;
@@ -108,17 +108,17 @@ BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data
 
   if (start_of_waveform_data_packet_record == 0)
   {
-    if (!compressed && (strstr(".wdp", file_name) || strstr(".WDP", file_name))) 
+    if (!compressed && (strstr(".wdp", file_name) || strstr(".WDP", file_name)))
     {
       file = fopen(file_name, "rb");
     }
-    else if (compressed && (strstr(".wdz", file_name) || strstr(".WDZ", file_name))) 
+    else if (compressed && (strstr(".wdz", file_name) || strstr(".WDZ", file_name)))
     {
       file = fopen(file_name, "rb");
     }
     else
     {
-      char* file_name_temp = _strdup(file_name);
+      char* file_name_temp = LASCopyString(file_name);
       int len = strlen(file_name_temp);
       if ((file_name_temp[len-3] == 'L') || (file_name_temp[len-3] == 'W'))
       {
@@ -173,7 +173,7 @@ BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data
 
   if (strncmp(magic, "LAStools waveform ", 18) == 0)
   {
-    // do waveform descriptor cross-check 
+    // do waveform descriptor cross-check
 
     U16 i, number;
     try { stream->get16bitsLE((U8*)&number); } catch(...)
@@ -278,7 +278,7 @@ BOOL LASwaveform13reader::read_waveform(const LASpoint* point)
   nsamples = wave_packet_descr[index]->getNumberOfSamples();
 
 //  temporary Optech Fix
-//  nsamples = point->wavepacket.getSize(); 
+//  nsamples = point->wavepacket.getSize();
 //  if (nbits == 16) nsamples / 2;
 
   if (nsamples == 0)

--- a/LASlib/src/laswaveform13writer.cpp
+++ b/LASlib/src/laswaveform13writer.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  laswaveform13writer.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "laswaveform13writer.hpp"
@@ -51,7 +51,7 @@ LASwaveform13writer::LASwaveform13writer()
   ic8 = 0;
   ic16 = 0;
 }
-  
+
 LASwaveform13writer::~LASwaveform13writer()
 {
   if (waveforms)
@@ -120,7 +120,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
 
   // create file name and open file
 
-  char* file_name_temp = _strdup(file_name);
+  char* file_name_temp = LASCopyString(file_name);
 
   int len = strlen(file_name_temp);
   if (file_name_temp[len-3] == 'L' || file_name_temp[len-3] == 'W')
@@ -186,7 +186,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
   }
   I8 description[32];
   memset(description, 0, 32);
-  sprintf(description, "%s by LAStools (%d)", (compressed ? "compressed" : "created"), LAS_TOOLS_VERSION);  
+  sprintf(description, "%s by LAStools (%d)", (compressed ? "compressed" : "created"), LAS_TOOLS_VERSION);
   if (!stream->putBytes((U8*)description, 32))
   {
     fprintf(stderr,"ERROR: writing EVLR description\n");

--- a/LASlib/src/laswriter.cpp
+++ b/LASlib/src/laswriter.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  laswriter.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "laswriter.hpp"
@@ -432,7 +432,7 @@ BOOL LASwriteOpener::set_directory(const CHAR* directory)
       fprintf(stderr,"         probably fail. please use -odir \"D:\" or -odir \"..\\tiles\"\n");
       fprintf(stderr,"         instead.\n");
     }
-    this->directory = _strdup(directory);
+    this->directory = LASCopyString(directory);
     int len = strlen(this->directory);
     if ((len > 0) && ((this->directory[len-1] == '\\') || (this->directory[len-1] == '/')))
     {
@@ -468,7 +468,7 @@ void LASwriteOpener::set_file_name(const CHAR* file_name)
   if (this->file_name) free(this->file_name);
   if (file_name)
   {
-    this->file_name = _strdup(file_name);
+    this->file_name = LASCopyString(file_name);
 
     // get length of file name
     int len = strlen(this->file_name);
@@ -605,7 +605,7 @@ void LASwriteOpener::set_appendix(const CHAR* appendix)
   if (this->appendix) free(this->appendix);
   if (appendix)
   {
-    this->appendix = _strdup(appendix);
+    this->appendix = LASCopyString(appendix);
     if (file_name) add_appendix();
   }
   else
@@ -631,7 +631,7 @@ BOOL LASwriteOpener::set_format(I32 format)
   {
     return FALSE;
   }
-  
+
   specified = TRUE;
   this->format = format;
 
@@ -749,7 +749,7 @@ void LASwriteOpener::make_numbered_file_name(const CHAR* file_name, I32 digits)
   }
   else
   {
-    if (this->file_name == 0) this->file_name = _strdup("output.xxx");
+    if (this->file_name == 0) this->file_name = LASCopyString("output.xxx");
     len = strlen(this->file_name);
     this->file_name = (CHAR*)realloc(this->file_name, len + digits + 2);
   }
@@ -798,7 +798,7 @@ void LASwriteOpener::make_file_name(const CHAR* file_name, I32 file_number)
     {
       if (this->file_name == 0)
       {
-        this->file_name = _strdup("output_0000000.xxx");
+        this->file_name = LASCopyString("output_0000000.xxx");
       }
       len = strlen(this->file_name);
     }
@@ -848,7 +848,7 @@ void LASwriteOpener::make_file_name(const CHAR* file_name, I32 file_number)
     else
     {
       len = 7;
-      this->file_name = _strdup("output.xxx");
+      this->file_name = LASCopyString("output.xxx");
     }
   }
   if (format <= LAS_TOOLS_FORMAT_LAS)
@@ -892,27 +892,27 @@ void LASwriteOpener::make_file_name(const CHAR* file_name, I32 file_number)
       free(this->file_name);
       if (format <= LAS_TOOLS_FORMAT_LAS)
       {
-        this->file_name = _strdup("temp.las");
+        this->file_name = LASCopyString("temp.las");
       }
       else if (format == LAS_TOOLS_FORMAT_LAZ)
       {
-        this->file_name = _strdup("temp.laz");
+        this->file_name = LASCopyString("temp.laz");
       }
       else if (format == LAS_TOOLS_FORMAT_BIN)
       {
-        this->file_name = _strdup("temp.bin");
+        this->file_name = LASCopyString("temp.bin");
       }
       else if (format == LAS_TOOLS_FORMAT_QFIT)
       {
-        this->file_name = _strdup("temp.qi");
+        this->file_name = LASCopyString("temp.qi");
       }
       else if (format == LAS_TOOLS_FORMAT_VRML)
       {
-        this->file_name = _strdup("temp.wrl");
+        this->file_name = LASCopyString("temp.wrl");
       }
       else // if (format == LAS_TOOLS_FORMAT_TXT)
       {
-        this->file_name = _strdup("temp.txt");
+        this->file_name = LASCopyString("temp.txt");
       }
       fprintf(stderr,"WARNING: generated output name '%s'\n", file_name);
       fprintf(stderr,"         identical to input name. changed to '%s'.\n", this->file_name);
@@ -937,7 +937,7 @@ CHAR* LASwriteOpener::get_file_name_base() const
 
   if (file_name)
   {
-    file_name_base = _strdup(file_name);
+    file_name_base = LASCopyString(file_name);
     // remove extension
     int len = strlen(file_name_base);
     while ((len > 0) && (file_name_base[len] != '.') && (file_name_base[len] != '\\') && (file_name_base[len] != '/') && (file_name_base[len] != ':')) len--;
@@ -1044,7 +1044,7 @@ void LASwriteOpener::set_parse_string(const CHAR* parse_string)
   if (this->parse_string) free(this->parse_string);
   if (parse_string)
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
   else
   {
@@ -1057,7 +1057,7 @@ void LASwriteOpener::set_separator(const CHAR* separator)
   if (this->separator) free(this->separator);
   if (separator)
   {
-    this->separator = _strdup(separator);
+    this->separator = LASCopyString(separator);
   }
   else
   {
@@ -1100,7 +1100,7 @@ void LASwriteOpener::add_appendix(const CHAR* appendix)
     I32 len = strlen(file_name);
     CHAR* new_file_name = (CHAR*)malloc(len + strlen(appendix) + 5);
     while ((len > 0) && (file_name[len] != '.') && (file_name[len] != '\\') && (file_name[len] != '/') && (file_name[len] != ':')) len--;
-    
+
     if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
     {
       sprintf(new_file_name, "%s%s", file_name, appendix);
@@ -1124,7 +1124,7 @@ void LASwriteOpener::cut_characters(U32 cut)
     I32 len = strlen(file_name);
     CHAR* new_file_name = (CHAR*)malloc(len - cut + 5);
     while ((len > 0) && (file_name[len] != '.') && (file_name[len] != '\\') && (file_name[len] != '/') && (file_name[len] != ':')) len--;
-    
+
     if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
     {
       len = strlen(file_name);

--- a/LASlib/src/laswriter_txt.cpp
+++ b/LASlib/src/laswriter_txt.cpp
@@ -2,11 +2,11 @@
 ===============================================================================
 
   FILE:  laswriter_txt.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "laswriter_txt.hpp"
@@ -89,7 +89,7 @@ BOOL LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_s
   if (this->parse_string) free (this->parse_string);
   if (parse_string)
   {
-    this->parse_string = _strdup(parse_string);
+    this->parse_string = LASCopyString(parse_string);
   }
   else
   {
@@ -145,11 +145,11 @@ BOOL LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_s
         if (this->parse_string) free(this->parse_string);
         if (ptsVLR && (ptsVLR->record_length_after_header >= 32))
         {
-          this->parse_string = _strdup((CHAR*)(ptsVLR->data + 16));
+          this->parse_string = LASCopyString((CHAR*)(ptsVLR->data + 16));
         }
         else if (ptxVLR && (ptxVLR->record_length_after_header >= 32))
         {
-          this->parse_string = _strdup((CHAR*)(ptxVLR->data + 16));
+          this->parse_string = LASCopyString((CHAR*)(ptxVLR->data + 16));
         }
         else if (ptsVLR)
         {
@@ -196,7 +196,7 @@ BOOL LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_s
       if ((this->parse_string == 0) || (strcmp(this->parse_string, "original") == 0))
       {
         if (this->parse_string) free(this->parse_string);
-        this->parse_string = _strdup((CHAR*)(payload + 16));
+        this->parse_string = LASCopyString((CHAR*)(payload + 16));
       }
       fprintf(file, "%u     \012", (U32)((I64*)payload)[4]); // ncols
       fprintf(file, "%u     \012", (U32)((I64*)payload)[5]); // nrows
@@ -247,19 +247,19 @@ BOOL LASwriterTXT::open(FILE* file, const LASheader* header, const CHAR* parse_s
   {
     if (header->point_data_format == 1 || header->point_data_format == 4)
     {
-      this->parse_string = _strdup("xyzt");
+      this->parse_string = LASCopyString("xyzt");
     }
     else if (header->point_data_format == 2)
     {
-      this->parse_string = _strdup("xyzRGB");
+      this->parse_string = LASCopyString("xyzRGB");
     }
     else if (header->point_data_format == 3 || header->point_data_format == 5)
     {
-      this->parse_string = _strdup("xyztRGB");
+      this->parse_string = LASCopyString("xyztRGB");
     }
     else
     {
-      this->parse_string = _strdup("xyz");
+      this->parse_string = LASCopyString("xyz");
     }
   }
 

--- a/LASzip/example/laszipdllexample.cpp
+++ b/LASzip/example/laszipdllexample.cpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laszipdllexample.cpp
-  
+
   CONTENTS:
-  
+
     This source code implements several different  easy-to-follow examples on
     how to use the LASzip DLL. The first and the second examples implement a
     small compression and decompression utilitity. The third example shows
@@ -24,11 +24,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
+     7 September 2018 -- introduced the LASCopyString macro to replace _strdup
     28 May 2017 -- 14th example reads compressed LAS 1.4 with "selective decompression"
-    25 April 2017 -- 13th example writes LAS 1.4 using new "native LAS 1.4 extension" 
+    25 April 2017 -- 13th example writes LAS 1.4 using new "native LAS 1.4 extension"
     11 January 2017 -- 12th example changes the default chunk size from 50000 to 5000
      8 January 2017 -- changed from "laszip_dll.h" to "laszip_api.h" because of hobu
     23 September 2015 -- 11th example writes without a-priori bounding box or counters
@@ -36,9 +37,9 @@
      5 September 2015 -- eighth and nineth example show pre-existing "extra bytes"
     19 July 2015 -- sixth and seventh example show LAS 1.4 compatibility mode
      2 April 2015 -- fourth and fifth example with integrated spatially indexing
-    11 August 2013 -- added third example for exporting geo-referenced points 
-    29 July 2013 -- created for the LASzip DLL after returning to Sommerhausen 
-  
+    11 August 2013 -- added third example for exporting geo-referenced points
+    29 July 2013 -- created for the LASzip DLL after returning to Sommerhausen
+
 ===============================================================================
 */
 
@@ -48,6 +49,13 @@
 #include <string.h>
 
 #include "laszip_api.h"
+
+#if defined(_MSC_VER) && \
+    (_MSC_FULL_VER >= 150000000)
+#define LASCopyString _strdup
+#else
+#define LASCopyString strdup
+#endif
 
 void usage(bool wait=false)
 {
@@ -82,7 +90,7 @@ static void dll_error(laszip_POINTER laszip)
 static void byebye(bool error=false, bool wait=false, laszip_POINTER laszip=0)
 {
   if (error)
-  {  
+  {
     dll_error(laszip);
   }
   if (wait)
@@ -152,15 +160,15 @@ int main(int argc, char *argv[])
     fprintf(stderr,"%s is better run in the command line\n", argv[0]);
     fprintf(stderr,"enter input file%s: ", ((EXAMPLE == EXAMPLE_THREE) ? " (not used)" : "")); fgets(file_name, 256, stdin);
     file_name[strlen(file_name)-1] = '\0';
-    file_name_in = _strdup(file_name);
+    file_name_in = LASCopyString(file_name);
     fprintf(stderr,"enter output file: "); fgets(file_name, 256, stdin);
     file_name[strlen(file_name)-1] = '\0';
-    file_name_out = _strdup(file_name);
+    file_name_out = LASCopyString(file_name);
   }
   else if (argc == 3)
   {
-    file_name_in = _strdup(argv[1]);
-    file_name_out = _strdup(argv[2]);
+    file_name_in = LASCopyString(argv[1]);
+    file_name_out = LASCopyString(argv[2]);
   }
   else
   {
@@ -194,7 +202,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -234,7 +242,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1);
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -251,7 +259,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -324,7 +332,7 @@ int main(int argc, char *argv[])
     fprintf(stderr,"total time: %g sec for reading %scompressed and writing %scompressed\n", taketime()-start_time, (is_compressed ? "" : "un"), (compress ? "" : "un"));
 
   } // end of EXAMPLE_ONE
-  
+
   if (EXAMPLE == EXAMPLE_TWO)
   {
     fprintf(stderr,"running EXAMPLE_TWO (another way of reading *without* and writing *without* compatibility mode)\n");
@@ -346,7 +354,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -401,7 +409,7 @@ int main(int argc, char *argv[])
     header_write->file_creation_day = header_read->file_creation_day;
     header_write->file_creation_year = header_read->file_creation_year;
     header_write->header_size = header_read->header_size;
-    header_write->offset_to_point_data = header_read->header_size; /* note !!! */ 
+    header_write->offset_to_point_data = header_read->header_size; /* note !!! */
     header_write->number_of_variable_length_records = header_read->number_of_variable_length_records;
     header_write->point_data_format = header_read->point_data_format;
     header_write->point_data_record_length = header_read->point_data_record_length;
@@ -476,7 +484,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the reader will be read
@@ -593,7 +601,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip reader\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for reading %scompressed and writing %scompressed\n", taketime()-start_time, (is_compressed ? "" : "un"), (compress ? "" : "un"));
 
   } // end of EXAMPLE_TWO
@@ -703,7 +711,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: adding funny VLR to the header\n");
       byebye(true, argc==1, laszip_writer);
     }
-    
+
     fprintf(stderr,"offset_to_point_data after adding two VLRs         : %d\n", (laszip_I32)header->offset_to_point_data);
 
     // open the writer
@@ -715,7 +723,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -788,10 +796,10 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // populate the third point
 
-    coordinates[0] = 630499.54;  
+    coordinates[0] = 630499.54;
     coordinates[1] = 4834749.66;
     coordinates[2] = 62.66;
 
@@ -819,7 +827,7 @@ int main(int argc, char *argv[])
 
     // populate the fourth point
 
-    coordinates[0] = 630498.56;     
+    coordinates[0] = 630498.56;
     coordinates[1] = 4834749.41;
     coordinates[2] = 63.68;
 
@@ -847,7 +855,7 @@ int main(int argc, char *argv[])
 
     // populate the fifth point
 
-    coordinates[0] = 630498.80; 
+    coordinates[0] = 630498.80;
     coordinates[1] = 4834748.73;
     coordinates[2] = 62.16;
 
@@ -872,7 +880,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // get the number of points written so far
 
     if (laszip_get_point_count(laszip_writer, &p_count))
@@ -898,7 +906,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip writer\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for writing %scompressed\n", taketime()-start_time, (compress ? "" : "un"));
 
   } // end of EXAMPLE_THREE
@@ -933,7 +941,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // check whether spatial indexing information is available
@@ -1010,7 +1018,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1);
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -1027,7 +1035,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -1120,7 +1128,7 @@ int main(int argc, char *argv[])
   if (EXAMPLE == EXAMPLE_FIVE)
   {
     fprintf(stderr,"running EXAMPLE_FIVE (reading from one file and writing to another file while simultaneously generating a spatial index)\n");
- 
+
     // create the reader
 
     laszip_POINTER laszip_reader;
@@ -1138,7 +1146,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -1178,7 +1186,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1);
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -1206,7 +1214,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' spatially indexed and %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -1360,7 +1368,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: adding funny VLR to the header\n");
       byebye(true, argc==1, laszip_writer);
     }
-    
+
     fprintf(stderr,"offset_to_point_data after adding VLRs                   : %d\n", (laszip_I32)header->offset_to_point_data);
 
     // open the writer
@@ -1374,7 +1382,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -1457,10 +1465,10 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // populate the third point
 
-    coordinates[0] = 630499.54;  
+    coordinates[0] = 630499.54;
     coordinates[1] = 4834749.66;
     coordinates[2] = 62.66;
 
@@ -1491,7 +1499,7 @@ int main(int argc, char *argv[])
 
     // populate the fourth point
 
-    coordinates[0] = 630498.56;     
+    coordinates[0] = 630498.56;
     coordinates[1] = 4834749.41;
     coordinates[2] = 63.68;
 
@@ -1522,7 +1530,7 @@ int main(int argc, char *argv[])
 
     // populate the fifth point
 
-    coordinates[0] = 630498.80; 
+    coordinates[0] = 630498.80;
     coordinates[1] = 4834748.73;
     coordinates[2] = 62.16;
 
@@ -1550,7 +1558,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // get the number of points written so far
 
     if (laszip_get_point_count(laszip_writer, &p_count))
@@ -1576,7 +1584,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip writer\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for writing %scompressed\n", taketime()-start_time, (compress ? "" : "un"));
 
   } // end of EXAMPLE_SIX
@@ -1661,7 +1669,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: adding funny VLR to the header\n");
       byebye(true, argc==1, laszip_writer);
     }
-    
+
     fprintf(stderr,"offset_to_point_data after adding VLRs                   : %d\n", (laszip_I32)header->offset_to_point_data);
 
     // enable the compatibility mode
@@ -1682,7 +1690,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -1765,10 +1773,10 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // populate the third point
 
-    coordinates[0] = 630499.54;  
+    coordinates[0] = 630499.54;
     coordinates[1] = 4834749.66;
     coordinates[2] = 62.66;
 
@@ -1799,7 +1807,7 @@ int main(int argc, char *argv[])
 
     // populate the fourth point
 
-    coordinates[0] = 630498.56;     
+    coordinates[0] = 630498.56;
     coordinates[1] = 4834749.41;
     coordinates[2] = 63.68;
 
@@ -1830,7 +1838,7 @@ int main(int argc, char *argv[])
 
     // populate the fifth point
 
-    coordinates[0] = 630498.80; 
+    coordinates[0] = 630498.80;
     coordinates[1] = 4834748.73;
     coordinates[2] = 62.16;
 
@@ -1859,7 +1867,7 @@ int main(int argc, char *argv[])
     }
     p_count++;
 
-    
+
     // get the number of points written so far
 
     if (laszip_get_point_count(laszip_writer, &p_count))
@@ -1885,11 +1893,11 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip writer\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for writing %scompressed\n", taketime()-start_time, (compress ? "" : "un"));
 
   } // end of EXAMPLE_SEVEN
-  
+
   if (EXAMPLE == EXAMPLE_EIGHT)
   {
     fprintf(stderr,"running EXAMPLE_EIGHT (always *with* compatibility mode when reading but when writing *only* for compressed output)\n");
@@ -1920,7 +1928,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -1976,7 +1984,7 @@ int main(int argc, char *argv[])
       }
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -1991,7 +1999,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -2163,7 +2171,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: adding funny VLR to the header\n");
       byebye(true, argc==1, laszip_writer);
     }
-    
+
     fprintf(stderr,"offset_to_point_data after adding VLRs                      : %d\n", (laszip_I32)header->offset_to_point_data);
 
     // enable the compatibility mode
@@ -2184,7 +2192,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -2279,10 +2287,10 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // populate the third point
 
-    coordinates[0] = 630499.54;  
+    coordinates[0] = 630499.54;
     coordinates[1] = 4834749.66;
     coordinates[2] = 62.66;
 
@@ -2319,7 +2327,7 @@ int main(int argc, char *argv[])
 
     // populate the fourth point
 
-    coordinates[0] = 630498.56;     
+    coordinates[0] = 630498.56;
     coordinates[1] = 4834749.41;
     coordinates[2] = 63.68;
 
@@ -2356,7 +2364,7 @@ int main(int argc, char *argv[])
 
     // populate the fifth point
 
-    coordinates[0] = 630498.80; 
+    coordinates[0] = 630498.80;
     coordinates[1] = 4834748.73;
     coordinates[2] = 62.16;
 
@@ -2390,7 +2398,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
     p_count++;
-    
+
     // get the number of points written so far
 
     if (laszip_get_point_count(laszip_writer, &p_count))
@@ -2416,7 +2424,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip writer\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for writing %scompressed\n", taketime()-start_time, (compress ? "" : "un"));
 
   } // end of EXAMPLE_NINE
@@ -2451,7 +2459,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -2540,7 +2548,7 @@ int main(int argc, char *argv[])
     header_write->file_creation_day = header_read->file_creation_day;
     header_write->file_creation_year = header_read->file_creation_year;
     header_write->header_size = header_read->header_size;
-    header_write->offset_to_point_data = header_read->header_size; /* note !!! */ 
+    header_write->offset_to_point_data = header_read->header_size; /* note !!! */
     header_write->number_of_variable_length_records = header_read->number_of_variable_length_records;
     header_write->point_data_format = header_read->point_data_format;
     header_write->point_data_record_length = header_read->point_data_record_length;
@@ -2668,7 +2676,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -2843,7 +2851,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: adding funny VLR to the header\n");
       byebye(true, argc==1, laszip_writer);
     }
-    
+
     fprintf(stderr,"offset_to_point_data after adding VLRs                   : %d\n", (laszip_I32)header->offset_to_point_data);
 
     // compressed output or not?
@@ -2869,7 +2877,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -2970,10 +2978,10 @@ int main(int argc, char *argv[])
     }
 
     p_count++;
-    
+
     // populate the third point
 
-    coordinates[0] = 630499.54;  
+    coordinates[0] = 630499.54;
     coordinates[1] = 4834749.66;
     coordinates[2] = 62.66;
 
@@ -3013,7 +3021,7 @@ int main(int argc, char *argv[])
 
     // populate the fourth point
 
-    coordinates[0] = 630498.56;     
+    coordinates[0] = 630498.56;
     coordinates[1] = 4834749.41;
     coordinates[2] = 63.68;
 
@@ -3053,7 +3061,7 @@ int main(int argc, char *argv[])
 
     // populate the fifth point
 
-    coordinates[0] = 630498.80; 
+    coordinates[0] = 630498.80;
     coordinates[1] = 4834748.73;
     coordinates[2] = 62.16;
 
@@ -3090,7 +3098,7 @@ int main(int argc, char *argv[])
     }
 
     p_count++;
-    
+
     // get the number of points written so far
 
     if (laszip_get_point_count(laszip_writer, &p_count))
@@ -3116,7 +3124,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip writer\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for writing %scompressed\n", taketime()-start_time, (compress ? "" : "un"));
 
   } // end of EXAMPLE_ELEVEN
@@ -3151,7 +3159,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -3207,7 +3215,7 @@ int main(int argc, char *argv[])
       }
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -3215,7 +3223,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
 
-    // change the chunk size from the default value to 50000 
+    // change the chunk size from the default value to 50000
 
     if (laszip_set_chunk_size(laszip_writer, 5000))
     {
@@ -3230,7 +3238,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -3334,7 +3342,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -3383,7 +3391,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -3402,7 +3410,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -3515,7 +3523,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -3564,7 +3572,7 @@ int main(int argc, char *argv[])
       byebye(true, argc==1, laszip_writer);
     }
 
-    // initialize the header for the writer using the header of the reader 
+    // initialize the header for the writer using the header of the reader
 
     if (laszip_set_header(laszip_writer, header))
     {
@@ -3583,7 +3591,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // read the points
@@ -3687,7 +3695,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip reader for '%s'\n", file_name_in);
       byebye(true, argc==1, laszip_reader);
     }
-  
+
     fprintf(stderr,"file '%s' is %scompressed\n", file_name_in, (is_compressed ? "" : "un"));
 
     // get a pointer to the header of the reader that was just populated
@@ -3753,7 +3761,7 @@ int main(int argc, char *argv[])
     if ((header_read->point_data_format > 5) || (header_read->extended_number_of_point_records > (2<<32-1)))
     {
       // legacy 32-bit counters should be zero for new point types > 5 or if there are more than 2<<32-1 points
-      header_write->number_of_point_records = 0;           
+      header_write->number_of_point_records = 0;
       for (i = 0; i < 5; i++)
       {
         header_write->number_of_points_by_return[i] = 0;
@@ -3762,7 +3770,7 @@ int main(int argc, char *argv[])
     else
     {
       // legacy 32-bit counters should be populated
-      header_write->number_of_point_records = (header_read->number_of_point_records ? header_read->number_of_point_records : (laszip_U32)(header_read->extended_number_of_point_records)); 
+      header_write->number_of_point_records = (header_read->number_of_point_records ? header_read->number_of_point_records : (laszip_U32)(header_read->extended_number_of_point_records));
       for (i = 0; i < 5; i++)
       {
         header_write->number_of_points_by_return[i] = (header_read->number_of_points_by_return[i] ? header_read->number_of_points_by_return[i] : (laszip_U32)(header_read->extended_number_of_points_by_return[i]));
@@ -3813,7 +3821,7 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: opening laszip writer for '%s'\n", file_name_out);
       byebye(true, argc==1, laszip_writer);
     }
-  
+
     fprintf(stderr,"writing file '%s' %scompressed\n", file_name_out, (compress ? "" : "un"));
 
     // get a pointer to the point of the writer that we will populate and write
@@ -3930,9 +3938,9 @@ int main(int argc, char *argv[])
       fprintf(stderr,"DLL ERROR: destroying laszip reader\n");
       byebye(true, argc==1);
     }
-  
+
     fprintf(stderr,"total time: %g sec for reading %scompressed and writing %scompressed\n", taketime()-start_time, (is_compressed ? "" : "un"), (compress ? "" : "un"));
-  
+
   } // end of EXAMPLE_FIFTEEN
 
   // unload LASzip DLL

--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -327,7 +327,7 @@ BOOL LASindex::write(FILE* file) const
 BOOL LASindex::read(const char* file_name)
 {
   if (file_name == 0) return FALSE;
-  char* name = _strdup(file_name);
+  char* name = LASCopyString(file_name);
   if (strstr(file_name, ".las") || strstr(file_name, ".laz"))
   {
     name[strlen(name)-1] = 'x';
@@ -502,7 +502,7 @@ BOOL LASindex::append(const char* file_name) const
 BOOL LASindex::write(const char* file_name) const
 {
   if (file_name == 0) return FALSE;
-  char* name = _strdup(file_name);
+  char* name = LASCopyString(file_name);
   if (strstr(file_name, ".las") || strstr(file_name, ".laz"))
   {
     name[strlen(name)-1] = 'x';

--- a/LASzip/src/lasindex.hpp
+++ b/LASzip/src/lasindex.hpp
@@ -27,10 +27,11 @@
 
   CHANGE HISTORY:
 
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
      7 January 2017 -- add read(FILE* file) for Trimble LASzip DLL improvement
      2 April 2015 -- add seek_next(LASreadPoint* reader, I64 &p_count) for DLL
      2 April 2015 -- delete read_next(LASreader* lasreader) that was not used
-    31 March 2015 -- remove unused LASquadtree inheritance of abstract LASspatial 
+    31 March 2015 -- remove unused LASquadtree inheritance of abstract LASspatial
     29 April 2011 -- created after cable outage during the royal wedding (-:
 
 ===============================================================================

--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -24,6 +24,7 @@
 
   CHANGE HISTORY:
 
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     6 April 2018 == added zero() function to laszip_dll struct to fix memory leak
    30 August 2017 -- completing stream-based writing (with writing LAS header)
    23 August 2017 -- turn on "native" by default
@@ -409,7 +410,7 @@ laszip_clean(
     }
 
     // dealloc the inventory although close_writer() call should have done this already
-    
+
     if (laszip_dll->inventory == 0)
     {
       delete laszip_dll->inventory;
@@ -2958,7 +2959,7 @@ laszip_open_writer(
 
       // copy the file name for later
 
-      laszip_dll->lax_file_name = _strdup(file_name);
+      laszip_dll->lax_file_name = LASCopyString(file_name);
     }
 
     // set the point number and point count

--- a/src/geoprojectionconverter.cpp
+++ b/src/geoprojectionconverter.cpp
@@ -2,20 +2,20 @@
 ===============================================================================
 
   FILE:  geoprojectionconverter.cpp
-  
+
   CONTENTS:
-  
+
     see corresponding header file
-  
+
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     chuck.gantz@globalstar.com
     gpotts@imagelinks.com
     craig.larrimore@noaa.gov
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2017, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -26,9 +26,9 @@
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
   CHANGE HISTORY:
-  
+
     see corresponding header file
-  
+
 ===============================================================================
 */
 #include "geoprojectionconverter.hpp"
@@ -41,6 +41,13 @@
 #include <windows.h>
 #else
 #include <unistd.h>
+#endif
+
+#if defined(_MSC_VER) && \
+    (_MSC_FULL_VER >= 150000000)
+#define LASCopyString _strdup
+#else
+#define LASCopyString strdup
 #endif
 
 static const double PI = 3.141592653589793238462643383279502884197169;
@@ -70,21 +77,21 @@ public:
   ReferenceEllipsoid(int id, char* name, double equatorialRadius, double eccentricitySquared, double inverseFlattening)
   {
     this->id = id;
-    this->name = name; 
+    this->name = name;
     this->equatorialRadius = equatorialRadius;
     this->eccentricitySquared = eccentricitySquared;
     this->inverseFlattening = inverseFlattening;
   }
   int id;
   char* name;
-  double equatorialRadius; 
-  double eccentricitySquared;  
-  double inverseFlattening;  
+  double equatorialRadius;
+  double eccentricitySquared;
+  double inverseFlattening;
 };
 
-static const ReferenceEllipsoid ellipsoid_list[] = 
+static const ReferenceEllipsoid ellipsoid_list[] =
 {
-  //  d, Ellipsoid name, Equatorial Radius, square of eccentricity, inverse flattening  
+  //  d, Ellipsoid name, Equatorial Radius, square of eccentricity, inverse flattening
   ReferenceEllipsoid( -1, "Placeholder", 0, 0, 0),  //placeholder to allow array indices to match id numbers
   ReferenceEllipsoid( 1, "Airy", 6377563.396, 0.00667054, 299.3249646),
   ReferenceEllipsoid( 2, "Australian National", 6378160.0, 0.006694542, 298.25),
@@ -511,7 +518,7 @@ public:
 
 static const StatePlaneLCC state_plane_lcc_nad27_list[] =
 {
-  // zone, false east [m], false north [m], ProjOrig(Lat), CentMerid(Long), 1st std para, 2nd std para 
+  // zone, false east [m], false north [m], ProjOrig(Lat), CentMerid(Long), 1st std para, 2nd std para
   StatePlaneLCC(PCS_NAD27_Alaska_zone_10, "AK_10",914401.8288,0,51,-176,51.83333333,53.83333333),
   StatePlaneLCC(PCS_NAD27_Arkansas_North, "AR_N",609601.2192,0,34.33333333,-92,34.93333333,36.23333333),
   StatePlaneLCC(PCS_NAD27_Arkansas_South, "AR_S",609601.2192,0,32.66666667,-92,33.3,34.76666667),
@@ -590,7 +597,7 @@ static const StatePlaneLCC state_plane_lcc_nad27_list[] =
 
 static const StatePlaneLCC state_plane_lcc_nad83_list[] =
 {
-  // geotiff key, zone, false east [m], false north [m], ProjOrig(Lat), CentMerid(Long), 1st std para, 2nd std para 
+  // geotiff key, zone, false east [m], false north [m], ProjOrig(Lat), CentMerid(Long), 1st std para, 2nd std para
   StatePlaneLCC(PCS_NAD83_Alaska_zone_10, "AK_10",1000000,0,51.000000,-176.000000,51.833333,53.833333),
   StatePlaneLCC(PCS_NAD83_Arkansas_North, "AR_N",400000,0,34.333333,-92.000000,34.933333,36.233333),
   StatePlaneLCC(PCS_NAD83_Arkansas_South, "AR_S",400000,400000,32.666667,-92.000000,33.300000,34.766667),
@@ -855,7 +862,7 @@ bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, GeoP
     case 4099: // VerticalUnitsGeoKey
       set_VerticalUnitsGeoKey(geo_keys[i].value_offset);
       break;
-    case 4096: // VerticalCSTypeGeoKey 
+    case 4096: // VerticalCSTypeGeoKey
       set_VerticalCSTypeGeoKey(geo_keys[i].value_offset);
       break;
     case 2048: // GeographicTypeGeoKey
@@ -898,7 +905,7 @@ bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, GeoP
       case 4001: // GCSE_Airy1830
         ellipsoid = GEO_ELLIPSOID_AIRY;
         break;
-      case 4002: // GCSE_AiryModified1849 
+      case 4002: // GCSE_AiryModified1849
         ellipsoid = 16;
         break;
       case 4003: // GCSE_AustralianNationalSpheroid
@@ -945,7 +952,7 @@ bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, GeoP
         fprintf(stderr, "GeographicTypeGeoKey: look-up for %d not implemented\n", geo_keys[i].value_offset);
       }
       break;
-    case 2050: // GeogGeodeticDatumGeoKey 
+    case 2050: // GeogGeodeticDatumGeoKey
       switch (geo_keys[i].value_offset)
       {
       case 32767: // user-defined GCS
@@ -1035,7 +1042,7 @@ bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, GeoP
         fprintf(stderr, "GeogGeodeticDatumGeoKey: look-up for %d not implemented\n", geo_keys[i].value_offset);
       }
       break;
-    case 2052: // GeogLinearUnitsGeoKey 
+    case 2052: // GeogLinearUnitsGeoKey
       switch (geo_keys[i].value_offset)
       {
       case 9001: // Linear_Meter
@@ -1148,7 +1155,7 @@ bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, GeoP
       break;
     case 3079: // ProjStdParallel2GeoKey
       offsetProjStdParallel2GeoKey = geo_keys[i].value_offset;
-      break;        
+      break;
     case 3080 : // ProjNatOriginLongGeoKey
       offsetProjNatOriginLongGeoKey = geo_keys[i].value_offset;
       break;
@@ -1343,7 +1350,7 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[0].count = 1;
         (*geo_keys)[0].value_offset = 1; // ModelTypeProjected
 
-        // user-defined custom LCC projection 
+        // user-defined custom LCC projection
         (*geo_keys)[1].key_id = 3072; // ProjectedCSTypeGeoKey
         (*geo_keys)[1].tiff_tag_location = 0;
         (*geo_keys)[1].count = 1;
@@ -1353,13 +1360,13 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[2].key_id = 3075; // ProjCoordTransGeoKey
         (*geo_keys)[2].tiff_tag_location = 0;
         (*geo_keys)[2].count = 1;
-        (*geo_keys)[2].value_offset = 8; // CT_LambertConfConic_2SP 
+        (*geo_keys)[2].value_offset = 8; // CT_LambertConfConic_2SP
 
         // which units do we use
         (*geo_keys)[3].key_id = 3076; // ProjCoordTransGeoKey
         (*geo_keys)[3].tiff_tag_location = 0;
         (*geo_keys)[3].count = 1;
-        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source); 
+        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source);
 
         // here come the 6 double parameters
 
@@ -1442,7 +1449,7 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[0].count = 1;
         (*geo_keys)[0].value_offset = 1; // ModelTypeProjected
 
-        // user-defined custom TM projection 
+        // user-defined custom TM projection
         (*geo_keys)[1].key_id = 3072; // ProjectedCSTypeGeoKey
         (*geo_keys)[1].tiff_tag_location = 0;
         (*geo_keys)[1].count = 1;
@@ -1458,7 +1465,7 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[3].key_id = 3076; // ProjCoordTransGeoKey
         (*geo_keys)[3].tiff_tag_location = 0;
         (*geo_keys)[3].count = 1;
-        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source); 
+        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source);
 
         // here come the 5 double parameters
 
@@ -1535,7 +1542,7 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[0].count = 1;
         (*geo_keys)[0].value_offset = 1; // ModelTypeProjected
 
-        // user-defined custom AEAC projection 
+        // user-defined custom AEAC projection
         (*geo_keys)[1].key_id = 3072; // ProjectedCSTypeGeoKey
         (*geo_keys)[1].tiff_tag_location = 0;
         (*geo_keys)[1].count = 1;
@@ -1545,13 +1552,13 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[2].key_id = 3075; // ProjCoordTransGeoKey
         (*geo_keys)[2].tiff_tag_location = 0;
         (*geo_keys)[2].count = 1;
-        (*geo_keys)[2].value_offset = 11; // CT_AlbersEqualArea 
+        (*geo_keys)[2].value_offset = 11; // CT_AlbersEqualArea
 
         // which units do we use
         (*geo_keys)[3].key_id = 3076; // ProjCoordTransGeoKey
         (*geo_keys)[3].tiff_tag_location = 0;
         (*geo_keys)[3].count = 1;
-        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source); 
+        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source);
 
         // here come the 6 double parameters
 
@@ -1634,7 +1641,7 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[0].count = 1;
         (*geo_keys)[0].value_offset = 1; // ModelTypeProjected
 
-        // user-defined custom LCC projection 
+        // user-defined custom LCC projection
         (*geo_keys)[1].key_id = 3072; // ProjectedCSTypeGeoKey
         (*geo_keys)[1].tiff_tag_location = 0;
         (*geo_keys)[1].count = 1;
@@ -1644,13 +1651,13 @@ bool GeoProjectionConverter::get_geo_keys_from_projection(int& num_geo_keys, Geo
         (*geo_keys)[2].key_id = 3075; // ProjCoordTransGeoKey
         (*geo_keys)[2].tiff_tag_location = 0;
         (*geo_keys)[2].count = 1;
-        (*geo_keys)[2].value_offset = 11; // CT_AlbersEqualArea 
+        (*geo_keys)[2].value_offset = 11; // CT_AlbersEqualArea
 
         // which units do we use
         (*geo_keys)[3].key_id = 3076; // ProjCoordTransGeoKey
         (*geo_keys)[3].tiff_tag_location = 0;
         (*geo_keys)[3].count = 1;
-        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source); 
+        (*geo_keys)[3].value_offset = get_ProjLinearUnitsGeoKey(source);
 
         // here come the 6 double parameters
 /*
@@ -1968,7 +1975,7 @@ bool GeoProjectionConverter::set_projection_from_ogc_wkt(const char* ogc_wkt, ch
     }
 
     // otherwise try to find the PROJECTION and all its parameters
- 
+
     const char* proj = strstr(projcs, "PROJECTION[");
 
     if (proj)
@@ -2090,10 +2097,10 @@ static char* get_epsg_name_from_pcs_file(const char* program_name, short value)
         if (line[run] == '\"')
         {
           // remove opening parentheses
-          run++; 
+          run++;
           // this is where the name starts
           name = &line[run];
-          run++; 
+          run++;
           // skip until closing parentheses
           while (line[run] != '\"') run++;
           // this is where the name ends
@@ -2109,7 +2116,7 @@ static char* get_epsg_name_from_pcs_file(const char* program_name, short value)
           line[run] = '\0';
         }
         // copy the name
-        epsg_name = _strdup(name);
+        epsg_name = LASCopyString(name);
         break;
       }
     }
@@ -2121,7 +2128,7 @@ static char* get_epsg_name_from_pcs_file(const char* program_name, short value)
 static int print_ogc_wkt_spheroid(char* string, short spheroid_code)
 {
   int n = 0;
-  
+
   if (spheroid_code == GEO_SPHEROID_WGS84)
   {
     n = sprintf(string, "SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],");
@@ -2160,7 +2167,7 @@ static int print_ogc_wkt_spheroid(char* string, short spheroid_code)
 static int print_ogc_wkt_datum(char* string, const char* datum_name, short datum_code, short spheroid_code)
 {
   int n = 0;
-  
+
   n += sprintf(&string[n], "DATUM[\"%s\",", datum_name);
   n += print_ogc_wkt_spheroid(&string[n], spheroid_code);
   n += sprintf(&string[n], "AUTHORITY[\"EPSG\",\"%d\"]],", datum_code);
@@ -2171,7 +2178,7 @@ static int print_ogc_wkt_datum(char* string, const char* datum_name, short datum
 static int print_ogc_wkt_geogcs(char* string, const char* gcs_name, short gcs_code, const char* datum_name, short datum_code, short spheroid_code)
 {
   int n = 0;
-  
+
   n += sprintf(&string[n], "GEOGCS[\"%s\",", gcs_name);
   n += print_ogc_wkt_datum(&string[n], datum_name, datum_code, spheroid_code);
   n += sprintf(&string[n], "PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"%d\"]],", gcs_code);
@@ -2193,7 +2200,7 @@ bool GeoProjectionConverter::get_ogc_wkt_from_projection(int& len, char** ogc_wk
     {
       n += sprintf(&string[n], "GEOCCS[\"WGS 84\",DATUM[\"World Geodetic System 1984\",SPHEROID[\"WGS 84\",6378137.0,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0.0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"m\",1.0],AXIS[\"Geocentric X\",OTHER],AXIS[\"Geocentric Y\",EAST],AXIS[\"Geocentric Z\",NORTH],AUTHORITY[\"EPSG\",\"4978\"]]");
     }
-    else 
+    else
     {
       // if not geographic we have a projection
       if ((projection->type != GEO_PROJECTION_LAT_LONG) && (projection->type != GEO_PROJECTION_LONG_LAT))
@@ -2213,7 +2220,7 @@ bool GeoProjectionConverter::get_ogc_wkt_from_projection(int& len, char** ogc_wk
             n += sprintf(&string[n], "NAVD88");
             if (vertical_geoid)
             {
-              if (vertical_geoid == GEO_VERTICAL_NAVD88_GEOID12B) 
+              if (vertical_geoid == GEO_VERTICAL_NAVD88_GEOID12B)
               {
                 n += sprintf(&string[n], " height - Geoid12B");
               }
@@ -2415,7 +2422,7 @@ bool GeoProjectionConverter::get_ogc_wkt_from_projection(int& len, char** ogc_wk
             n += sprintf(&string[n], "PARAMETER[\"false_easting\",%.15g],PARAMETER[\"false_northing\",%.15g],", os->os_false_easting_meter*meter2coordinates, os->os_false_northing_meter*meter2coordinates);
           }
         }
-        else 
+        else
         {
           free(string);
           len = 0;
@@ -2479,7 +2486,7 @@ bool GeoProjectionConverter::get_ogc_wkt_from_projection(int& len, char** ogc_wk
           n += sprintf(&string[n], "VERT_CS[\"NAVD88");
           if (vertical_geoid)
           {
-            if (vertical_geoid == GEO_VERTICAL_NAVD88_GEOID12B) 
+            if (vertical_geoid == GEO_VERTICAL_NAVD88_GEOID12B)
             {
               n += sprintf(&string[n], " height - Geoid12B");
             }
@@ -2628,7 +2635,7 @@ bool GeoProjectionConverter::get_ogc_wkt_from_projection(int& len, char** ogc_wk
 static int print_prj_spheroid(char* string, short spheroid_code)
 {
   int n = 0;
-  
+
   if (spheroid_code == GEO_SPHEROID_WGS84)
   {
     n = sprintf(string, "SPHEROID[\"WGS 84\",6378137,298.257223563]");
@@ -2667,7 +2674,7 @@ static int print_prj_spheroid(char* string, short spheroid_code)
 static int print_prj_datum(char* string, const char* datum_name, short datum_code, short spheroid_code)
 {
   int n = 0;
-  
+
   if (datum_code == (GEO_GCS_WGS84 + 2000))
   {
     n += sprintf(&string[n], "DATUM[\"D_WGS_1984\",");
@@ -2685,7 +2692,7 @@ static int print_prj_datum(char* string, const char* datum_name, short datum_cod
 static int print_prj_geogcs(char* string, const char* gcs_name, short gcs_code, const char* datum_name, short datum_code, short spheroid_code)
 {
   int n = 0;
-  
+
   n += sprintf(&string[n], "GEOGCS[\"%s\",", gcs_name);
   n += print_prj_datum(&string[n], datum_name, datum_code, spheroid_code);
   n += sprintf(&string[n], "PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.017453292519943295]],");
@@ -2707,7 +2714,7 @@ bool GeoProjectionConverter::get_prj_from_projection(int& len, char** prj, bool 
     {
       n += sprintf(&string[n], "GEOCCS[\"WGS 84\",DATUM[\"World Geodetic System 1984\",SPHEROID[\"WGS 84\",6378137.0,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0.0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"m\",1.0],AXIS[\"Geocentric X\",OTHER],AXIS[\"Geocentric Y\",EAST],AXIS[\"Geocentric Z\",NORTH],AUTHORITY[\"EPSG\",\"4978\"]]");
     }
-    else 
+    else
     {
       // if not geographic we have a projection
       if ((projection->type != GEO_PROJECTION_LAT_LONG) && (projection->type != GEO_PROJECTION_LONG_LAT))
@@ -2840,7 +2847,7 @@ bool GeoProjectionConverter::get_prj_from_projection(int& len, char** prj, bool 
             n += sprintf(&string[n], "PARAMETER[\"false_easting\",%.15g],PARAMETER[\"false_northing\",%.15g],", os->os_false_easting_meter*meter2coordinates, os->os_false_northing_meter*meter2coordinates);
           }
         }
-        else 
+        else
         {
           free(string);
           len = 0;
@@ -3089,7 +3096,7 @@ bool GeoProjectionConverter::get_proj4_string_from_projection(int& len, char** p
     {
       n += sprintf(&string[n], "+datum=bessel ");
     }
-    else 
+    else
     {
       free(string);
       len = 0;
@@ -3197,7 +3204,7 @@ short GeoProjectionConverter::get_GeographicTypeGeoKey() const
     return 4022;
   case GEO_ELLIPSOID_KRASSOWSKY: // GCSE_Krassowsky1940
     return 4024;
-  case 16: // GCSE_AiryModified1849 
+  case 16: // GCSE_AiryModified1849
     return 4002;
   case 17: // GCSE_Everest1830Modified
     return 4018;
@@ -3431,7 +3438,7 @@ short GeoProjectionConverter::get_ProjectedCSTypeGeoKey(bool source) const
           {
             if ((1 <= utm->utm_zone_number) && (utm->utm_zone_number <= 23))
             {
-              return 26900 + utm->utm_zone_number; 
+              return 26900 + utm->utm_zone_number;
             }
             else if ((59 <= utm->utm_zone_number) && (utm->utm_zone_number <= 60))
             {
@@ -3456,7 +3463,7 @@ short GeoProjectionConverter::get_ProjectedCSTypeGeoKey(bool source) const
           {
             if ((1 <= utm->utm_zone_number) && (utm->utm_zone_number <= 19))
             {
-              return 6329 + utm->utm_zone_number; 
+              return 6329 + utm->utm_zone_number;
             }
             else if ((59 <= utm->utm_zone_number) && (utm->utm_zone_number <= 60))
             {
@@ -3470,7 +3477,7 @@ short GeoProjectionConverter::get_ProjectedCSTypeGeoKey(bool source) const
           {
             if ((1 <= utm->utm_zone_number) && (utm->utm_zone_number <= 19))
             {
-              return 3707 + utm->utm_zone_number; 
+              return 3707 + utm->utm_zone_number;
             }
             else if ((59 <= utm->utm_zone_number) && (utm->utm_zone_number <= 60))
             {
@@ -3484,11 +3491,11 @@ short GeoProjectionConverter::get_ProjectedCSTypeGeoKey(bool source) const
           {
             if ((10 <= utm->utm_zone_number) && (utm->utm_zone_number <= 19))
             {
-              return 3730 + utm->utm_zone_number; 
+              return 3730 + utm->utm_zone_number;
             }
             else if ((4 <= utm->utm_zone_number) && (utm->utm_zone_number <= 5))
             {
-              return 3746 + utm->utm_zone_number; 
+              return 3746 + utm->utm_zone_number;
             }
           }
           else
@@ -3505,7 +3512,7 @@ short GeoProjectionConverter::get_ProjectedCSTypeGeoKey(bool source) const
           {
             if ((7 <= utm->utm_zone_number) && (utm->utm_zone_number <= 22))
             {
-              return 6643 + utm->utm_zone_number; 
+              return 6643 + utm->utm_zone_number;
             }
           }
         }
@@ -4014,7 +4021,7 @@ bool GeoProjectionConverter::set_reference_ellipsoid(int id, char* description)
   ellipsoid->eccentricity_squared = ellipsoid_list[id].eccentricitySquared;
   ellipsoid->inverse_flattening = ellipsoid_list[id].inverseFlattening;
   ellipsoid->eccentricity_prime_squared = (ellipsoid->eccentricity_squared)/(1-ellipsoid->eccentricity_squared);
-  ellipsoid->polar_radius = ellipsoid->equatorial_radius*sqrt(1-ellipsoid->eccentricity_squared);    
+  ellipsoid->polar_radius = ellipsoid->equatorial_radius*sqrt(1-ellipsoid->eccentricity_squared);
   ellipsoid->eccentricity = sqrt(ellipsoid->eccentricity_squared);
   ellipsoid->eccentricity_e1 = (1-sqrt(1-ellipsoid->eccentricity_squared))/(1+sqrt(1-ellipsoid->eccentricity_squared));
 
@@ -4191,10 +4198,10 @@ bool GeoProjectionConverter::set_gcs(short code, char* description)
           if (line[run] == '\"')
           {
             // remove opening parentheses
-            run++; 
+            run++;
             // this is where the name starts
             gname = &line[run];
-            run++; 
+            run++;
             // skip until closing parentheses
             while (line[run] != '\"') run++;
             // this is where the name ends
@@ -4226,10 +4233,10 @@ bool GeoProjectionConverter::set_gcs(short code, char* description)
           if (line[run] == '\"')
           {
             // remove opening parentheses
-            run++; 
+            run++;
             // this is where the name starts
             dname = &line[run];
-            run++; 
+            run++;
             // skip until closing parentheses
             while (line[run] != '\"') run++;
             // this is where the name ends
@@ -4523,7 +4530,7 @@ bool GeoProjectionConverter::set_target_utm_projection(char* description, const 
 // Conformal Conic  projection parameters as inputs and sets the corresponding
 // state variables.
 //
-// falseEastingMeter & falseNorthingMeter are just an offset in meters added 
+// falseEastingMeter & falseNorthingMeter are just an offset in meters added
 // to the final coordinate calculated.
 //
 // latOriginDegree & longMeridianDegree are the "center" latitiude and
@@ -4566,7 +4573,7 @@ void GeoProjectionConverter::set_lambert_conformal_conic_projection(double false
 /*
   * The function set_transverse_mercator_projection() receives the Tranverse
   * Mercator projection parameters as input and sets the corresponding state
-  * variables. 
+  * variables.
   * falseEastingMeter   : Easting/X in meters at the center of the projection
   * falseNorthingMeter  : Northing/Y in meters at the center of the projection
   * latOriginDegree     : Latitude in decimal degree at the origin of the projection
@@ -4602,11 +4609,11 @@ void GeoProjectionConverter::set_transverse_mercator_projection(double falseEast
 
 // Configure a Albers Equal Area Conic Projection
 //
-// The function set_albers_equal_area_conic_projection() receives the Albers 
+// The function set_albers_equal_area_conic_projection() receives the Albers
 // Equal Area Conic projection parameters as inputs and sets the corresponding
 // state variables.
 //
-// falseEastingMeter & falseNorthingMeter are just an offset in meters added 
+// falseEastingMeter & falseNorthingMeter are just an offset in meters added
 // to the final coordinate calculated.
 //
 // latCenterDegree & longCenterDegree are the "center" latitiude and
@@ -4648,11 +4655,11 @@ void GeoProjectionConverter::set_albers_equal_area_conic_projection(double false
 
 // Configure an Oblique Mercator Projection
 //
-// The function set_hotine_oblique_mercator_projection() receives the Hotine  
+// The function set_hotine_oblique_mercator_projection() receives the Hotine
 // Oblique Mercator projection parameters as inputs and sets the corresponding
 // state variables.
 //
-// falseEastingMeter & falseNorthingMeter are just an offset in meters added 
+// falseEastingMeter & falseNorthingMeter are just an offset in meters added
 // to the final coordinate calculated.
 //
 // latCenterDegree & longCenterDegree are the "center" latitiude and
@@ -4689,7 +4696,7 @@ void GeoProjectionConverter::set_hotine_oblique_mercator_projection(double false
 /*
   * The function set_oblique_stereographic_projection() receives the Oblique
   * Stereographic projection parameters as input and sets the corresponding
-  * state variables. 
+  * state variables.
   * falseEastingMeter   : Easting/X in meters at the center of the projection
   * falseNorthingMeter  : Northing/Y in meters at the center of the projection
   * latOriginDegree     : Latitude in decimal degree at the origin of the projection
@@ -4903,10 +4910,10 @@ bool GeoProjectionConverter::set_epsg_code(short value, char* description, bool 
           if (line[run] == '\"')
           {
             // remove opening parentheses
-            run++; 
+            run++;
             // this is where the name starts
             name = &line[run];
-            run++; 
+            run++;
             // skip until closing parentheses
             while (line[run] != '\"') run++;
             // this is where the name ends
@@ -5132,7 +5139,7 @@ bool GeoProjectionConverter::set_epsg_code(short value, char* description, bool 
             if (description) sprintf(description, "%s", name);
             return true;
           }
-          else 
+          else
           {
             fprintf(stderr, "transform %d of EPSG code %d not implemented.\n", transform, value);
             return false;
@@ -5469,7 +5476,7 @@ void GeoProjectionConverter::compute_os_parameters(bool source)
   double sphi = sin(os->os_lat_origin_radian);
   double cphi = cos(os->os_lat_origin_radian);
   cphi *= cphi;
-  
+
   os->os_R2 = 2.0 * sqrt(1.0 - ellipsoid->eccentricity_squared) / (1.0 - ellipsoid->eccentricity_squared * sphi * sphi);
   os->os_C = sqrt(1.0 + ellipsoid->eccentricity_squared * cphi * cphi / (1.0 - ellipsoid->eccentricity_squared));
   os->os_phic0 = asin(sphi / os->os_C);
@@ -5480,10 +5487,10 @@ void GeoProjectionConverter::compute_os_parameters(bool source)
   os->os_gf = os->os_scale_factor * ellipsoid->equatorial_radius;
 }
 
-// converts UTM coords to lat/long.  Equations from USGS Bulletin 1532 
-// East Longitudes are positive, West longitudes are negative. 
+// converts UTM coords to lat/long.  Equations from USGS Bulletin 1532
+// East Longitudes are positive, West longitudes are negative.
 // North latitudes are positive, South latitudes are negative
-// Lat and LongDegree are in decimal degrees. 
+// Lat and LongDegree are in decimal degrees.
 // adapted from code written by Chuck Gantz- chuck.gantz@globalstar.com
 
 bool GeoProjectionConverter::UTMtoLL(const double UTMEastingMeter, const double UTMNorthingMeter, double& LatDegree,  double& LongDegree, const GeoProjectionEllipsoid* ellipsoid, const GeoProjectionParametersUTM* utm) const
@@ -5501,7 +5508,7 @@ bool GeoProjectionConverter::UTMtoLL(const double UTMEastingMeter, const double 
   double M = y / k0;
   double mu = M/(ellipsoid->equatorial_radius*(1-ellipsoid->eccentricity_squared/4-3*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/64-5*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/256));
 
-  double phi1Rad = mu  + (3*ellipsoid->eccentricity_e1/2-27*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1/32)*sin(2*mu) 
+  double phi1Rad = mu  + (3*ellipsoid->eccentricity_e1/2-27*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1/32)*sin(2*mu)
                        + (21*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1/16-55*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1/32)*sin(4*mu)
                        + (151*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1*ellipsoid->eccentricity_e1/96)*sin(6*mu);
 
@@ -5521,8 +5528,8 @@ bool GeoProjectionConverter::UTMtoLL(const double UTMEastingMeter, const double 
   return true;
 }
 
-// converts lat/long to UTM coords.  Equations from USGS Bulletin 1532 
-// East Longitudes are positive, West longitudes are negative. 
+// converts lat/long to UTM coords.  Equations from USGS Bulletin 1532
+// East Longitudes are positive, West longitudes are negative.
 // North latitudes are positive, South latitudes are negative
 // LatDegree and LongDegree are in decimal degrees
 // adapted from code written by Chuck Gantz- chuck.gantz@globalstar.com
@@ -5535,7 +5542,7 @@ bool GeoProjectionConverter::compute_utm_zone(const double LatDegree, const doub
   utm->utm_zone_number = (int)((LongTemp + 180)/6) + 1;
   if( LatDegree >= 56.0 && LatDegree < 64.0 && LongTemp >= 3.0 && LongTemp < 12.0 ) utm->utm_zone_number = 32;
   // Special zones for Svalbard
-  if( LatDegree >= 72.0 && LatDegree < 84.0 ) 
+  if( LatDegree >= 72.0 && LatDegree < 84.0 )
   {
     if(      LongTemp >= 0.0  && LongTemp <  9.0 ) utm->utm_zone_number = 31;
     else if( LongTemp >= 9.0  && LongTemp < 21.0 ) utm->utm_zone_number = 33;
@@ -5570,7 +5577,7 @@ bool GeoProjectionConverter::compute_utm_zone(const double LatDegree, const doub
 bool GeoProjectionConverter::LLtoUTM(const double LatDegree, const double LongDegree, double &UTMEastingMeter, double &UTMNorthingMeter, const GeoProjectionEllipsoid* ellipsoid, const GeoProjectionParametersUTM* utm) const
 {
   const double k0 = 0.9996;
-  
+
   // Make sure the longitude is between -180.00 .. 179.9
   double LongTemp = (LongDegree+180)-int((LongDegree+180)/360)*360-180; // -180.00 .. 179.9;
   double LatRad = LatDegree*deg2rad;
@@ -5582,11 +5589,11 @@ bool GeoProjectionConverter::LLtoUTM(const double LatDegree, const double LongDe
   double C = ellipsoid->eccentricity_prime_squared*cos(LatRad)*cos(LatRad);
   double A = cos(LatRad)*(LongRad-LongOriginRad);
 
-  double M = ellipsoid->equatorial_radius*((1  - ellipsoid->eccentricity_squared/4 - 3*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/64  - 5*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/256)*LatRad 
+  double M = ellipsoid->equatorial_radius*((1  - ellipsoid->eccentricity_squared/4 - 3*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/64  - 5*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/256)*LatRad
               - (3*ellipsoid->eccentricity_squared/8  + 3*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/32  + 45*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/1024)*sin(2*LatRad)
-             + (15*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/256 + 45*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/1024)*sin(4*LatRad) 
+             + (15*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/256 + 45*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/1024)*sin(4*LatRad)
              - (35*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared*ellipsoid->eccentricity_squared/3072)*sin(6*LatRad));
-  
+
   UTMEastingMeter = (double)(k0*N*(A+(1-T+C)*A*A*A/6
           + (5-18*T+T*T+72*C-58*ellipsoid->eccentricity_prime_squared)*A*A*A*A*A/120)
           + 500000.0);
@@ -5605,11 +5612,11 @@ bool GeoProjectionConverter::LLtoUTM(const double LatDegree, const double LongDe
 /*
 An alternate way to convert Lambert Conic Conformal Northing/Easting coordinates
 into Latitude & Longitude coordinates. The code adapted from Brenor Brophy
-(brenor dot brophy at gmail dot com) Homepage:  www.brenorbrophy.com 
+(brenor dot brophy at gmail dot com) Homepage:  www.brenorbrophy.com
 */
 void lcc2ll( double e2, // Square of ellipsoid->eccentricity
              double a,  // Equatorial Radius
-             double firstStdParallel, 
+             double firstStdParallel,
              double secondStdParallel,
              double latOfOrigin,
              double longOfOrigin,
@@ -5647,7 +5654,7 @@ void lcc2ll( double e2, // Square of ellipsoid->eccentricity
    phi1  = PI_OVER_2 - 2*atan(t_*pow(((1-e*sin(phi0))/(1+e*sin(phi0))),e/2));
    phi2  = PI_OVER_2 - 2*atan(t_*pow(((1-e*sin(phi1))/(1+e*sin(phi1))),e/2));
   double phi  = PI_OVER_2 - 2*atan(t_*pow(((1-e*sin(phi2))/(1+e*sin(phi2))),e/2));
-  
+
   LatDegree = rad2deg*phi;
   LongDegree = rad2deg*lamda;
 }
@@ -5660,11 +5667,11 @@ meters) and are relative to the falseNorthing/falseEasting coordinate.
 Which in turn is relative to the Lat/Long of origin. The formula were
 obtained from URL: http://www.ihsenergy.com/epsg/guid7_2.html.
 The code adapted from Brenor Brophy (brenor dot brophy at gmail dot com)
-Homepage:  www.brenorbrophy.com 
+Homepage:  www.brenorbrophy.com
 */
 void ll2lcc( double e2, // Square of ellipsoid->eccentricity
              double a,  // Equatorial Radius
-             double firstStdParallel, 
+             double firstStdParallel,
              double secondStdParallel,
              double latOfOrigin,
              double longOfOrigin,
@@ -5705,7 +5712,7 @@ void ll2lcc( double e2, // Square of ellipsoid->eccentricity
   * coordinates, according to the current ellipsoid and Lambert Conformal
   * Conic projection parameters.
   *
-  *   LCCEastingMeter   : input Easting/X in meters 
+  *   LCCEastingMeter   : input Easting/X in meters
   *   LLCNorthingMeter  : input Northing/Y in meters
   *   LatDegree         : output Latitude in decimal degrees
   *   LongDegree        : output Longitude in decimal degrees
@@ -5792,18 +5799,18 @@ bool GeoProjectionConverter::LCCtoLL(const double LCCEastingMeter, const double 
   * The function LLtoLCC() converts Geodetic (latitude and longitude)
   * coordinates to Lambert Conformal Conic projection (easting and
   * northing) coordinates, according to the current ellipsoid and
-  * Lambert Conformal Conic projection parameters. 
+  * Lambert Conformal Conic projection parameters.
   *
   *   LatDegree         : input Latitude in decimal degrees
   *   LongDegree        : input Longitude in decimal degrees
-  *   LCCEastingMeter   : output Easting/X in meters 
+  *   LCCEastingMeter   : output Easting/X in meters
   *   LCCNorthingMeter  : output Northing/Y in meters
   *
   * adapted from code by Garrett Potts ((C) 2000 ImageLinks Inc.)
 */
 bool GeoProjectionConverter::LLtoLCC(const double LatDegree, const double LongDegree, double& LCCEastingMeter,  double& LCCNorthingMeter, const GeoProjectionEllipsoid* ellipsoid, const GeoProjectionParametersLCC* lcc) const
 {
-/* >>> alternate way to compute (but seems less precise) <<< 
+/* >>> alternate way to compute (but seems less precise) <<<
   ll2lcc(ellipsoid->eccentricity_squared,
             ellipsoid->equatorial_radius,
             lcc->lcc_first_std_parallel_degree,
@@ -5859,12 +5866,12 @@ bool GeoProjectionConverter::LLtoLCC(const double LatDegree, const double LongDe
 /*
   * The function LLtoTM() converts geodetic (latitude and longitude)
   * coordinates to Transverse Mercator projection (easting and northing)
-  * coordinates, according to the current ellipsoid and Transverse Mercator 
-  * projection parameters.  
+  * coordinates, according to the current ellipsoid and Transverse Mercator
+  * projection parameters.
   *
   *   LatDegree        : input Latitude in decimal degrees
   *   LongDegree       : input Longitude in decimal degrees
-  *   TMEastingMeter   : output Easting/X in meters 
+  *   TMEastingMeter   : output Easting/X in meters
   *   TMNorthingMeter  : output Northing/Y in meters
   *
   * adapted from code by Garrett Potts ((C) 2000 ImageLinks Inc.)
@@ -5944,24 +5951,24 @@ bool GeoProjectionConverter::LLtoTM(const double LatDegree, const double LongDeg
   /* northing */
   t1 = (tmd - tmdo) * tm->tm_scale_factor;
   t2 = sn * s * c * tm->tm_scale_factor/ 2.e0;
-  t3 = sn * s * c3 * tm->tm_scale_factor * (5.e0 - tan2 + 9.e0 * eta 
-                                             + 4.e0 * eta2) /24.e0; 
+  t3 = sn * s * c3 * tm->tm_scale_factor * (5.e0 - tan2 + 9.e0 * eta
+                                             + 4.e0 * eta2) /24.e0;
 
   t4 = sn * s * c5 * tm->tm_scale_factor * (61.e0 - 58.e0 * tan2
                                              + tan4 + 270.e0 * eta - 330.e0 * tan2 * eta + 445.e0 * eta2
-                                             + 324.e0 * eta3 -680.e0 * tan2 * eta2 + 88.e0 * eta4 
+                                             + 324.e0 * eta3 -680.e0 * tan2 * eta2 + 88.e0 * eta4
                                              -600.e0 * tan2 * eta3 - 192.e0 * tan2 * eta4) / 720.e0;
 
-  t5 = sn * s * c7 * tm->tm_scale_factor * (1385.e0 - 3111.e0 * 
+  t5 = sn * s * c7 * tm->tm_scale_factor * (1385.e0 - 3111.e0 *
                                              tan2 + 543.e0 * tan4 - tan6) / 40320.e0;
 
-  TMNorthingMeter = tm->tm_false_northing_meter + t1 + pow(dlam,2.e0) * t2 + pow(dlam,4.e0) * t3 + pow(dlam,6.e0) * t4 + pow(dlam,8.e0) * t5; 
+  TMNorthingMeter = tm->tm_false_northing_meter + t1 + pow(dlam,2.e0) * t2 + pow(dlam,4.e0) * t3 + pow(dlam,6.e0) * t4 + pow(dlam,8.e0) * t5;
 
   /* Easting */
   t6 = sn * c * tm->tm_scale_factor;
   t7 = sn * c3 * tm->tm_scale_factor * (1.e0 - tan2 + eta ) /6.e0;
   t8 = sn * c5 * tm->tm_scale_factor * (5.e0 - 18.e0 * tan2 + tan4
-                                         + 14.e0 * eta - 58.e0 * tan2 * eta + 13.e0 * eta2 + 4.e0 * eta3 
+                                         + 14.e0 * eta - 58.e0 * tan2 * eta + 13.e0 * eta2 + 4.e0 * eta3
                                          - 64.e0 * tan2 * eta2 - 24.e0 * tan2 * eta3 )/ 120.e0;
   t9 = sn * c7 * tm->tm_scale_factor * ( 61.e0 - 479.e0 * tan2
                                           + 179.e0 * tan4 - tan6 ) /5040.e0;
@@ -5970,14 +5977,14 @@ bool GeoProjectionConverter::LLtoTM(const double LatDegree, const double LongDeg
 
   return true;
 }
- 
+
 /*
   * The function TMtoLL() converts Transverse Mercator projection (easting and
-  * northing) coordinates to geodetic (latitude and longitude) coordinates, 
+  * northing) coordinates to geodetic (latitude and longitude) coordinates,
   * according to the current ellipsoid and Transverse Mercator projection
   * parameters.
   *
-  *   TMEastingMeter   : input Easting/X in meters 
+  *   TMEastingMeter   : input Easting/X in meters
   *   TMNorthingMeter  : input Northing/Y in meters
   *   LatDegree        : output Latitude in decimal degrees
   *   LongDegree       : output Longitude in decimal degrees
@@ -6015,7 +6022,7 @@ bool GeoProjectionConverter::TMtoLL(const double TMEastingMeter, const double TM
   tmdo = SPHTMD(tm->tm_lat_origin_radian);
 
   /*  Origin  */
-  tmd = tmdo + (TMNorthingMeter - tm->tm_false_northing_meter) / tm->tm_scale_factor; 
+  tmd = tmdo + (TMNorthingMeter - tm->tm_false_northing_meter) / tm->tm_scale_factor;
 
   /* First Estimate */
   sr = SPHSR(0.e0);
@@ -6054,31 +6061,31 @@ bool GeoProjectionConverter::TMtoLL(const double TMEastingMeter, const double TM
   double Latitude;
   t10 = t / (2.e0 * sr * sn * pow(tm->tm_scale_factor, 2));
   t11 = t * (5.e0  + 3.e0 * tan2 + eta - 4.e0 * pow(eta,2)
-            - 9.e0 * tan2 * eta) / (24.e0 * sr * pow(sn,3) 
+            - 9.e0 * tan2 * eta) / (24.e0 * sr * pow(sn,3)
                                     * pow(tm->tm_scale_factor,4));
   t12 = t * (61.e0 + 90.e0 * tan2 + 46.e0 * eta + 45.E0 * tan4
-            - 252.e0 * tan2 * eta  - 3.e0 * eta2 + 100.e0 
+            - 252.e0 * tan2 * eta  - 3.e0 * eta2 + 100.e0
             * eta3 - 66.e0 * tan2 * eta2 - 90.e0 * tan4
             * eta + 88.e0 * eta4 + 225.e0 * tan4 * eta2
             + 84.e0 * tan2* eta3 - 192.e0 * tan2 * eta4)
        / ( 720.e0 * sr * pow(sn,5) * pow(tm->tm_scale_factor, 6) );
-  t13 = t * ( 1385.e0 + 3633.e0 * tan2 + 4095.e0 * tan4 + 1575.e0 
+  t13 = t * ( 1385.e0 + 3633.e0 * tan2 + 4095.e0 * tan4 + 1575.e0
              * pow(t,6))/ (40320.e0 * sr * pow(sn,7) * pow(tm->tm_scale_factor,8));
   Latitude = ftphi - pow(de,2) * t10 + pow(de,4) * t11 - pow(de,6) * t12 + pow(de,8) * t13;
 
   t14 = 1.e0 / (sn * c * tm->tm_scale_factor);
 
-  t15 = (1.e0 + 2.e0 * tan2 + eta) / (6.e0 * pow(sn,3) * c * 
+  t15 = (1.e0 + 2.e0 * tan2 + eta) / (6.e0 * pow(sn,3) * c *
                                      pow(tm->tm_scale_factor,3));
 
   t16 = (5.e0 + 6.e0 * eta + 28.e0 * tan2 - 3.e0 * eta2
-        + 8.e0 * tan2 * eta + 24.e0 * tan4 - 4.e0 
-        * eta3 + 4.e0 * tan2 * eta2 + 24.e0 
-        * tan2 * eta3) / (120.e0 * pow(sn,5) * c  
+        + 8.e0 * tan2 * eta + 24.e0 * tan4 - 4.e0
+        * eta3 + 4.e0 * tan2 * eta2 + 24.e0
+        * tan2 * eta3) / (120.e0 * pow(sn,5) * c
                           * pow(tm->tm_scale_factor,5));
 
-  t17 = (61.e0 +  662.e0 * tan2 + 1320.e0 * tan4 + 720.e0 
-        * pow(t,6)) / (5040.e0 * pow(sn,7) * c 
+  t17 = (61.e0 +  662.e0 * tan2 + 1320.e0 * tan4 + 720.e0
+        * pow(t,6)) / (5040.e0 * pow(sn,7) * c
                        * pow(tm->tm_scale_factor,7));
 
   /* Difference in Longitude */
@@ -6117,9 +6124,9 @@ bool GeoProjectionConverter::TMtoLL(const double TMEastingMeter, const double TM
   * (ECEF)coordinates to geodetic (latitude and longitude) coordinates on
   * the provided ellipsoid
   *
-  *   ECEFMeterX       : input X coordinate in meters 
-  *   ECEFMeterY       : input Y coordinate in meters 
-  *   ECEFMeterZ       : input Z coordinate in meters 
+  *   ECEFMeterX       : input X coordinate in meters
+  *   ECEFMeterY       : input Y coordinate in meters
+  *   ECEFMeterZ       : input Z coordinate in meters
   *   LatDegree        : output Latitude in decimal degrees
   *   LongDegree       : output Longitude in decimal degrees
   *   ElevationMeter   : output Elevation in meters
@@ -6245,7 +6252,7 @@ bool GeoProjectionConverter::ECEFtoLL(const double ECEFMeterX, const double ECEF
  */
   ElevationMeter = (r - A*t)*cos( LatDegree ) + (z - B)*sin( LatDegree );
 /*
- *   6.0 compute longitude 
+ *   6.0 compute longitude
  */
   zlong = atan2( y, x );
 
@@ -6267,9 +6274,9 @@ bool GeoProjectionConverter::ECEFtoLL(const double ECEFMeterX, const double ECEF
   *   LatDegree        : input Latitude in decimal degrees
   *   LongDegree       : input Longitude in decimal degrees
   *   ElevationMeter   : input Elevation in meters
-  *   ECEFMeterX       : output X coordinate in meters 
-  *   ECEFMeterY       : output Y coordinate in meters 
-  *   ECEFMeterZ       : output Z coordinate in meters 
+  *   ECEFMeterX       : output X coordinate in meters
+  *   ECEFMeterY       : output Y coordinate in meters
+  *   ECEFMeterZ       : output Z coordinate in meters
   *
   * adapted from code by Craig Larrimore (Craig.Larrimore@noaa.gov) and C. Goad
 */
@@ -6361,10 +6368,10 @@ bool GeoProjectionConverter::LLtoECEF(const double LatDegree, const double LongD
 /*
   * The function AEACtoLL() converts Albers Equal Area Conic projection
   * (easting and northing) coordinates to Geodetic (latitude and longitude)
-  * coordinates, according to the current ellipsoid and Albers Equal Area 
+  * coordinates, according to the current ellipsoid and Albers Equal Area
   * Conic projection parameters.
   *
-  *   AEACEastingMeter  : input Easting/X in meters 
+  *   AEACEastingMeter  : input Easting/X in meters
   *   AEACNorthingMeter : input Northing/Y in meters
   *   LatDegree         : output Latitude in decimal degrees
   *   LongDegree        : output Longitude in decimal degrees
@@ -6392,7 +6399,7 @@ bool GeoProjectionConverter::AEACtoLL(const double AEACEastingMeter, const doubl
   }
 
   if ((AEACNorthingMeter < (aeac->aeac_false_northing_meter - Albers_Delta_Northing)) || (AEACNorthingMeter > aeac->aeac_false_northing_meter + Albers_Delta_Northing))
-  { 
+  {
     return false; /* Northing out of range */
   }
 
@@ -6461,7 +6468,7 @@ bool GeoProjectionConverter::AEACtoLL(const double AEACEastingMeter, const doubl
     else
       LatDegree = -PI_OVER_2;
   }
-  
+
   LongDegree = aeac->aeac_longitude_of_center_radian + theta / aeac->aeac_n;
 
   if (LongDegree > PI)
@@ -6484,11 +6491,11 @@ bool GeoProjectionConverter::AEACtoLL(const double AEACEastingMeter, const doubl
   * The function LLtoAEAC() converts Geodetic (latitude and longitude)
   * coordinates to Albers Equal Area Conic projection (easting and
   * northing) coordinates, according to the current ellipsoid and
-  * Albers Equal Area Conic projection parameters. 
+  * Albers Equal Area Conic projection parameters.
   *
   *   LatDegree         : input Latitude in decimal degrees
   *   LongDegree        : input Longitude in decimal degrees
-  *   AEACEastingMeter  : output Easting/X in meters 
+  *   AEACEastingMeter  : output Easting/X in meters
   *   AEACNorthingMeter : output Northing/Y in meters
   *
   * adapted from ALBERS code of U.S. Army Topographic Engineering Center
@@ -6544,10 +6551,10 @@ bool GeoProjectionConverter::LLtoAEAC(const double LatDegree, const double LongD
 /*
   * The function HOMtoLL() converts the Hotine Oblique Mercator projection
   * (easting and northing) coordinates to Geodetic (latitude and longitude)
-  * coordinates, according to the current ellipsoid and Oblique Mercator 
+  * coordinates, according to the current ellipsoid and Oblique Mercator
   * projection parameters.
   *
-  *   HOMEastingMeter    : input Easting/X in meters 
+  *   HOMEastingMeter    : input Easting/X in meters
   *   HOMNorthingMeter   : input Northing/Y in meters
   *   LatDegree         : output Latitude in decimal degrees
   *   LongDegree        : output Longitude in decimal degrees
@@ -6562,11 +6569,11 @@ bool GeoProjectionConverter::HOMtoLL(const double OMEastingMeter, const double O
   * The function LLtoHOM() converts Geodetic (latitude and longitude)
   * coordinates to the Hotine Oblique Mercator projection (easting and
   * northing) coordinates, according to the current ellipsoid and
-  * Oblique Mercator projection parameters. 
+  * Oblique Mercator projection parameters.
   *
   *   LatDegree         : input Latitude in decimal degrees
   *   LongDegree        : input Longitude in decimal degrees
-  *   HOMEastingMeter    : output Easting/X in meters 
+  *   HOMEastingMeter    : output Easting/X in meters
   *   HOMNorthingMeter   : output Northing/Y in meters
   *
 */
@@ -6581,7 +6588,7 @@ bool GeoProjectionConverter::LLtoHOM(const double LatDegree, const double LongDe
   * coordinates, according to the current ellipsoid and Oblique Stereographic
   * projection parameters.
   *
-  *   OSEastingMeter    : input Easting/X in meters 
+  *   OSEastingMeter    : input Easting/X in meters
   *   OSNorthingMeter   : input Northing/Y in meters
   *   LatDegree         : output Latitude in decimal degrees
   *   LongDegree        : output Longitude in decimal degrees
@@ -6640,11 +6647,11 @@ bool GeoProjectionConverter::OStoLL(const double OSEastingMeter, const double OS
   * The function LLtoOS() converts Geodetic (latitude and longitude)
   * coordinates to the Oblique Stereographic projection (easting and
   * northing) coordinates, according to the current ellipsoid and
-  * Oblique Stereographic projection parameters. 
+  * Oblique Stereographic projection parameters.
   *
   *   LatDegree         : input Latitude in decimal degrees
   *   LongDegree        : input Longitude in decimal degrees
-  *   OSEastingMeter    : output Easting/X in meters 
+  *   OSEastingMeter    : output Easting/X in meters
   *   OSNorthingMeter   : output Northing/Y in meters
   *
   * formulas from "Oblique Stereographic Alternative" by Gerald Evenden and Rueben Schulz
@@ -6693,7 +6700,7 @@ GeoProjectionConverter::GeoProjectionConverter()
   elevation_units_set[1] = false;
   elevation2meter = 1.0;
   meter2elevation = 1.0;
- 
+
   target_precision = 0;
   target_elevation_precision = 0;
 
@@ -6714,7 +6721,7 @@ bool GeoProjectionConverter::parse(int argc, char* argv[])
   char tmp[256];
 
   if (argv_zero) free(argv_zero);
-  argv_zero = _strdup(argv[0]);
+  argv_zero = LASCopyString(argv[0]);
 
   for (i = 1; i < argc; i++)
   {
@@ -6825,7 +6832,7 @@ bool GeoProjectionConverter::parse(int argc, char* argv[])
         vertical_geokey = GEO_VERTICAL_NAVD88;
         if (strcmp(argv[i] + 16,"") == 0)
         {
-          vertical_geoid = 0; // none 
+          vertical_geoid = 0; // none
         }
         else if (strcmp(argv[i] + 16,"_geoid12b") == 0)
         {
@@ -7766,7 +7773,7 @@ bool GeoProjectionConverter::get_img_datum_parameters(char** psDatumame, int* pr
   {
     if (ellipsoid->id == GEO_ELLIPSOID_WGS84)
     {
-      *psDatumame = _strdup("NAD27");
+      *psDatumame = LASCopyString("NAD27");
 
         if (utm->utm_northern_hemisphere)
         {
@@ -7919,7 +7926,7 @@ bool GeoProjectionConverter::get_img_projection_parameters(char** proName, int* 
     {
       *proNumber = 0;
     }
-    else if (projection->type == 
+    else if (projection->type ==
   }
   else if ()
   {
@@ -8527,7 +8534,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *
   * REUSE NOTES
   *
-  *    OBLIQUE MERCATOR is intended for reuse by any application that 
+  *    OBLIQUE MERCATOR is intended for reuse by any application that
   *    performs an Oblique Mercator projection or its inverse.
   *
   * REFERENCES
@@ -8560,14 +8567,14 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *    ----              -----------
   *    06-07-00          Original Code
   *    03-02-07          Original C++ Code
-  *    
+  *
   *
   */
- 
- 
+
+
  #include "CoordinateSystem.h"
- 
- 
+
+
  namespace MSP
  {
    namespace CCS
@@ -8575,21 +8582,21 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
      class ObliqueMercatorParameters;
      class MapProjectionCoordinates;
      class GeodeticCoordinates;
- 
- 
+
+
      /***************************************************************************/
      /*
       *                              DEFINES
       */
- 
+
      class ObliqueMercator : public CoordinateSystem
      {
      public:
- 
+
        /*
         * The constructor receives the ellipsoid parameters and
         * projection parameters as inputs, and sets the corresponding state
-        * variables.  If any errors occur, an exception is thrown with a description 
+        * variables.  If any errors occur, an exception is thrown with a description
         * of the error.
         *
         *    ellipsoidSemiMajorAxis   : Semi-major axis of ellipsoid, in meters  (input)
@@ -8611,21 +8618,21 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
         *    scaleFactor              : Multiplier which reduces distances in the
         *                               projection to the actual distance on the
         *                               ellipsoid                                (input)
-        *    errorStatus              : Error status                             (output) 
+        *    errorStatus              : Error status                             (output)
         */
- 
+
          ObliqueMercator( double ellipsoidSemiMajorAxis, double ellipsoidFlattening, double originLatitude, double longitude1, double latitude1, double longitude2, double latitude2, double falseEasting, double falseNorthing, double scaleFactor );
- 
- 
+
+
        ObliqueMercator( const ObliqueMercator &om );
- 
- 
+
+
          ~ObliqueMercator( void );
- 
- 
+
+
        ObliqueMercator& operator=( const ObliqueMercator &om );
- 
- 
+
+
        /*
         * The function getParameters returns the current ellipsoid
         * parameters and Oblique Mercator projection parameters.
@@ -8650,15 +8657,15 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
         *                              projection to the actual distance on the
         *                              ellipsoid                              (output)
         */
- 
+
        ObliqueMercatorParameters* getParameters() const;
- 
- 
+
+
        /*
         * The function convertFromGeodetic converts geodetic (latitude and
         * longitude) coordinates to Oblique Mercator projection (easting and
-        * northing) coordinates, according to the current ellipsoid and Oblique Mercator 
-        * projection parameters.  If any errors occur, an exception is thrown with a description 
+        * northing) coordinates, according to the current ellipsoid and Oblique Mercator
+        * projection parameters.  If any errors occur, an exception is thrown with a description
         * of the error.
         *
         *    longitude         : Longitude (lambda), in radians       (input)
@@ -8666,15 +8673,15 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
         *    easting           : Easting (X), in meters               (output)
         *    northing          : Northing (Y), in meters              (output)
         */
- 
+
        MSP::CCS::MapProjectionCoordinates* convertFromGeodetic( MSP::CCS::GeodeticCoordinates* geodeticCoordinates );
- 
- 
+
+
        /*
         * The function convertToGeodetic converts Oblique Mercator projection
         * (easting and northing) coordinates to geodetic (latitude and longitude)
         * coordinates, according to the current ellipsoid and Oblique Mercator projection
-        * coordinates.  If any errors occur, an exception is thrown with a description 
+        * coordinates.  If any errors occur, an exception is thrown with a description
         * of the error.
         *
         *    easting           : Easting (X), in meters                  (input)
@@ -8682,11 +8689,11 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
         *    longitude         : Longitude (lambda), in radians          (output)
         *    latitude          : Latitude (phi), in radians              (output)
         */
- 
+
        MSP::CCS::GeodeticCoordinates* convertToGeodetic( MSP::CCS::MapProjectionCoordinates* mapProjectionCoordinates );
- 
+
      private:
-     
+
        /* Ellipsoid Parameters, default to WGS 84 */
        double es;
        double es_OVER_2;
@@ -8698,7 +8705,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
        double OMerc_Origin_Long;                 /* Longitude at center of projection */
        double cos_gamma;
        double sin_gamma;
-       double sin_azimuth;  
+       double sin_azimuth;
        double cos_azimuth;
        double A_over_B;
        double B_over_A;
@@ -8713,13 +8720,13 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
        double OMerc_Scale_Factor;                /* Scale factor at projection center */
        double OMerc_False_Northing;              /* False northing, in meters, at projection center */
        double OMerc_False_Easting;               /* False easting, in meters, at projection center */
- 
+
        double OMerc_Delta_Northing;
        double OMerc_Delta_Easting;
- 
- 
+
+
        double omercT( double lat, double e_sinlat, double e_over_2 );
- 
+
      };
    }
  }
@@ -8776,7 +8783,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *
   * REUSE NOTES
   *
-  *    OBLIQUE MERCATOR is intended for reuse by any application that 
+  *    OBLIQUE MERCATOR is intended for reuse by any application that
   *    performs an Oblique Mercator projection or its inverse.
   *
   * REFERENCES
@@ -8812,13 +8819,13 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *    05-11-11          BAEts28017 - Fix Oblique Mercator near poles
   *
   */
- 
- 
+
+
  /***************************************************************************/
  /*
   *                               INCLUDES
   */
- 
+
  #include <math.h>
  #include "ObliqueMercator.h"
  #include "ObliqueMercatorParameters.h"
@@ -8827,7 +8834,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
  #include "CoordinateConversionException.h"
  #include "ErrorMessages.h"
  #include "WarningMessages.h"
- 
+
  /*
   *    math.h     - Standard C math library
   *    ObliqueMercator.h   - Is for prototype error checking
@@ -8837,29 +8844,29 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *    ErrorMessages.h  - Contains exception messages
   *    WarningMessages.h  - Contains warning messages
   */
- 
- 
+
+
  using namespace MSP::CCS;
- 
- 
+
+
  /***************************************************************************/
- /*                               DEFINES 
+ /*                               DEFINES
   *
   */
- 
+
  const double PI = 3.14159265358979323e0;  /* PI                            */
- const double PI_OVER_2 = ( PI / 2.0);                 
- const double PI_OVER_4 = ( PI / 4.0);                 
- const double TWO_PI = ( 2.0 * PI);                 
+ const double PI_OVER_2 = ( PI / 2.0);
+ const double PI_OVER_4 = ( PI / 4.0);
+ const double TWO_PI = ( 2.0 * PI);
  const double MIN_SCALE_FACTOR = 0.3;
  const double MAX_SCALE_FACTOR = 3.0;
- 
- 
+
+
  /************************************************************************/
- /*                              FUNCTIONS     
+ /*                              FUNCTIONS
   *
   */
- 
+
  ObliqueMercator::ObliqueMercator( double ellipsoidSemiMajorAxis, double ellipsoidFlattening, double originLatitude, double longitude1, double latitude1, double longitude2, double latitude2, double falseEasting, double falseNorthing, double scaleFactor ) :
    CoordinateSystem(),
    es( 0.08181919084262188000 ),
@@ -8872,7 +8879,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    OMerc_Origin_Long( -.46732023406900 ),
    cos_gamma( .91428423352628 ),
    sin_gamma( .40507325303611 ),
-   sin_azimuth( .57237890829911 ),  
+   sin_azimuth( .57237890829911 ),
    cos_azimuth( .81998925927985 ),
    A_over_B( 6378101.0302010 ),
    B_over_A( 1.5678647849335e-7 ),
@@ -8891,7 +8898,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
  /*
   * The constructor receives the ellipsoid parameters and
   * projection parameters as inputs, and sets the corresponding state
-  * variables.  If any errors occur, an exception is thrown with a description 
+  * variables.  If any errors occur, an exception is thrown with a description
   * of the error.
   *
   *    ellipsoidSemiMajorAxis   : Semi-major axis of ellipsoid, in meters  (input)
@@ -8914,7 +8921,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *                               projection to the actual distance on the
   *                               ellipsoid                                (input)
   */
- 
+
    double inv_f = 1 / ellipsoidFlattening;
    double es2, one_MINUS_es2;
    double cos_olat, cos_olat2;
@@ -8925,7 +8932,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    double E2;
    double F, G, J, P;
    double dlon;
- 
+
    if (ellipsoidSemiMajorAxis <= 0.0)
    { /* Semi-major axis must be greater than zero */
      throw CoordinateConversionException( ErrorMessages::semiMajorAxis );
@@ -8971,10 +8978,10 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    { /* scale factor out of range */
      throw CoordinateConversionException( ErrorMessages::scaleFactor );
    }
- 
+
    semiMajorAxis = ellipsoidSemiMajorAxis;
    flattening = ellipsoidFlattening;
- 
+
    OMerc_Origin_Lat = originLatitude;
    OMerc_Lon_1 = longitude1;
    OMerc_Lat_1 = latitude1;
@@ -8983,28 +8990,28 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    OMerc_False_Northing = falseNorthing;
    OMerc_False_Easting = falseEasting;
    OMerc_Scale_Factor = scaleFactor;
- 
+
    es2 = 2 * flattening - flattening * flattening;
    es = sqrt(es2);
    one_MINUS_es2 = 1 - es2;
    es_OVER_2 = es / 2.0;
- 
+
    cos_olat = cos(OMerc_Origin_Lat);
    cos_olat2 = cos_olat * cos_olat;
    sin_olat = sin(OMerc_Origin_Lat);
    sin_olat2 = sin_olat * sin_olat;
    es2_sin_olat2 = es2 * sin_olat2;
- 
+
    OMerc_B = sqrt(1 + (es2 * cos_olat2 * cos_olat2) / one_MINUS_es2);
-   OMerc_A = (semiMajorAxis * OMerc_B * OMerc_Scale_Factor * sqrt(one_MINUS_es2)) / (1.0 - es2_sin_olat2);  
+   OMerc_A = (semiMajorAxis * OMerc_B * OMerc_Scale_Factor * sqrt(one_MINUS_es2)) / (1.0 - es2_sin_olat2);
    A_over_B = OMerc_A / OMerc_B;
    B_over_A = OMerc_B / OMerc_A;
- 
+
    t0 = omercT(OMerc_Origin_Lat, es * sin_olat, es_OVER_2);
-   t1 = omercT(OMerc_Lat_1, es * sin(OMerc_Lat_1), es_OVER_2);  
-   t2 = omercT(OMerc_Lat_2, es * sin(OMerc_Lat_2), es_OVER_2);  
- 
-   D = (OMerc_B * sqrt(one_MINUS_es2)) / (cos_olat * sqrt(1.0 - es2_sin_olat2)); 
+   t1 = omercT(OMerc_Lat_1, es * sin(OMerc_Lat_1), es_OVER_2);
+   t2 = omercT(OMerc_Lat_2, es * sin(OMerc_Lat_2), es_OVER_2);
+
+   D = (OMerc_B * sqrt(one_MINUS_es2)) / (cos_olat * sqrt(1.0 - es2_sin_olat2));
    D2 = D * D;
    if (D2 < 1.0)
      D2 = 1.0;
@@ -9027,7 +9034,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    LH = L * H;
    J = (E2 - LH) / (E2 + LH);
    P = (L - H) / (L + H);
- 
+
    dlon = OMerc_Lon_1 - OMerc_Lon_2;
    if (dlon < -PI )
      OMerc_Lon_2 -= TWO_PI;
@@ -9035,103 +9042,103 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
      OMerc_Lon_2 += TWO_PI;
    dlon = OMerc_Lon_1 - OMerc_Lon_2;
    OMerc_Origin_Long = (OMerc_Lon_1 + OMerc_Lon_2) / 2.0 - (atan(J * tan(OMerc_B * dlon / 2.0) / P)) / OMerc_B;
- 
+
    dlon = OMerc_Lon_1 - OMerc_Origin_Long;
    if (dlon < -PI )
      OMerc_Origin_Long -= TWO_PI;
    if (dlon > PI)
      OMerc_Origin_Long += TWO_PI;
-  
+
    dlon = OMerc_Lon_1 - OMerc_Origin_Long;
    OMerc_gamma = atan(sin(OMerc_B * dlon) / G);
    cos_gamma = cos(OMerc_gamma);
    sin_gamma = sin(OMerc_gamma);
- 
+
    OMerc_azimuth = asin(D * sin_gamma);
    cos_azimuth = cos(OMerc_azimuth);
    sin_azimuth = sin(OMerc_azimuth);
- 
+
    if (OMerc_Origin_Lat >= 0)
      OMerc_u =  A_over_B * atan(sqrt_D2_MINUS_1/cos_azimuth);
    else
      OMerc_u = -A_over_B * atan(sqrt_D2_MINUS_1/cos_azimuth);
  }
- 
- 
+
+
  ObliqueMercator::ObliqueMercator( const ObliqueMercator &om )
  {
    semiMajorAxis = om.semiMajorAxis;
    flattening = om.flattening;
-   es = om.es;     
-   es_OVER_2 = om.es_OVER_2;     
-   OMerc_A = om.OMerc_A;     
-   OMerc_B = om.OMerc_B;     
-   OMerc_E = om.OMerc_E;     
-   OMerc_gamma = om.OMerc_gamma; 
-   OMerc_azimuth = om.OMerc_azimuth; 
-   OMerc_Origin_Long = om.OMerc_Origin_Long; 
-   cos_gamma = om.cos_gamma; 
-   sin_gamma = om.sin_gamma; 
-   sin_azimuth = om.sin_azimuth; 
-   cos_azimuth = om.cos_azimuth; 
-   A_over_B = om.A_over_B; 
-   B_over_A = om.B_over_A; 
-   OMerc_u = om.OMerc_u; 
-   OMerc_Origin_Lat = om.OMerc_Origin_Lat; 
-   OMerc_Lon_1 = om.OMerc_Lon_1; 
-   OMerc_Lat_1 = om.OMerc_Lat_1; 
-   OMerc_Lon_2 = om.OMerc_Lon_2; 
-   OMerc_Lat_2 = om.OMerc_Lat_2; 
-   OMerc_False_Easting = om.OMerc_False_Easting; 
-   OMerc_False_Northing = om.OMerc_False_Northing; 
-   OMerc_Scale_Factor = om.OMerc_Scale_Factor; 
-   OMerc_Delta_Northing = om.OMerc_Delta_Northing; 
-   OMerc_Delta_Easting = om.OMerc_Delta_Easting; 
+   es = om.es;
+   es_OVER_2 = om.es_OVER_2;
+   OMerc_A = om.OMerc_A;
+   OMerc_B = om.OMerc_B;
+   OMerc_E = om.OMerc_E;
+   OMerc_gamma = om.OMerc_gamma;
+   OMerc_azimuth = om.OMerc_azimuth;
+   OMerc_Origin_Long = om.OMerc_Origin_Long;
+   cos_gamma = om.cos_gamma;
+   sin_gamma = om.sin_gamma;
+   sin_azimuth = om.sin_azimuth;
+   cos_azimuth = om.cos_azimuth;
+   A_over_B = om.A_over_B;
+   B_over_A = om.B_over_A;
+   OMerc_u = om.OMerc_u;
+   OMerc_Origin_Lat = om.OMerc_Origin_Lat;
+   OMerc_Lon_1 = om.OMerc_Lon_1;
+   OMerc_Lat_1 = om.OMerc_Lat_1;
+   OMerc_Lon_2 = om.OMerc_Lon_2;
+   OMerc_Lat_2 = om.OMerc_Lat_2;
+   OMerc_False_Easting = om.OMerc_False_Easting;
+   OMerc_False_Northing = om.OMerc_False_Northing;
+   OMerc_Scale_Factor = om.OMerc_Scale_Factor;
+   OMerc_Delta_Northing = om.OMerc_Delta_Northing;
+   OMerc_Delta_Easting = om.OMerc_Delta_Easting;
  }
- 
- 
+
+
  ObliqueMercator::~ObliqueMercator()
  {
  }
- 
- 
+
+
  ObliqueMercator& ObliqueMercator::operator=( const ObliqueMercator &om )
  {
    if( this != &om )
    {
      semiMajorAxis = om.semiMajorAxis;
      flattening = om.flattening;
-     es = om.es;     
-     es_OVER_2 = om.es_OVER_2;     
-     OMerc_A = om.OMerc_A;     
-     OMerc_B = om.OMerc_B;     
-     OMerc_E = om.OMerc_E;     
-     OMerc_gamma = om.OMerc_gamma; 
-     OMerc_azimuth = om.OMerc_azimuth; 
-     OMerc_Origin_Long = om.OMerc_Origin_Long; 
-     cos_gamma = om.cos_gamma; 
-     sin_gamma = om.sin_gamma; 
-     sin_azimuth = om.sin_azimuth; 
-     cos_azimuth = om.cos_azimuth; 
-     A_over_B = om.A_over_B; 
-     B_over_A = om.B_over_A; 
-     OMerc_u = om.OMerc_u; 
-     OMerc_Origin_Lat = om.OMerc_Origin_Lat; 
-     OMerc_Lon_1 = om.OMerc_Lon_1; 
-     OMerc_Lat_1 = om.OMerc_Lat_1; 
-     OMerc_Lon_2 = om.OMerc_Lon_2; 
-     OMerc_Lat_2 = om.OMerc_Lat_2; 
-     OMerc_False_Easting = om.OMerc_False_Easting; 
-     OMerc_False_Northing = om.OMerc_False_Northing; 
-     OMerc_Scale_Factor = om.OMerc_Scale_Factor; 
-     OMerc_Delta_Northing = om.OMerc_Delta_Northing; 
-     OMerc_Delta_Easting = om.OMerc_Delta_Easting; 
+     es = om.es;
+     es_OVER_2 = om.es_OVER_2;
+     OMerc_A = om.OMerc_A;
+     OMerc_B = om.OMerc_B;
+     OMerc_E = om.OMerc_E;
+     OMerc_gamma = om.OMerc_gamma;
+     OMerc_azimuth = om.OMerc_azimuth;
+     OMerc_Origin_Long = om.OMerc_Origin_Long;
+     cos_gamma = om.cos_gamma;
+     sin_gamma = om.sin_gamma;
+     sin_azimuth = om.sin_azimuth;
+     cos_azimuth = om.cos_azimuth;
+     A_over_B = om.A_over_B;
+     B_over_A = om.B_over_A;
+     OMerc_u = om.OMerc_u;
+     OMerc_Origin_Lat = om.OMerc_Origin_Lat;
+     OMerc_Lon_1 = om.OMerc_Lon_1;
+     OMerc_Lat_1 = om.OMerc_Lat_1;
+     OMerc_Lon_2 = om.OMerc_Lon_2;
+     OMerc_Lat_2 = om.OMerc_Lat_2;
+     OMerc_False_Easting = om.OMerc_False_Easting;
+     OMerc_False_Northing = om.OMerc_False_Northing;
+     OMerc_Scale_Factor = om.OMerc_Scale_Factor;
+     OMerc_Delta_Northing = om.OMerc_Delta_Northing;
+     OMerc_Delta_Easting = om.OMerc_Delta_Easting;
    }
- 
+
    return *this;
  }
- 
- 
+
+
  ObliqueMercatorParameters* ObliqueMercator::getParameters() const
  {
  /*
@@ -9158,18 +9165,18 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *                              projection to the actual distance on the
   *                              ellipsoid                              (output)
   */
- 
+
    return new ObliqueMercatorParameters( CoordinateType::obliqueMercator, OMerc_Origin_Lat, OMerc_Lon_1, OMerc_Lat_1, OMerc_Lon_2, OMerc_Lat_2, OMerc_False_Easting, OMerc_False_Northing, OMerc_Scale_Factor );
  }
- 
- 
+
+
  MSP::CCS::MapProjectionCoordinates* ObliqueMercator::convertFromGeodetic( MSP::CCS::GeodeticCoordinates* geodeticCoordinates )
  {
  /*
   * The function convertFromGeodetic converts geodetic (latitude and
   * longitude) coordinates to Oblique Mercator projection (easting and
-  * northing) coordinates, according to the current ellipsoid and Oblique Mercator 
-  * projection parameters.  If any errors occur, an exception is thrown with a description 
+  * northing) coordinates, according to the current ellipsoid and Oblique Mercator
+  * projection parameters.  If any errors occur, an exception is thrown with a description
   * of the error.
   *
   *    longitude         : Longitude (lambda), in radians       (input)
@@ -9177,7 +9184,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *    easting           : Easting (X), in meters               (output)
   *    northing          : Northing (Y), in meters              (output)
   */
- 
+
    double dlam, B_dlam, cos_B_dlam;
    double t, S, T, V, U;
    double Q, Q_inv;
@@ -9185,10 +9192,10 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    /* Natural origin*/
    double v = 0;
    double u = 0;
- 
+
    double longitude = geodeticCoordinates->longitude();
    double latitude = geodeticCoordinates->latitude();
- 
+
    if ((latitude < -PI_OVER_2) || (latitude > PI_OVER_2))
    { /* Latitude out of range */
      throw CoordinateConversionException( ErrorMessages::latitude );
@@ -9197,16 +9204,16 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    { /* Longitude out of range */
      throw CoordinateConversionException( ErrorMessages::longitude );
    }
- 
+
    dlam = longitude - OMerc_Origin_Long;
- 
+
    char warning[256];
    warning[0] = '\0';
    if (fabs(dlam) >= PI_OVER_2)
    { /* Distortion will result if Longitude is 90 degrees or more from the Central Meridian */
      strcat( warning, MSP::CCS::WarningMessages::longitude );
    }
- 
+
    if (dlam > PI)
    {
      dlam -= TWO_PI;
@@ -9215,10 +9222,10 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    {
      dlam += TWO_PI;
    }
- 
+
    if (fabs(fabs(latitude) - PI_OVER_2) > 1.0e-10)
    {
-     t = omercT(latitude, es * sin(latitude), es_OVER_2);  
+     t = omercT(latitude, es * sin(latitude), es_OVER_2);
      Q = OMerc_E / pow(t, OMerc_B);
      Q_inv = 1.0 / Q;
      S = (Q - Q_inv) / 2.0;
@@ -9257,25 +9264,25 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
        v = A_over_B * log(tan(PI_OVER_4 + (OMerc_gamma / 2.0)));
      u = A_over_B * latitude;
    }
- 
- 
+
+
    u = u - OMerc_u;
- 
+
    double easting = OMerc_False_Easting + v * cos_azimuth + u * sin_azimuth;
    double northing = OMerc_False_Northing + u * cos_azimuth - v * sin_azimuth;
- 
+
    return new MapProjectionCoordinates(
       CoordinateType::obliqueMercator, warning, easting, northing );
  }
- 
- 
+
+
  MSP::CCS::GeodeticCoordinates* ObliqueMercator::convertToGeodetic( MSP::CCS::MapProjectionCoordinates* mapProjectionCoordinates )
  {
  /*
   * The function convertToGeodetic converts Oblique Mercator projection
   * (easting and northing) coordinates to geodetic (latitude and longitude)
   * coordinates, according to the current ellipsoid and Oblique Mercator projection
-  * coordinates.  If any errors occur, an exception is thrown with a description 
+  * coordinates.  If any errors occur, an exception is thrown with a description
   * of the error.
   *
   *    easting           : Easting (X), in meters                  (input)
@@ -9283,7 +9290,7 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
   *    longitude         : Longitude (lambda), in radians          (output)
   *    latitude          : Latitude (phi), in radians              (output)
   */
- 
+
    double dx, dy;
    /* Coordinate axes defined with respect to the azimuth of the center line */
    /* Natural origin*/
@@ -9297,21 +9304,21 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
    double temp_phi = 0.0;
    int count = 60;
    double longitude, latitude;
- 
+
    double easting  = mapProjectionCoordinates->easting();
    double northing = mapProjectionCoordinates->northing();
- 
-   if ((easting < (OMerc_False_Easting - OMerc_Delta_Easting)) 
+
+   if ((easting < (OMerc_False_Easting - OMerc_Delta_Easting))
        || (easting > (OMerc_False_Easting + OMerc_Delta_Easting)))
    { /* Easting out of range  */
      throw CoordinateConversionException( ErrorMessages::easting );
    }
-   if ((northing < (OMerc_False_Northing - OMerc_Delta_Northing)) 
+   if ((northing < (OMerc_False_Northing - OMerc_Delta_Northing))
        || (northing > (OMerc_False_Northing + OMerc_Delta_Northing)))
    { /* Northing out of range */
      throw CoordinateConversionException( ErrorMessages::northing );
    }
- 
+
    dy = northing - OMerc_False_Northing;
    dx = easting - OMerc_False_Easting;
    v = dx * cos_azimuth - dy * sin_azimuth;
@@ -9343,48 +9350,48 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
        phi = PI_OVER_2 - 2.0 * atan(t * pow((1.0 - es_sin) / (1.0 + es_sin), es_OVER_2));
        count --;
      }
- 
+
      if(!count)
        throw CoordinateConversionException( ErrorMessages::northing );
- 
+
      latitude = phi;
      longitude = OMerc_Origin_Long - atan2((S_prime * cos_gamma - V_prime * sin_gamma), cos(u_B_over_A)) / OMerc_B;
    }
- 
+
    if (fabs(latitude) < 2.0e-7)  /* force lat to 0 to avoid -0 degrees */
      latitude = 0.0;
    if (latitude > PI_OVER_2)  /* force distorted values to 90, -90 degrees */
      latitude = PI_OVER_2;
    else if (latitude < -PI_OVER_2)
      latitude = -PI_OVER_2;
- 
+
    if (longitude > PI)
      longitude -= TWO_PI;
    if (longitude < -PI)
      longitude += TWO_PI;
- 
+
    if (fabs(longitude) < 2.0e-7)  /* force lon to 0 to avoid -0 degrees */
      longitude = 0.0;
    if (longitude > PI)  /* force distorted values to 180, -180 degrees */
      longitude = PI;
    else if (longitude < -PI)
      longitude = -PI;
- 
+
    char warning[256];
    warning[0] = '\0';
    if (fabs(longitude - OMerc_Origin_Long) >= PI_OVER_2)
    { /* Distortion results if Longitude > 90 degrees from the Central Meridian */
      strcat( warning, MSP::CCS::WarningMessages::longitude );
    }
- 
+
    return new GeodeticCoordinates(
       CoordinateType::geodetic, warning, longitude, latitude );
  }
- 
- 
+
+
  double ObliqueMercator::omercT( double lat, double e_sinlat, double e_over_2 )
- {  
+ {
    return (tan(PI_OVER_4 - lat / 2.0)) / (pow((1 - e_sinlat) / (1 + e_sinlat), e_over_2));
  }
- 
+
 #endif // NOT

--- a/src/geoprojectionconverter.hpp
+++ b/src/geoprojectionconverter.hpp
@@ -2,7 +2,7 @@
 ===============================================================================
 
   FILE:  geoprojectionconverter.hpp
-  
+
   CONTENTS:
 
     Easy conversion between horizontal datums: UTM coodinates, Transverse
@@ -12,7 +12,7 @@
 
     Converting between UTM coodinates and latitude / longitude coodinates
     adapted from code written by Chuck Gantz (chuck.gantz@globalstar.com)
-  
+
     Converting between Lambert Conformal Conic and latitude / longitude
     adapted from code written by Garrett Potts (gpotts@imagelinks.com)
 
@@ -32,14 +32,14 @@
     formulas from "Oblique Stereographic Alternative" by Gerald Evenden and Rueben Schulz
 
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     chuck.gantz@globalstar.com
     gpotts@imagelinks.com
     craig.larrimore@noaa.gov
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2017, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -48,13 +48,14 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
 
+     7 September 2018 -- introduced the LASCopyString macro to replace _strdup
     30 October 2017 -- '-vertical_evrf2007' for European Vertical Reference Frame 2007
      1 February 2017 -- set_projection_from_ogc_wkt() from EPSG code of OGC WKT string
      9 November 2016 -- support "user defined" AlbersEqualArea projection in GeoTIFF
-    30 July 2016 -- no more special handling for stateplanes. just parse for EPSG code 
+    30 July 2016 -- no more special handling for stateplanes. just parse for EPSG code
      9 January 2016 -- use GeographicTypeGeoKey not GeogGeodeticDatumGeoKey for custom
      2 January 2016 -- parse 'pcs.csv' file when unknown EPSG code is encountered
     28 June 2015 -- tried to add the Oblique Mercator projection (very incomplete)
@@ -62,7 +63,7 @@
      3 March 2015 -- LCC/TM custom projections write GeogGeodeticDatumGeoKey
     13 August 2014 -- added long overdue ECEF (geocentric) conversion
      8 February 2007 -- created after interviews with purdue and google
-  
+
 ===============================================================================
 */
 #ifndef GEO_PROJECTION_CONVERTER_HPP
@@ -395,7 +396,7 @@ public:
   bool to_lon_lat_ele(double* point) const;
   bool to_lon_lat_ele(const double* point, double& longitude, double& latitude, double& elevation_in_meter) const;
 
-  // from current projection to target projection 
+  // from current projection to target projection
 
   bool to_target(double* point) const;
   bool to_target(const double* point, double& x, double& y, double& elevation) const;
@@ -411,7 +412,7 @@ public:
 //  int get_img_projection_number(bool source=true) const;
   bool get_dtm_projection_parameters(short* horizontal_units, short* vertical_units, short* coordinate_system, short* coordinate_zone, short* horizontal_datum, short* vertical_datum, bool source=true);
   bool set_dtm_projection_parameters(short horizontal_units, short vertical_units, short coordinate_system, short coordinate_zone, short horizontal_datum, short vertical_datum, bool source=true);
-  
+
   // helps us to find the 'pcs.csv' file
   char* argv_zero;
 

--- a/src/las2txt.cpp
+++ b/src/las2txt.cpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  las2txt.cpp
-  
+
   CONTENTS:
-  
+
     This tool converts LIDAR data from the binary LAS format to a human
     readable ASCII format. The tool can create different formattings for
     the textual representation that are controlable via the 'parse' and
@@ -12,11 +12,11 @@
     beginning of the file each line preceeded by some comment symbol.
 
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2017, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -25,23 +25,24 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
-    22 November 2017 -- parse attributes with indices > 9 by bracketing (12) them 
-    19 April 2017 -- 1st example for selective decompression for new LAS 1.4 points 
+
+     7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
+    22 November 2017 -- parse attributes with indices > 9 by bracketing (12) them
+    19 April 2017 -- 1st example for selective decompression for new LAS 1.4 points
     11 January 2017 -- added with<h>eld and scanner channe<l> for the parse string
     24 April 2015 -- added 'k'eypoint and 'o'verlap flags for the parse string
-    30 March 2015 -- support LAS 1.4 extended return counts and number of returns 
+    30 March 2015 -- support LAS 1.4 extended return counts and number of returns
     25 October 2011 -- changed LAS 1.3 parsing to use new LASwaveform13reader
     17 May 2011 -- enabling batch processing with wildcards or multiple file names
     13 May 2011 -- moved indexing, filtering, transforming into LASreader
-    15 March 2011 -- added the 'E' option to place an '-extra STRING' 
-    26 January 2011 -- added the LAStransform to modify before output 
-     4 January 2011 -- added the LASfilter to drop or keep points 
+    15 March 2011 -- added the 'E' option to place an '-extra STRING'
+    26 January 2011 -- added the LAStransform to modify before output
+     4 January 2011 -- added the LASfilter to drop or keep points
      1 January 2011 -- added LAS 1.3 waveforms while homesick for Livermore
      1 December 2010 -- support output of raw unscaled XYZ coordinates
-    12 March 2009 -- updated to ask for input if started without arguments 
+    12 March 2009 -- updated to ask for input if started without arguments
     17 September 2008 -- updated to deal with LAS format version 1.2
     13 June 2007 -- added 'e' and 'd' for the parse string and fixed 'n'
      6 June 2007 -- added lidardouble2string() after Vinton Valentine's bug report
@@ -425,7 +426,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == '–') argv[i][0] = '-';
+      if (argv[i][0] == 'ï¿½') argv[i][0] = '-';
       if (strcmp(argv[i],"-opts") == 0)
       {
         opts = TRUE;
@@ -495,12 +496,12 @@ int main(int argc, char *argv[])
       }
       i++;
       if (parse_string) free(parse_string);
-      parse_string = _strdup(argv[i]);
+      parse_string = LASCopyString(argv[i]);
     }
     else if (strcmp(argv[i],"-parse_all") == 0)
     {
       if (parse_string) free(parse_string);
-      parse_string = _strdup("txyzirndecaup");
+      parse_string = LASCopyString("txyzirndecaup");
     }
     else if (strcmp(argv[i],"-extra") == 0)
     {
@@ -787,7 +788,7 @@ int main(int argc, char *argv[])
     LASheader* header = &(lasreader->header);
 
     // open output file
-  
+
     FILE* file_out;
 
     if (laswriteopener.is_piped())
@@ -796,7 +797,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-      // create output file name if needed 
+      // create output file name if needed
 
       if (laswriteopener.get_file_name() == 0)
       {
@@ -839,11 +840,11 @@ int main(int argc, char *argv[])
           if (parse_string) free(parse_string);
           if (ptsVLR && (ptsVLR->record_length_after_header >= 32))
           {
-            parse_string = _strdup((CHAR*)(ptsVLR->data + 16));
+            parse_string = LASCopyString((CHAR*)(ptsVLR->data + 16));
           }
           else if (ptxVLR && (ptxVLR->record_length_after_header >= 32))
           {
-            parse_string = _strdup((CHAR*)(ptxVLR->data + 16));
+            parse_string = LASCopyString((CHAR*)(ptxVLR->data + 16));
           }
           else if (ptsVLR)
           {
@@ -890,7 +891,7 @@ int main(int argc, char *argv[])
         if ((parse_string == 0) || (strcmp(parse_string, "original") == 0))
         {
           if (parse_string) free(parse_string);
-          parse_string = _strdup((CHAR*)(payload + 16));
+          parse_string = LASCopyString((CHAR*)(payload + 16));
         }
         fprintf(file_out, "%u     \012", (U32)((I64*)payload)[4]); // ncols
         fprintf(file_out, "%u     \012", (U32)((I64*)payload)[5]); // nrows
@@ -973,7 +974,7 @@ int main(int argc, char *argv[])
 
     // maybe create default parse string
 
-    if (parse_string == 0) parse_string = _strdup("xyz");
+    if (parse_string == 0) parse_string = LASCopyString("xyz");
 
     // check requested fields and print warnings if attributes do not exist
 

--- a/src/lasdiff.cpp
+++ b/src/lasdiff.cpp
@@ -10,11 +10,11 @@
     are checked.
 
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-17, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -26,12 +26,13 @@
 
   CHANGE HISTORY:
 
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
     13 July 2017 -- added missing checks for LAS 1.4 EVLR size and payloads
-    18 August 2015 -- fixed report for truncated files (fewer or more points) 
+    18 August 2015 -- fixed report for truncated files (fewer or more points)
     11 September 2014 -- added missing checks for LAS 1.4 files and points
     27 July 2011 -- added capability to create a difference output file
-    2 December 2010 -- updated to merely warn when the point scaling is off  
-    12 March 2009 -- updated to ask for input if started without arguments 
+    2 December 2010 -- updated to merely warn when the point scaling is off
+    12 March 2009 -- updated to ask for input if started without arguments
     17 September 2008 -- updated to deal with LAS format version 1.2
     11 July 2007 -- added more complete reporting about differences
     23 February 2007 -- created just before getting ready for the cabin trip
@@ -132,7 +133,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == '–') argv[i][0] = '-';
+      if (argv[i][0] == 'ï¿½') argv[i][0] = '-';
     }
     if (!lasreadopener.parse(argc, argv)) byebye(true);
     if (!laswriteopener.parse(argc, argv)) byebye(true);
@@ -219,14 +220,14 @@ int main(int argc, char *argv[])
     if (lasreadopener.get_file_name_number() == 2)
     {
       lasreader1 = lasreadopener.open();
-      file_name1 = _strdup(lasreadopener.get_file_name());
+      file_name1 = LASCopyString(lasreadopener.get_file_name());
       if (lasreader1 == 0)
       {
         fprintf (stderr, "ERROR: cannot open '%s'\n", file_name1);
         byebye(true, argc==1);
       }
       lasreader2 = lasreadopener.open();
-      file_name2 = _strdup(lasreadopener.get_file_name());
+      file_name2 = LASCopyString(lasreadopener.get_file_name());
       if (lasreader2 == 0)
       {
         fprintf (stderr, "ERROR: cannot open '%s'\n", file_name2);
@@ -236,13 +237,13 @@ int main(int argc, char *argv[])
     else
     {
       lasreader1 = lasreadopener.open();
-      file_name1 = _strdup(lasreadopener.get_file_name());
+      file_name1 = LASCopyString(lasreadopener.get_file_name());
       if (lasreader1 == 0)
       {
         fprintf (stderr, "ERROR: cannot open '%s'\n", file_name1);
         byebye(true, argc==1);
       }
-      file_name2 = _strdup(lasreadopener.get_file_name());
+      file_name2 = LASCopyString(lasreadopener.get_file_name());
       int len = strlen(file_name1);
       if (strncmp(&file_name1[len-4], ".las", 4) == 0)
       {
@@ -287,7 +288,7 @@ int main(int argc, char *argv[])
     if (memcmp((const void*)&(lasreader1->header), (const void*)&(lasreader2->header), memcmp_until))
     {
       char printstring[128];
-    
+
       LASheader* lasheader1 = &(lasreader1->header);
       LASheader* lasheader2 = &(lasreader2->header);
 
@@ -732,7 +733,7 @@ int main(int argc, char *argv[])
                 different_scaled_offset_coordinates++;
               }
             }
-            else 
+            else
             {
               if (lasreader1->point.get_X() != lasreader2->point.get_X())
               {

--- a/src/laszip.cpp
+++ b/src/laszip.cpp
@@ -2,18 +2,18 @@
 ===============================================================================
 
   FILE:  laszip.cpp
-  
+
   CONTENTS:
-  
+
     This tool compresses and uncompresses LiDAR data in the LAS format to our
     losslessly compressed LAZ format.
 
   PROGRAMMERS:
-  
+
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2015, martin isenburg, rapidlasso - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -22,21 +22,22 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
-    29 March 2015 -- using LASwriterCompatible for LAS 1.4 compatibility mode  
-    9 September 2014 -- prototyping forward-compatible coding of LAS 1.4 points  
+
+    7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
+    29 March 2015 -- using LASwriterCompatible for LAS 1.4 compatibility mode
+    9 September 2014 -- prototyping forward-compatible coding of LAS 1.4 points
     5 August 2011 -- possible to add/change projection info in command line
-    23 June 2011 -- turned on LASzip version 2.0 compressor with chunking 
+    23 June 2011 -- turned on LASzip version 2.0 compressor with chunking
     17 May 2011 -- enabling batch processing with wildcards or multiple file names
     25 April 2011 -- added chunking for random access decompression
-    23 January 2011 -- added LASreadOpener and LASwriteOpener 
+    23 January 2011 -- added LASreadOpener and LASwriteOpener
     16 December 2010 -- updated to use the new library
-    12 March 2009 -- updated to ask for input if started without arguments 
+    12 March 2009 -- updated to ask for input if started without arguments
     17 September 2008 -- updated to deal with LAS format version 1.2
     14 February 2007 -- created after picking flowers for the Valentine dinner
-  
+
 ===============================================================================
 */
 
@@ -165,7 +166,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == '–') argv[i][0] = '-';
+      if (argv[i][0] == 'ï¿½') argv[i][0] = '-';
     }
     if (!geoprojectionconverter.parse(argc, argv)) byebye(true);
     if (!lasreadopener.parse(argc, argv)) byebye(true);
@@ -452,7 +453,7 @@ int main(int argc, char *argv[])
     {
       I64 start_of_waveform_data_packet_record = 0;
 
-      // create output file name if no output was specified 
+      // create output file name if no output was specified
       if (!laswriteopener.active())
       {
         if (lasreadopener.get_file_name() == 0)
@@ -529,7 +530,7 @@ int main(int argc, char *argv[])
         if (lasreader->header.global_encoding & 2) // if bit # 1 is set we have internal waveform data
         {
           lasreader->header.global_encoding &= ~((U16)2); // remove internal bit
-          if (lasreader->header.start_of_waveform_data_packet_record) // offset to 
+          if (lasreader->header.start_of_waveform_data_packet_record) // offset to
           {
             start_of_waveform_data_packet_record = lasreader->header.start_of_waveform_data_packet_record;
             lasreader->header.start_of_waveform_data_packet_record = 0;
@@ -543,7 +544,7 @@ int main(int argc, char *argv[])
       // open laswriter
 
       LASwriter* laswriter = 0;
-      
+
       if ((lasreader->header.point_data_format > 5) && !laswriteopener.get_native() && (laswriteopener.get_format() == LAS_TOOLS_FORMAT_LAZ))
       {
         LASwriterCompatibleDown* laswritercompatibledown = new LASwriterCompatibleDown();
@@ -735,7 +736,7 @@ int main(int argc, char *argv[])
             // create lax index
             LASindex lasindex;
             lasindex.prepare(lasquadtree, threshold);
-  
+
             // compress points and add to index
             while (lasreader->read_point())
             {
@@ -802,7 +803,7 @@ int main(int argc, char *argv[])
             // create lax index
             LASindex lasindex;
             lasindex.prepare(lasquadtree, threshold);
-  
+
             // compress points and add to index
             while (lasreader->read_point())
             {
@@ -866,7 +867,7 @@ int main(int argc, char *argv[])
       }
 
       delete laswriter;
-  
+
 #ifdef _WIN32
       if (verbose) fprintf(stderr,"%g secs to write %I64d bytes for '%s' with %I64d points of type %d\n", taketime()-start_time, bytes_written, laswriteopener.get_file_name(), lasreader->p_count, lasreader->header.point_data_format);
 #else
@@ -881,7 +882,7 @@ int main(int argc, char *argv[])
         char* wave_form_file_name;
         if (laswriteopener.get_file_name())
         {
-          wave_form_file_name = _strdup(laswriteopener.get_file_name());
+          wave_form_file_name = LASCopyString(laswriteopener.get_file_name());
           int len = strlen(wave_form_file_name);
           if (wave_form_file_name[len-3] == 'L')
           {
@@ -898,7 +899,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-          wave_form_file_name = _strdup("wave_form.wdp");
+          wave_form_file_name = LASCopyString("wave_form.wdp");
         }
         FILE* file = fopen(wave_form_file_name, "wb");
         if (file)
@@ -926,7 +927,7 @@ int main(int argc, char *argv[])
         laswriteopener.set_format((const CHAR*)NULL);
       }
     }
-  
+
     lasreader->close();
 
     delete lasreader;


### PR DESCRIPTION
The only functional change I made was to replace calls to _strdup (which wouldn't compile in my GCC environment) with calls to the LASCopyString macro which already existed in laszip.hpp and appeared to be designed for this purpose.

Two files, however, did not include the correct headers to be able to see this macro, so instead of including headers (which I thought could be potentially upsetting to your header dependencies), I just copied the LASCopyString macro directly into the file in those cases. The two files for which I did this were:
geoprojectionconverter.cpp
laszipdllexample.cpp

I realized afterward that my IDE also removed trailing white spaces after the end of lines in the files that I modified, but I figured this could only be a good thing anyway. It does make the commit harder to read though.

Anyway, tell me if I'm full of crap.