### PR TITLE
Added a check to confirm src_full exists prior to trying to include it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,6 @@ endif()
 
 add_subdirectory(LASlib/src)
 add_subdirectory(src)
-add_subdirectory(src_full)
+if (EXISTS src_full)
+	add_subdirectory(src_full)
+endif()


### PR DESCRIPTION
The CMakeLists.txt file attempts to include src_full, which doesn't exist in the repository. I suspect this is your folder of closed-source tools. So, I've just wrapped it in a if exists block.