### PR TITLE
Fix copc query with LASreaderMerged

### DIFF
--- a/LASlib/inc/lasreader.hpp
+++ b/LASlib/inc/lasreader.hpp
@@ -157,6 +157,7 @@ protected:
 
 	 // optional resolution-of-interest query (copc indexed)
  	U8  inside_depth;  // 0 all, 1 max depth, 2 resolution
+	U8  copc_stream_order; // 0 normal, 1 spatially, 2 depth
 	F32 copc_resolution;
 	I32 copc_depth;
 

--- a/LASlib/inc/lasreadermerged.hpp
+++ b/LASlib/inc/lasreadermerged.hpp
@@ -66,6 +66,7 @@ public:
   void set_skip_lines(I32 skip_lines);
   void set_populate_header(BOOL populate_header);
   void set_keep_lastiling(BOOL keep_lastiling);
+  void set_copc_stream_order(U8 order);
   BOOL open();
   BOOL reopen();
 

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -105,11 +105,8 @@ void LASreader::set_index(LASindex* index)
 
 void LASreader::set_copcindex(COPCindex* copc_index)
 {
-  if (!this->copc_index)
-  {
     if (this->copc_index) delete this->copc_index;
     this->copc_index = copc_index;
-  }
 }
 
 void LASreader::set_filter(LASfilter* filter)

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -62,6 +62,9 @@ LASreader::LASreader()
 	read_complex = 0;
 	index = 0;
 	copc_index = 0;
+	copc_stream_order = 0;
+	copc_resolution = 0;
+	copc_depth = I32_MAX;
 	filter = 0;
 	transform = 0;
 	ignore = 0;
@@ -647,6 +650,7 @@ LASreader* LASreadOpener::open(const CHAR* other_file_name, BOOL reset_after_oth
 			lasreadermerged->set_translate_scan_angle(translate_scan_angle);
 			lasreadermerged->set_scale_scan_angle(scale_scan_angle);
 			lasreadermerged->set_io_ibuffer_size(io_ibuffer_size);
+			lasreadermerged->set_copc_stream_order(copc_stream_order); 
 			if (file_names_ID)
 			{
 				for (file_name_current = 0; file_name_current < file_name_number; file_name_current++) lasreadermerged->add_file_name(file_names[file_name_current], file_names_ID[file_name_current]);

--- a/LASlib/src/lasreadermerged.cpp
+++ b/LASlib/src/lasreadermerged.cpp
@@ -634,6 +634,12 @@ void LASreaderMerged::set_keep_lastiling(BOOL keep_lastiling)
   this->keep_lastiling = keep_lastiling;
 }
 
+void LASreaderMerged::set_copc_stream_order(U8 order)
+{
+  if (order < 0 || order > 2) order = 0;
+  copc_stream_order = order;
+}
+
 BOOL LASreaderMerged::open()
 {
   if (file_name_number == 0)
@@ -1529,6 +1535,9 @@ BOOL LASreaderMerged::open_next_file()
         }
 
         COPCindex *copc_index = new COPCindex(lasreaderlas->header);
+        if (copc_stream_order == 0) 	 copc_index->set_stream_ordered_by_chunk();
+        else if (copc_stream_order == 1) copc_index->set_stream_ordered_spatially();
+        else if (copc_stream_order == 2) copc_index->set_stream_ordered_by_depth();
         lasreaderlas->set_copcindex(copc_index);
       }
     }

--- a/LASzip/src/lascopc.hpp
+++ b/LASzip/src/lascopc.hpp
@@ -191,7 +191,7 @@ protected:
   std::unordered_map<EPTkey, EPToctant, EPTKeyHasher> registry;
 };
 
-class COPCindex : private EPToctree
+class COPCindex : public EPToctree
 {
 public:
   COPCindex(const LASheader& header);


### PR DESCRIPTION
This PR fixes one major and one minor issue for copc queries with `LASreaderMerged`

When performing a query in a set of COPC files, if the query is contained by more than one file and we use `LASreaderMerged` the `COPCindex` was not properly updated. This results in an infinite loop trying to read the points of the second file with the index of the first file. Can be reproduced with a command like

```
las2las -merged -lof lof.txt -inside_circle 422100 5482500 20 -olas -odir ./
```
 
The second commit propagates the stream order request to `LASreaderMerged`. I missed that one in my implementation.