### PR TITLE
Fix a memory leak in laszip_dll.cpp

### DIFF
--- a/LASzip/CHANGES.txt
+++ b/LASzip/CHANGES.txt
@@ -1,3 +1,4 @@
+ 2 December 2020 -- fix memory leak in laszip_dll.cpp
 23 September 2020 -- LASzip and LASlib: rare fix for reading bit-corrupted LAZ files where chunk table is zeroed
 24 December 2019 -- bug fix for file names with special characters like 'Töögrupid.laz'
  9 November 2019 -- upped version to 3.4 revision 3 for selective decompression extra bytes fix

--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -1204,8 +1204,10 @@ laszip_set_geokeys(
     if (laszip_add_vlr(laszip_dll, "LASF_Projection", 34735, (laszip_U16)(8 + number*8), 0, (laszip_U8*)key_entries_plus_one))
     {
       sprintf(laszip_dll->error, "setting %u geodouble_params", number);
+      delete[] key_entries_plus_one;
       return 1;
     }
+    delete[] key_entries_plus_one;
   }
   catch (...)
   {


### PR DESCRIPTION
`key_entries_plus_one` is allocated but never deallocated.