### PR TITLE
Fix warning -Wself-assign-field

### DIFF
--- a/LASlib/src/lastransform.cpp
+++ b/LASlib/src/lastransform.cpp
@@ -860,7 +860,7 @@ public:
       point->set_extended_classification(class_to);
     }
   };
-  LASoperationClassifyAttributeBetweenAs(U32 index, F64 z_below, F64 z_above, U8 class_to) { this->index = index; this->below = below; this->above = above; this->class_to = class_to; };
+  LASoperationClassifyAttributeBetweenAs(U32 index, F64 z_below, F64 z_above, U8 class_to) { this->index = index; this->below = z_below; this->above = z_above; this->class_to = class_to; };
 private:
   U32 index;
   F64 below;


### PR DESCRIPTION
In `lastransforn.cpp` the constructor self assign its members because of a typo

```
lastransform.cpp:863:127: warning: assigning field to itself [-Wself-assign-field]
lastransform.cpp:863:148: warning: assigning field to itself [-Wself-assign-field]
```