### PR TITLE
Install CMake config files

### DIFF
--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -77,3 +77,4 @@ install(TARGETS LASlib EXPORT LASlib-targets
 	ARCHIVE DESTINATION lib/LASlib)
 install(FILES ${LAS_INCLUDES} DESTINATION include/LASlib)
 install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)
+install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION lib/cmake/LASlib)

--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -3,9 +3,6 @@ if (!MSVC)
 endif()
 add_definitions(-DNDEBUG -DUNORDERED -DHAVE_UNORDERED_MAP)
 
-include_directories(../../LASzip/src)
-include_directories(../inc)
-
 set(LAS_SRC
 	lasreader.cpp
 	laswriter.cpp
@@ -61,13 +58,22 @@ foreach(file ${LAZ_SRC})
 	list(APPEND LAZ_SRC_FULL ../../LASzip/src/${file})
 endforeach(file)
 
+file(GLOB_RECURSE LAS_INCLUDES
+	${CMAKE_SOURCE_DIR}/LASzip/src/*.hpp 
+	${CMAKE_SOURCE_DIR}/LASlib/inc/*.hpp
+)
+
 add_library(LASlib STATIC ${LAS_SRC} ${LAZ_SRC_FULL})
+target_include_directories(LASlib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASlib/inc>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASzip/src>
+  $<INSTALL_INTERFACE:include/LASlib>
+)
 set_target_properties(LASlib PROPERTIES
-	ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib)
+	ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+)
 
-
-install(TARGETS LASlib DESTINATION lib/LASlib)
-install(DIRECTORY ../inc/ DESTINATION include/LASlib
-        FILES_MATCHING PATTERN "*.hpp")
-install(DIRECTORY ../../LASzip/src/ DESTINATION include/LASlib
-        FILES_MATCHING PATTERN "*.hpp")
+install(TARGETS LASlib EXPORT LASlib-targets
+	ARCHIVE DESTINATION lib/LASlib)
+install(FILES ${LAS_INCLUDES} DESTINATION include/LASlib)
+install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)

--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -65,9 +65,8 @@ file(GLOB_RECURSE LAS_INCLUDES
 
 add_library(LASlib STATIC ${LAS_SRC} ${LAZ_SRC_FULL})
 target_include_directories(LASlib PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASlib/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASzip/src>
-  $<INSTALL_INTERFACE:include/LASlib>
+  ${CMAKE_SOURCE_DIR}/LASlib/inc>
+  ${CMAKE_SOURCE_DIR}/LASzip/src>
 )
 set_target_properties(LASlib PROPERTIES
 	ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib

--- a/LASlib/src/LASlib-config.cmake
+++ b/LASlib/src/LASlib-config.cmake
@@ -1,0 +1,6 @@
+get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${SELF_DIR}/LASlib-targets.cmake)
+get_filename_component(LASlib_INCLUDE_DIRS "${SELF_DIR}/../../../include/LASlib" ABSOLUTE)
+set_property(TARGET LASlib PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LASlib_INCLUDE_DIRS})
+
+set(LASlib_FOUND true)


### PR DESCRIPTION
This makes it a lot easier to include LASlib as a dependency in other CMake projects. 

With these changes one can simply add to a `CMakelists.txt`:

```
find_package(LASlib)
...
target_link_libraries(my_target LASlib)
```

and things will just work, including the inclusion of the right include directories.