### PR TITLE
Modified build configurations to build LASlib as DLL and prevent memory leak in reader/writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ bin/*.exe
 .vs
 *.pdb
 *.ilk
-build/
-install/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/*.exe
 .vs
 *.pdb
 *.ilk
+build/
+install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ else()
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
+option(BUILD_SHARED_LIBS "Build LASlib as DLL" OFF)
+
 add_subdirectory(LASlib/src)
 add_subdirectory(src)
-add_subdirectory(src_full)
+#add_subdirectory(src_full)

--- a/LASlib/inc/lasreader.hpp
+++ b/LASlib/inc/lasreader.hpp
@@ -127,6 +127,8 @@ public:
   LASreader();
   virtual ~LASreader();
 
+  void dealloc();
+
 protected:
   virtual BOOL read_point_default() = 0;
 

--- a/LASlib/inc/lasutility.hpp
+++ b/LASlib/inc/lasutility.hpp
@@ -36,7 +36,7 @@
 
 #include "lasdefinitions.hpp"
 
-class LASinventory
+class LASLIB_DLL LASinventory
 {
 public:
   BOOL active() const { return (first == FALSE); }; 
@@ -56,7 +56,7 @@ private:
   BOOL first;
 };
 
-class LASsummary
+class LASLIB_DLL LASsummary
 {
 public:
   BOOL active() const { return (first == FALSE); }; 
@@ -124,7 +124,7 @@ private:
   F64* values_neg;
 };
 
-class LAShistogram
+class LASLIB_DLL LAShistogram
 {
 public:
   BOOL active() const { return is_active; }; 
@@ -178,7 +178,7 @@ private:
   LASbin* return_map_bin_intensity;
 };
 
-class LASoccupancyGrid
+class LASLIB_DLL LASoccupancyGrid
 {
 public:
   void reset();

--- a/LASlib/inc/laswaveform13reader.hpp
+++ b/LASlib/inc/laswaveform13reader.hpp
@@ -40,7 +40,7 @@ class LASwaveformDescription;
 class ArithmeticDecoder;
 class IntegerCompressor;
 
-class LASwaveform13reader
+class LASLIB_DLL LASwaveform13reader
 {
 public:
   U32 nbits;

--- a/LASlib/inc/laswaveform13writer.hpp
+++ b/LASlib/inc/laswaveform13writer.hpp
@@ -40,7 +40,7 @@ class LASwaveformDescription;
 class ArithmeticEncoder;
 class IntegerCompressor;
 
-class LASwaveform13writer
+class LASLIB_DLL LASwaveform13writer
 {
 public:
   BOOL open(const char* file_name, const LASvlr_wave_packet_descr * const * wave_packet_descr);

--- a/LASlib/inc/laswriter.hpp
+++ b/LASlib/inc/laswriter.hpp
@@ -63,6 +63,8 @@ public:
   virtual BOOL update_header(const LASheader* header, BOOL use_inventory=FALSE, BOOL update_extra_bytes=FALSE) = 0;
   virtual I64 close(BOOL update_npoints=TRUE) = 0;
 
+  void dealloc();
+
   LASwriter() { npoints = 0; p_count = 0; };
   virtual ~LASwriter() {};
 };

--- a/LASlib/inc/laswritercompatible.hpp
+++ b/LASlib/inc/laswritercompatible.hpp
@@ -34,7 +34,7 @@
 
 #include "laswriter.hpp"
 
-class LASwriterCompatibleDown : public LASwriter
+class LASLIB_DLL LASwriterCompatibleDown : public LASwriter
 {
 public:
   BOOL open(LASheader* header, LASwriteOpener* laswriteopener, BOOL moveCRSfromEVLRtoVLR=FALSE, BOOL moveEVLRtoVLR=FALSE);
@@ -59,7 +59,7 @@ private:
   I32 start_NIR_band;
 };
 
-class LASwriterCompatibleUp : public LASwriter
+class LASLIB_DLL LASwriterCompatibleUp : public LASwriter
 {
 public:
   BOOL open(LASheader* header, LASwriteOpener* laswriteopener);

--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -64,7 +64,12 @@ file(GLOB_RECURSE LAS_INCLUDES
 	${CMAKE_SOURCE_DIR}/LASlib/inc/*.hpp
 )
 
-add_library(LASlib STATIC ${LAS_SRC} ${LAZ_SRC_FULL})
+add_library(LASlib ${LAS_SRC} ${LAZ_SRC_FULL})
+
+if (BUILD_SHARED_LIBS)
+	target_compile_definitions(LASlib PRIVATE "COMPILE_AS_DLL")
+endif()
+
 target_include_directories(LASlib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASlib/inc>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/LASzip/src>
@@ -75,7 +80,9 @@ set_target_properties(LASlib PROPERTIES
 )
 
 install(TARGETS LASlib EXPORT LASlib-targets
-	ARCHIVE DESTINATION lib/LASlib)
+	ARCHIVE DESTINATION lib/LASlib 
+	LIBRARY DESTINATION lib/LASlib 
+	RUNTIME DESTINATION lib/LASlib)
 install(FILES ${LAS_INCLUDES} DESTINATION include/LASlib)
 install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)
 install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION lib/cmake/LASlib)

--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -77,12 +77,36 @@ target_include_directories(LASlib PUBLIC
 )
 set_target_properties(LASlib PROPERTIES
 	ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+	LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib
 )
 
-install(TARGETS LASlib EXPORT LASlib-targets
-	ARCHIVE DESTINATION lib/LASlib 
-	LIBRARY DESTINATION lib/LASlib 
-	RUNTIME DESTINATION lib/LASlib)
+if(MSVC)
+   target_compile_options(LASlib PRIVATE /Zi)
+
+   # Tell linker to include symbol data
+    set_target_properties(LASlib PROPERTIES 
+        LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF"
+    )
+
+    # Set file name & location
+    set_target_properties(LASlib PROPERTIES 
+        COMPILE_PDB_NAME LASlib 
+        COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR}
+    )
+endif()
+
 install(FILES ${LAS_INCLUDES} DESTINATION include/LASlib)
-install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)
-install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION lib/cmake/LASlib)
+
+if (MSVC)
+	foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+		install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib/${OUTPUTCONFIG} DESTINATION lib/LASlib)
+	endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
+else()
+	install(TARGETS LASlib EXPORT LASlib-targets
+		ARCHIVE DESTINATION lib/LASlib
+		LIBRARY DESTINATION lib/LASlib
+		RUNTIME DESTINATION lib/LASlib)
+	install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)
+	install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION lib/cmake/LASlib)
+endif(MSVC)

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -87,6 +87,11 @@ LASreader::~LASreader()
   if (transform) transform->check_for_overflow();
 }
 
+void LASreader::dealloc()
+{
+  delete this;
+}
+
 void LASreader::set_index(LASindex* index)
 {
   if (this->index) delete this->index;

--- a/LASlib/src/laswriter.cpp
+++ b/LASlib/src/laswriter.cpp
@@ -47,6 +47,11 @@
 #define DIRECTORY_SLASH '/'
 #endif
 
+void LASwriter::dealloc()
+{
+  delete this;
+}
+
 BOOL LASwriteOpener::is_piped() const
 {
   return ((file_name == 0) && use_stdout);

--- a/LASzip/src/lasindex.hpp
+++ b/LASzip/src/lasindex.hpp
@@ -53,7 +53,7 @@ class LASreader;
 class ByteStreamIn;
 class ByteStreamOut;
 
-class LASindex
+class LASLIB_DLL LASindex
 {
 public:
   LASindex();

--- a/LASzip/src/lasquadtree.hpp
+++ b/LASzip/src/lasquadtree.hpp
@@ -42,7 +42,7 @@ class ByteStreamOut;
 
 #define LAS_SPATIAL_QUAD_TREE 0
 
-class LASquadtree
+class LASLIB_DLL LASquadtree
 {
 public:
   LASquadtree();

--- a/LASzip/src/laszip.hpp
+++ b/LASzip/src/laszip.hpp
@@ -58,6 +58,8 @@
 #ifndef LASZIP_HPP
 #define LASZIP_HPP
 
+#include "mydefs.hpp"
+
 #if defined(_MSC_VER) && (_MSC_VER < 1300)
 #define LZ_WIN32_VC6
 typedef __int64   SIGNED_INT64;
@@ -93,7 +95,7 @@ typedef long long SIGNED_INT64;
 
 #define LASZIP_CHUNK_SIZE_DEFAULT           50000
 
-class LASitem
+class LASLIB_DLL LASitem
 {
 public:
   enum Type { BYTE = 0, SHORT, INT, LONG, FLOAT, DOUBLE, POINT10, GPSTIME11, RGB12, WAVEPACKET13, POINT14, RGB14, RGBNIR14, WAVEPACKET14, BYTE14 } type;
@@ -103,7 +105,7 @@ public:
   const char* get_name() const;
 };
 
-class LASzip
+class LASLIB_DLL LASzip
 {
 public:
 


### PR DESCRIPTION
These changes enable the LASlib to be compiled as DLL.
The changes are as follows:
- I have added an option in cmake to select during configure step whether LASlib should be compiled as DLL or not (by default, LASlib will be built as static library)
- When LASlib is compiled as DLL then LASreader and LASwriter cannot be deallocated from heap by the consumer of LASlib DLL so for this reason, two new methods have been added to invoke delete on these objects with in the LASlib DLL
- Furthermore, for MSVC the linker flags are different to generate symbol data for the DLL (useful for debugging) and therefore, the install is also changed for MSVC to also install all the files to install directory with correct build type folder (Release, Debug etc.)