### PR TITLE
Fix incorrect parenthesis

### DIFF
--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -1940,7 +1940,7 @@ BOOL LASreadOpener::parse(int argc, char* argv[], BOOL parse_ignore)
         fprintf(stderr,"ERROR: '%s' needs 1 argument: list_of_files\n", argv[i]);
         return FALSE;
       }
-      if (!add_list_of_files(argv[i+1]), unique)
+      if (!add_list_of_files(argv[i+1], unique))
       {
         fprintf(stderr, "ERROR: cannot load list of files '%s'\n", argv[i+1]);
         return FALSE;


### PR DESCRIPTION
The signature of `add_list_of_files`  is  `add_list_of_files(const CHAR*, BOOL )` so the parenthesis is incorrect leading to a warning `-Wunused-value` and probably bugs in some cases