### PR TITLE
PLY: Add support for `uint8`

### DIFF
--- a/LASlib/src/lasreader_ply.cpp
+++ b/LASlib/src/lasreader_ply.cpp
@@ -1746,7 +1746,7 @@ BOOL LASreaderPLY::parse_header(BOOL quiet)
           items++;
         }
       }
-      else if (strncmp(&line[9], "uchar", 5) == 0)
+      else if ((strncmp(&line[9], "uchar", 5) == 0) || strncmp(&line[9], "uint8", 5) == 0)
       {
         if (strstr(&line[15], "red"))
         {


### PR DESCRIPTION
Fixes error

```
ERROR processing file '/path/to/myfile.ply'. maybe file is corrupt?
```

when it contains

```
ply
format binary_little_endian 1.0
element vertex 10159351
property float x
property float y
property float z
property uint8 red
property uint8 green
property uint8 blue
end_header
...
```