### PR TITLE
Fix memory access crash when removing an EVLR

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -757,7 +757,7 @@ public:
         if (number_of_extended_variable_length_records)
         {
           evlrs[i] = evlrs[number_of_extended_variable_length_records];
-          evlrs = (LASevlr*)realloc(evlrs, sizeof(LASvlr)*number_of_extended_variable_length_records);
+          evlrs = (LASevlr*)realloc(evlrs, sizeof(LASevlr)*number_of_extended_variable_length_records);
         }
         else
         {


### PR DESCRIPTION
This was caused by reallocating the size of the wrong type (`LASvlr` instead of `LASevlr`), and caused crashing bugs in release mode under MSVC 16 on Windows 11 (other platforms not tested).

(Note that casting the result of `malloc` and `realloc` is not recommended, and the return value is not checked for validity which could lead memory leaks, but this PR does not address these.)