### PR TITLE
Removal of warnings that appear when compiling with G++ v7

### DIFF
--- a/LASlib/src/laswriter.cpp
+++ b/LASlib/src/laswriter.cpp
@@ -1133,7 +1133,7 @@ void LASwriteOpener::cut_characters(U32 cut)
     if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
     {
       len = (I32)strlen(file_name);
-      strncpy(new_file_name, file_name, len-cut);
+      memcpy(new_file_name, file_name, len-cut);
     }
     else
     {

--- a/src/geoprojectionconverter.cpp
+++ b/src/geoprojectionconverter.cpp
@@ -75,7 +75,7 @@ static const int GEO_PROJECTION_NONE     = 9;
 class ReferenceEllipsoid
 {
 public:
-  ReferenceEllipsoid(int id, char* name, double equatorialRadius, double eccentricitySquared, double inverseFlattening)
+  ReferenceEllipsoid(int id, char const* name, double equatorialRadius, double eccentricitySquared, double inverseFlattening)
   {
     this->id = id;
     this->name = name;
@@ -84,7 +84,7 @@ public:
     this->inverseFlattening = inverseFlattening;
   }
   int id;
-  char* name;
+  char const* name;
   double equatorialRadius;
   double eccentricitySquared;
   double inverseFlattening;
@@ -496,7 +496,7 @@ static const short GCTP_NAD83_Puerto_Rico = 5200;
 class StatePlaneLCC
 {
 public:
-  StatePlaneLCC(short geokey, char* zone, double falseEastingMeter, double falseNorthingMeter, double latOriginDegree, double longMeridianDegree, double firstStdParallelDegree, double secondStdParallelDegree)
+  StatePlaneLCC(short geokey, char const* zone, double falseEastingMeter, double falseNorthingMeter, double latOriginDegree, double longMeridianDegree, double firstStdParallelDegree, double secondStdParallelDegree)
   {
     this->geokey = geokey;
     this->zone = zone;
@@ -508,7 +508,7 @@ public:
     this->secondStdParallelDegree = secondStdParallelDegree;
   }
   short geokey;
-  char* zone;
+  char const* zone;
   double falseEastingMeter;
   double falseNorthingMeter;
   double latOriginDegree;
@@ -672,7 +672,7 @@ static const StatePlaneLCC state_plane_lcc_nad83_list[] =
 class StatePlaneTM
 {
 public:
-  StatePlaneTM(short geokey, char* zone, double falseEastingMeter, double falseNorthingMeter, double latOriginDegree, double longMeridianDegree, double scaleFactor)
+  StatePlaneTM(short geokey, char const* zone, double falseEastingMeter, double falseNorthingMeter, double latOriginDegree, double longMeridianDegree, double scaleFactor)
   {
     this->geokey = geokey;
     this->zone = zone;
@@ -683,7 +683,7 @@ public:
     this->scaleFactor = scaleFactor;
   }
   short geokey;
-  char* zone;
+  char const* zone;
   double falseEastingMeter;
   double falseNorthingMeter;
   double latOriginDegree;

--- a/src/geoprojectionconverter.hpp
+++ b/src/geoprojectionconverter.hpp
@@ -147,7 +147,7 @@ class GeoProjectionEllipsoid
 {
 public:
   int id;
-  char* name;
+  char const* name;
   double equatorial_radius;
   double polar_radius;
   double eccentricity_squared;

--- a/src/las2txt.cpp
+++ b/src/las2txt.cpp
@@ -586,7 +586,7 @@ int main(int argc, char *argv[])
   bool diff = false;
   bool verbose = false;
   CHAR separator_sign = ' ';
-  CHAR* separator = "space";
+  CHAR const* separator = "space";
   bool opts = false;
   bool optx = false;
   CHAR header_comment_sign = '\0';


### PR DESCRIPTION
These are the warnings that appear:
```
warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
```