### PR TITLE
LASreadPoint::seek fix to avoid seek crash for truncated input

### DIFF
--- a/LASzip/src/lasreadpoint.cpp
+++ b/LASzip/src/lasreadpoint.cpp
@@ -388,7 +388,10 @@ BOOL LASreadPoint::seek(const U32 current, const U32 target)
     }
     while (delta)
     {
-      read(seek_point);
+      if (!read(seek_point))
+      {
+        return FALSE;
+      }
       delta--;
     }
   }


### PR DESCRIPTION
We came across this bug that affects truncated LAZ input files.

If we try to seek past the end of the file `ByteStreamInFile::getBytes` throws an exception for I/O error, and `LASreadPoint::read` catches that and returns FALSE.  But `LASreadPoint::seek` is ignoring the return value from `LASreadPoint::read`.  As a consequence the arithmetic decoder can crash (divide by zero) evaluating `dv`:

```
U32 ArithmeticDecoder::decodeSymbol(ArithmeticModel* m)
{
  U32 n, sym, x, y = length;

  if (m->decoder_table) {             // use table look-up for faster decoding

    unsigned dv = value / (length >>= DM__LengthShift);
    unsigned t = dv >> m->table_shift;

    sym = m->decoder_table[t];      // initial decision based on table look-up
    n = m->decoder_table[t+1] + 1;

    while (n > sym + 1) {                      // finish with bisection search
      U32 k = (sym + n) >> 1;
      if (m->distribution[k] > dv) n = k; else sym = k;
    }
                                                           // compute products
    x = m->distribution[sym] * length;
    if (sym != m->last_symbol) y = m->distribution[sym+1] * length;
  }
```

Fortunately the fix for this is a straight-forward one.

See also: [LasZip PR #82](https://github.com/LASzip/LASzip/pull/82)