### PR TITLE
fixes for using LASlib on linux

### DIFF
--- a/LASlib/src/CMakeLists.txt
+++ b/LASlib/src/CMakeLists.txt
@@ -67,6 +67,7 @@ file(GLOB_RECURSE LAS_INCLUDES
 )
 
 add_library(LASlib ${LAS_SRC} ${LAZ_SRC_FULL})
+set_property(TARGET LASlib PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if (BUILD_SHARED_LIBS)
 	target_compile_definitions(LASlib PRIVATE "COMPILE_AS_DLL")
@@ -105,10 +106,10 @@ if (MSVC)
 		install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib/${OUTPUTCONFIG} DESTINATION lib/LASlib)
 	endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
 else()
-	install(TARGETS LASlib EXPORT LASlib-targets
+	install(TARGETS LASlib EXPORT laslib-targets
 		ARCHIVE DESTINATION lib/LASlib
 		LIBRARY DESTINATION lib/LASlib
 		RUNTIME DESTINATION lib/LASlib)
-	install(EXPORT LASlib-targets DESTINATION lib/cmake/LASlib)
-	install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION lib/cmake/LASlib)
+	install(EXPORT laslib-targets DESTINATION lib/cmake/LASlib)
+	install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/laslib-config.cmake DESTINATION lib/cmake/LASlib)
 endif(MSVC)

--- a/LASlib/src/laslib-config.cmake
+++ b/LASlib/src/laslib-config.cmake
@@ -1,5 +1,5 @@
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-include(${SELF_DIR}/LASlib-targets.cmake)
+include(${SELF_DIR}/laslib-targets.cmake)
 get_filename_component(LASlib_INCLUDE_DIRS "${SELF_DIR}/../../../include/LASlib" ABSOLUTE)
 set_property(TARGET LASlib PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LASlib_INCLUDE_DIRS})
 


### PR DESCRIPTION
I noticed some errors with including LASlib as a static library in other projects on ubuntu linux. This pull request fixes these by 

1. use the right capitalisation for the cmake files that are installed to make LASlib easy to find for cmake when including it on other projects
2. enable the `POSITION_INDEPENDENT_CODE` property. It is not possible to link a static library without this.