### PR TITLE
Fix -Wcast-qual warnings

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -145,10 +145,10 @@ public:
   void clean() {memset(data, 0, 26);};
   inline U8 getBitsPerSample() const {return data[0];};
   inline U8 getCompressionType() const {return data[1];};
-  inline U32 getNumberOfSamples() const {return ((U32*)&(data[2]))[0];};
-  inline U32 getTemporalSpacing() const {return ((U32*)&(data[6]))[0];};
-  inline F64 getDigitizerGain() const {return ((F64*)&(data[10]))[0];};
-  inline F64 getDigitizerOffset() const {return ((F64*)&(data[18]))[0];};
+  inline U32 getNumberOfSamples() const {return ((const U32*)&(data[2]))[0];};
+  inline U32 getTemporalSpacing() const {return ((const U32*)&(data[6]))[0];};
+  inline F64 getDigitizerGain() const {return ((const F64*)&(data[10]))[0];};
+  inline F64 getDigitizerOffset() const {return ((const F64*)&(data[18]))[0];};
   inline void setBitsPerSample(U8 bps) {data[0] = bps;};
   inline void setCompressionType(U8 compression) {data[1] = compression;};
   inline void setNumberOfSamples(U32 samples) {((U32*)&(data[2]))[0] = samples;};

--- a/LASlib/inc/lasvlrpayload.hpp
+++ b/LASlib/inc/lasvlrpayload.hpp
@@ -134,67 +134,67 @@ public:
   }
   BOOL save(ByteStreamOut* stream) const
   {
-    if (!stream->put32bitsLE((U8*)&nbands))
+    if (!stream->put32bitsLE((const U8*)&nbands))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.nbands\n");
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&nbits))
+    if (!stream->put32bitsLE((const U8*)&nbits))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.nbits\n");
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&ncols))
+    if (!stream->put32bitsLE((const U8*)&ncols))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.ncols\n");
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&nrows))
+    if (!stream->put32bitsLE((const U8*)&nrows))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.nrows\n");
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&reserved1))
+    if (!stream->put32bitsLE((const U8*)&reserved1))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.reserved1\n");
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&reserved2))
+    if (!stream->put32bitsLE((const U8*)&reserved2))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.reserved2\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&stepx))
+    if (!stream->put64bitsLE((const U8*)&stepx))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.stepx\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&stepx_y))
+    if (!stream->put64bitsLE((const U8*)&stepx_y))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.stepx_y\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&stepy))
+    if (!stream->put64bitsLE((const U8*)&stepy))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.stepy\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&stepy_x))
+    if (!stream->put64bitsLE((const U8*)&stepy_x))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.stepy_x\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&llx))
+    if (!stream->put64bitsLE((const U8*)&llx))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.llx\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&lly))
+    if (!stream->put64bitsLE((const U8*)&lly))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.lly\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&sigmaxy))
+    if (!stream->put64bitsLE((const U8*)&sigmaxy))
     {
       fprintf(stderr,"ERROR: writing LASvlrRasterLAZ.sigmaxy\n");
       return FALSE;

--- a/LASlib/src/Makefile
+++ b/LASlib/src/Makefile
@@ -1,7 +1,7 @@
 # makefile for liblas.a
 #
 #COPTS    = -g -Wall -DUNORDERED -DHAVE_UNORDERED_MAP -std=c++11
-COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -DNDEBUG -DUNORDERED -DHAVE_UNORDERED_MAP -std=c++11
+COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -Wcast-qual -DNDEBUG -DUNORDERED -DHAVE_UNORDERED_MAP -std=c++11
 COMPILER  = g++
 AR  = ar rc
 #BITS     = -64

--- a/LASlib/src/laswriter_las.cpp
+++ b/LASlib/src/laswriter_las.cpp
@@ -232,37 +232,37 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
 
   // write header variable after variable (to avoid alignment issues)
 
-  if (!stream->putBytes((U8*)&(header->file_signature), 4))
+  if (!stream->putBytes((const U8*)&(header->file_signature), 4))
   {
     fprintf(stderr,"ERROR: writing header->file_signature\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->file_source_ID)))
+  if (!stream->put16bitsLE((const U8*)&(header->file_source_ID)))
   {
     fprintf(stderr,"ERROR: writing header->file_source_ID\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->global_encoding)))
+  if (!stream->put16bitsLE((const U8*)&(header->global_encoding)))
   {
     fprintf(stderr,"ERROR: writing header->global_encoding\n");
     return FALSE;
   }
-  if (!stream->put32bitsLE((U8*)&(header->project_ID_GUID_data_1)))
+  if (!stream->put32bitsLE((const U8*)&(header->project_ID_GUID_data_1)))
   {
     fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_1\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->project_ID_GUID_data_2)))
+  if (!stream->put16bitsLE((const U8*)&(header->project_ID_GUID_data_2)))
   {
     fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_2\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->project_ID_GUID_data_3)))
+  if (!stream->put16bitsLE((const U8*)&(header->project_ID_GUID_data_3)))
   {
     fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_3\n");
     return FALSE;
   }
-  if (!stream->putBytes((U8*)header->project_ID_GUID_data_4, 8))
+  if (!stream->putBytes((const U8*)header->project_ID_GUID_data_4, 8))
   {
     fprintf(stderr,"ERROR: writing header->project_ID_GUID_data_4\n");
     return FALSE;
@@ -291,27 +291,27 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     fprintf(stderr,"ERROR: writing header->version_minor\n");
     return FALSE;
   }
-  if (!stream->putBytes((U8*)header->system_identifier, 32))
+  if (!stream->putBytes((const U8*)header->system_identifier, 32))
   {
     fprintf(stderr,"ERROR: writing header->system_identifier\n");
     return FALSE;
   }
-  if (!stream->putBytes((U8*)header->generating_software, 32))
+  if (!stream->putBytes((const U8*)header->generating_software, 32))
   {
     fprintf(stderr,"ERROR: writing header->generating_software\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->file_creation_day)))
+  if (!stream->put16bitsLE((const U8*)&(header->file_creation_day)))
   {
     fprintf(stderr,"ERROR: writing header->file_creation_day\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->file_creation_year)))
+  if (!stream->put16bitsLE((const U8*)&(header->file_creation_year)))
   {
     fprintf(stderr,"ERROR: writing header->file_creation_year\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->header_size)))
+  if (!stream->put16bitsLE((const U8*)&(header->header_size)))
   {
     fprintf(stderr,"ERROR: writing header->header_size\n");
     return FALSE;
@@ -320,7 +320,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
   if (laszip) offset_to_point_data += (54 + laszip_vlr_data_size);
   if (header->vlr_lastiling) offset_to_point_data += (54 + 28);
   if (header->vlr_lasoriginal) offset_to_point_data += (54 + 176);
-  if (!stream->put32bitsLE((U8*)&offset_to_point_data))
+  if (!stream->put32bitsLE((const U8*)&offset_to_point_data))
   {
     fprintf(stderr,"ERROR: writing header->offset_to_point_data\n");
     return FALSE;
@@ -329,7 +329,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
   if (laszip) number_of_variable_length_records++;
   if (header->vlr_lastiling) number_of_variable_length_records++;
   if (header->vlr_lasoriginal) number_of_variable_length_records++;
-  if (!stream->put32bitsLE((U8*)&(number_of_variable_length_records)))
+  if (!stream->put32bitsLE((const U8*)&(number_of_variable_length_records)))
   {
     fprintf(stderr,"ERROR: writing header->number_of_variable_length_records\n");
     return FALSE;
@@ -340,80 +340,80 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     fprintf(stderr,"ERROR: writing header->point_data_format\n");
     return FALSE;
   }
-  if (!stream->put16bitsLE((U8*)&(header->point_data_record_length)))
+  if (!stream->put16bitsLE((const U8*)&(header->point_data_record_length)))
   {
     fprintf(stderr,"ERROR: writing header->point_data_record_length\n");
     return FALSE;
   }
-  if (!stream->put32bitsLE((U8*)&(header->number_of_point_records)))
+  if (!stream->put32bitsLE((const U8*)&(header->number_of_point_records)))
   {
     fprintf(stderr,"ERROR: writing header->number_of_point_records\n");
     return FALSE;
   }
   for (i = 0; i < 5; i++)
   {
-    if (!stream->put32bitsLE((U8*)&(header->number_of_points_by_return[i])))
+    if (!stream->put32bitsLE((const U8*)&(header->number_of_points_by_return[i])))
     {
       fprintf(stderr,"ERROR: writing header->number_of_points_by_return[%d]\n", i);
       return FALSE;
     }
   }
-  if (!stream->put64bitsLE((U8*)&(header->x_scale_factor)))
+  if (!stream->put64bitsLE((const U8*)&(header->x_scale_factor)))
   {
     fprintf(stderr,"ERROR: writing header->x_scale_factor\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->y_scale_factor)))
+  if (!stream->put64bitsLE((const U8*)&(header->y_scale_factor)))
   {
     fprintf(stderr,"ERROR: writing header->y_scale_factor\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->z_scale_factor)))
+  if (!stream->put64bitsLE((const U8*)&(header->z_scale_factor)))
   {
     fprintf(stderr,"ERROR: writing header->z_scale_factor\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->x_offset)))
+  if (!stream->put64bitsLE((const U8*)&(header->x_offset)))
   {
     fprintf(stderr,"ERROR: writing header->x_offset\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->y_offset)))
+  if (!stream->put64bitsLE((const U8*)&(header->y_offset)))
   {
     fprintf(stderr,"ERROR: writing header->y_offset\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->z_offset)))
+  if (!stream->put64bitsLE((const U8*)&(header->z_offset)))
   {
     fprintf(stderr,"ERROR: writing header->z_offset\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->max_x)))
+  if (!stream->put64bitsLE((const U8*)&(header->max_x)))
   {
     fprintf(stderr,"ERROR: writing header->max_x\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->min_x)))
+  if (!stream->put64bitsLE((const U8*)&(header->min_x)))
   {
     fprintf(stderr,"ERROR: writing header->min_x\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->max_y)))
+  if (!stream->put64bitsLE((const U8*)&(header->max_y)))
   {
     fprintf(stderr,"ERROR: writing header->max_y\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->min_y)))
+  if (!stream->put64bitsLE((const U8*)&(header->min_y)))
   {
     fprintf(stderr,"ERROR: writing header->min_y\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->max_z)))
+  if (!stream->put64bitsLE((const U8*)&(header->max_z)))
   {
     fprintf(stderr,"ERROR: writing header->max_z\n");
     return FALSE;
   }
-  if (!stream->put64bitsLE((U8*)&(header->min_z)))
+  if (!stream->put64bitsLE((const U8*)&(header->min_z)))
   {
     fprintf(stderr,"ERROR: writing header->min_z\n");
     return FALSE;
@@ -432,7 +432,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
 #endif
       start_of_waveform_data_packet_record = 0;
     }
-    if (!stream->put64bitsLE((U8*)&start_of_waveform_data_packet_record))
+    if (!stream->put64bitsLE((const U8*)&start_of_waveform_data_packet_record))
     {
       fprintf(stderr,"ERROR: writing start_of_waveform_data_packet_record\n");
       return FALSE;
@@ -452,13 +452,13 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       writing_new_point_type = FALSE;
     }
     start_of_first_extended_variable_length_record = header->start_of_first_extended_variable_length_record;
-    if (!stream->put64bitsLE((U8*)&(start_of_first_extended_variable_length_record)))
+    if (!stream->put64bitsLE((const U8*)&(start_of_first_extended_variable_length_record)))
     {
       fprintf(stderr,"ERROR: writing header->start_of_first_extended_variable_length_record\n");
       return FALSE;
     }
     number_of_extended_variable_length_records = header->number_of_extended_variable_length_records;
-    if (!stream->put32bitsLE((U8*)&(number_of_extended_variable_length_records)))
+    if (!stream->put32bitsLE((const U8*)&(number_of_extended_variable_length_records)))
     {
       fprintf(stderr,"ERROR: writing header->number_of_extended_variable_length_records\n");
       return FALSE;
@@ -469,7 +469,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       extended_number_of_point_records = header->number_of_point_records;
     else
       extended_number_of_point_records = header->extended_number_of_point_records;
-    if (!stream->put64bitsLE((U8*)&extended_number_of_point_records))
+    if (!stream->put64bitsLE((const U8*)&extended_number_of_point_records))
     {
       fprintf(stderr,"ERROR: writing header->extended_number_of_point_records\n");
       return FALSE;
@@ -481,7 +481,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
         extended_number_of_points_by_return = header->number_of_points_by_return[i];
       else
         extended_number_of_points_by_return = header->extended_number_of_points_by_return[i];
-      if (!stream->put64bitsLE((U8*)&extended_number_of_points_by_return))
+      if (!stream->put64bitsLE((const U8*)&extended_number_of_points_by_return))
       {
         fprintf(stderr,"ERROR: writing header->extended_number_of_points_by_return[%d]\n", i);
         return FALSE;
@@ -500,7 +500,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
   {
     if (header->user_data_in_header)
     {
-      if (!stream->putBytes((U8*)header->user_data_in_header, header->user_data_in_header_size))
+      if (!stream->putBytes((const U8*)header->user_data_in_header, header->user_data_in_header_size))
       {
         fprintf(stderr,"ERROR: writing %d bytes of data from header->user_data_in_header\n", header->user_data_in_header_size);
         return FALSE;
@@ -526,27 +526,27 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
 
     // write variable length records variable after variable (to avoid alignment issues)
 
-    if (!stream->put16bitsLE((U8*)&(header->vlrs[i].reserved)))
+    if (!stream->put16bitsLE((const U8*)&(header->vlrs[i].reserved)))
     {
       fprintf(stderr,"ERROR: writing header->vlrs[%d].reserved\n", i);
       return FALSE;
     }
-    if (!stream->putBytes((U8*)header->vlrs[i].user_id, 16))
+    if (!stream->putBytes((const U8*)header->vlrs[i].user_id, 16))
     {
       fprintf(stderr,"ERROR: writing header->vlrs[%d].user_id\n", i);
       return FALSE;
     }
-    if (!stream->put16bitsLE((U8*)&(header->vlrs[i].record_id)))
+    if (!stream->put16bitsLE((const U8*)&(header->vlrs[i].record_id)))
     {
       fprintf(stderr,"ERROR: writing header->vlrs[%d].record_id\n", i);
       return FALSE;
     }
-    if (!stream->put16bitsLE((U8*)&(header->vlrs[i].record_length_after_header)))
+    if (!stream->put16bitsLE((const U8*)&(header->vlrs[i].record_length_after_header)))
     {
       fprintf(stderr,"ERROR: writing header->vlrs[%d].record_length_after_header\n", i);
       return FALSE;
     }
-    if (!stream->putBytes((U8*)header->vlrs[i].description, 32))
+    if (!stream->putBytes((const U8*)header->vlrs[i].description, 32))
     {
       fprintf(stderr,"ERROR: writing header->vlrs[%d].description\n", i);
       return FALSE;
@@ -558,7 +558,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     {
       if (header->vlrs[i].data)
       {
-        if (!stream->putBytes((U8*)header->vlrs[i].data, header->vlrs[i].record_length_after_header))
+        if (!stream->putBytes((const U8*)header->vlrs[i].data, header->vlrs[i].record_length_after_header))
         {
           fprintf(stderr,"ERROR: writing %d bytes of data from header->vlrs[%d].data\n", header->vlrs[i].record_length_after_header, i);
           return FALSE;
@@ -579,25 +579,25 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     // write variable length records variable after variable (to avoid alignment issues)
 
     U16 reserved = 0; // used to be 0xAABB
-    if (!stream->put16bitsLE((U8*)&(reserved)))
+    if (!stream->put16bitsLE((const U8*)&(reserved)))
     {
       fprintf(stderr,"ERROR: writing reserved %d\n", (I32)reserved);
       return FALSE;
     }
     U8 user_id[16] = "laszip encoded\0";
-    if (!stream->putBytes((U8*)user_id, 16))
+    if (!stream->putBytes((const U8*)user_id, 16))
     {
       fprintf(stderr,"ERROR: writing user_id %s\n", user_id);
       return FALSE;
     }
     U16 record_id = 22204;
-    if (!stream->put16bitsLE((U8*)&(record_id)))
+    if (!stream->put16bitsLE((const U8*)&(record_id)))
     {
       fprintf(stderr,"ERROR: writing record_id %d\n", (I32)record_id);
       return FALSE;
     }
     U16 record_length_after_header = laszip_vlr_data_size;
-    if (!stream->put16bitsLE((U8*)&(record_length_after_header)))
+    if (!stream->put16bitsLE((const U8*)&(record_length_after_header)))
     {
       fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (I32)record_length_after_header);
       return FALSE;
@@ -605,7 +605,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     char description[32];
     memset(description, 0, 32);
     sprintf(description, "by laszip of LAStools (%d)", LAS_TOOLS_VERSION);
-    if (!stream->putBytes((U8*)description, 32))
+    if (!stream->putBytes((const U8*)description, 32))
     {
       fprintf(stderr,"ERROR: writing description %s\n", description);
       return FALSE;
@@ -626,12 +626,12 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     //        U16 version             2 bytes * num_items
     // which totals 34+6*num_items
 
-    if (!stream->put16bitsLE((U8*)&(laszip->compressor)))
+    if (!stream->put16bitsLE((const U8*)&(laszip->compressor)))
     {
       fprintf(stderr,"ERROR: writing compressor %d\n", (I32)compressor);
       return FALSE;
     }
-    if (!stream->put16bitsLE((U8*)&(laszip->coder)))
+    if (!stream->put16bitsLE((const U8*)&(laszip->coder)))
     {
       fprintf(stderr,"ERROR: writing coder %d\n", (I32)laszip->coder);
       return FALSE;
@@ -646,49 +646,49 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       fprintf(stderr,"ERROR: writing version_minor %d\n", laszip->version_minor);
       return FALSE;
     }
-    if (!stream->put16bitsLE((U8*)&(laszip->version_revision)))
+    if (!stream->put16bitsLE((const U8*)&(laszip->version_revision)))
     {
       fprintf(stderr,"ERROR: writing version_revision %d\n", laszip->version_revision);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(laszip->options)))
+    if (!stream->put32bitsLE((const U8*)&(laszip->options)))
     {
       fprintf(stderr,"ERROR: writing options %d\n", (I32)laszip->options);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(laszip->chunk_size)))
+    if (!stream->put32bitsLE((const U8*)&(laszip->chunk_size)))
     {
       fprintf(stderr,"ERROR: writing chunk_size %d\n", laszip->chunk_size);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(laszip->number_of_special_evlrs)))
+    if (!stream->put64bitsLE((const U8*)&(laszip->number_of_special_evlrs)))
     {
       fprintf(stderr,"ERROR: writing number_of_special_evlrs %d\n", (I32)laszip->number_of_special_evlrs);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(laszip->offset_to_special_evlrs)))
+    if (!stream->put64bitsLE((const U8*)&(laszip->offset_to_special_evlrs)))
     {
       fprintf(stderr,"ERROR: writing offset_to_special_evlrs %d\n", (I32)laszip->offset_to_special_evlrs);
       return FALSE;
     }
-    if (!stream->put16bitsLE((U8*)&(laszip->num_items)))
+    if (!stream->put16bitsLE((const U8*)&(laszip->num_items)))
     {
       fprintf(stderr,"ERROR: writing num_items %d\n", laszip->num_items);
       return FALSE;
     }
     for (i = 0; i < laszip->num_items; i++)
     {
-      if (!stream->put16bitsLE((U8*)&(laszip->items[i].type)))
+      if (!stream->put16bitsLE((const U8*)&(laszip->items[i].type)))
       {
         fprintf(stderr,"ERROR: writing type %d of item %d\n", laszip->items[i].type, i);
         return FALSE;
       }
-      if (!stream->put16bitsLE((U8*)&(laszip->items[i].size)))
+      if (!stream->put16bitsLE((const U8*)&(laszip->items[i].size)))
       {
         fprintf(stderr,"ERROR: writing size %d of item %d\n", laszip->items[i].size, i);
         return FALSE;
       }
-      if (!stream->put16bitsLE((U8*)&(laszip->items[i].version)))
+      if (!stream->put16bitsLE((const U8*)&(laszip->items[i].version)))
       {
         fprintf(stderr,"ERROR: writing version %d of item %d\n", laszip->items[i].version, i);
         return FALSE;
@@ -706,32 +706,32 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     // write variable length records variable after variable (to avoid alignment issues)
 
     U16 reserved = 0; // used to be 0xAABB
-    if (!stream->put16bitsLE((U8*)&(reserved)))
+    if (!stream->put16bitsLE((const U8*)&(reserved)))
     {
       fprintf(stderr,"ERROR: writing reserved %d\n", (I32)reserved);
       return FALSE;
     }
     U8 user_id[16] = "LAStools\0\0\0\0\0\0\0";
-    if (!stream->putBytes((U8*)user_id, 16))
+    if (!stream->putBytes((const U8*)user_id, 16))
     {
       fprintf(stderr,"ERROR: writing user_id %s\n", user_id);
       return FALSE;
     }
     U16 record_id = 10;
-    if (!stream->put16bitsLE((U8*)&(record_id)))
+    if (!stream->put16bitsLE((const U8*)&(record_id)))
     {
       fprintf(stderr,"ERROR: writing record_id %d\n", (I32)record_id);
       return FALSE;
     }
     U16 record_length_after_header = 28;
-    if (!stream->put16bitsLE((U8*)&(record_length_after_header)))
+    if (!stream->put16bitsLE((const U8*)&(record_length_after_header)))
     {
       fprintf(stderr,"ERROR: writing record_length_after_header %d\n", (I32)record_length_after_header);
       return FALSE;
     }
     CHAR description[33] = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
     sprintf(description, "tile %s buffer %s", (header->vlr_lastiling->buffer ? "with" : "without"), (header->vlr_lastiling->reversible ? ", reversible" : ""));
-    if (!stream->putBytes((U8*)description, 32))
+    if (!stream->putBytes((const U8*)description, 32))
     {
       fprintf(stderr,"ERROR: writing description %s\n", description);
       return FALSE;
@@ -746,12 +746,12 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     //   F32  min_y                                          4 bytes
     //   F32  max_y                                          4 bytes
 
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->level)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->level)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->level %u\n", header->vlr_lastiling->level);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->level_index)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->level_index)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->level_index %u\n", header->vlr_lastiling->level_index);
       return FALSE;
@@ -761,22 +761,22 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->implicit_levels %u\n", header->vlr_lastiling->implicit_levels);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->min_x)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->min_x)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->min_x %g\n", header->vlr_lastiling->min_x);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->max_x)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->max_x)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->max_x %g\n", header->vlr_lastiling->max_x);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->min_y)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->min_y)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->min_y %g\n", header->vlr_lastiling->min_y);
       return FALSE;
     }
-    if (!stream->put32bitsLE((U8*)&(header->vlr_lastiling->max_y)))
+    if (!stream->put32bitsLE((const U8*)&(header->vlr_lastiling->max_y)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lastiling->max_y %g\n", header->vlr_lastiling->max_y);
       return FALSE;
@@ -826,45 +826,45 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
 
     // write the payload of this VLR which contains 176 bytes
 
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->number_of_point_records)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->number_of_point_records)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->number_of_point_records %u\n", (U32)header->vlr_lasoriginal->number_of_point_records);
       return FALSE;
     }
     for (j = 0; j < 15; j++)
     {
-      if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->number_of_points_by_return[j])))
+      if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->number_of_points_by_return[j])))
       {
         fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->number_of_points_by_return[%u] %u\n", j, (U32)header->vlr_lasoriginal->number_of_points_by_return[j]);
         return FALSE;
       }
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->min_x)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->min_x)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_x %g\n", header->vlr_lasoriginal->min_x);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->max_x)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->max_x)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_x %g\n", header->vlr_lasoriginal->max_x);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->min_y)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->min_y)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_y %g\n", header->vlr_lasoriginal->min_y);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->max_y)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->max_y)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_y %g\n", header->vlr_lasoriginal->max_y);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->min_z)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->min_z)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->min_z %g\n", header->vlr_lasoriginal->min_z);
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->vlr_lasoriginal->max_z)))
+    if (!stream->put64bitsLE((const U8*)&(header->vlr_lasoriginal->max_z)))
     {
       fprintf(stderr,"ERROR: writing header->vlr_lasoriginal->max_z %g\n", header->vlr_lasoriginal->max_z);
       return FALSE;
@@ -953,7 +953,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
     {
       number = (U32)inventory.extended_number_of_point_records;
     }
-    if (!stream->put32bitsLE((U8*)&number))
+    if (!stream->put32bitsLE((const U8*)&number))
     {
       fprintf(stderr,"ERROR: updating inventory.number_of_point_records\n");
       return FALSE;
@@ -980,7 +980,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
       {
         number = (U32)inventory.extended_number_of_points_by_return[i+1];
       }
-      if (!stream->put32bitsLE((U8*)&number))
+      if (!stream->put32bitsLE((const U8*)&number))
       {
         fprintf(stderr,"ERROR: updating inventory.number_of_points_by_return[%d]\n", i);
         return FALSE;
@@ -989,37 +989,37 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
     stream->seek(header_start_position+179);
     F64 value;
     value = quantizer.get_x(inventory.max_X);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.max_X\n");
       return FALSE;
     }
     value = quantizer.get_x(inventory.min_X);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.min_X\n");
       return FALSE;
     }
     value = quantizer.get_y(inventory.max_Y);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.max_Y\n");
       return FALSE;
     }
     value = quantizer.get_y(inventory.min_Y);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.min_Y\n");
       return FALSE;
     }
     value = quantizer.get_z(inventory.max_Z);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.max_Z\n");
       return FALSE;
     }
     value = quantizer.get_z(inventory.min_Z);
-    if (!stream->put64bitsLE((U8*)&value))
+    if (!stream->put64bitsLE((const U8*)&value))
     {
       fprintf(stderr,"ERROR: updating inventory.min_Z\n");
       return FALSE;
@@ -1028,14 +1028,14 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
     if (header->version_minor >= 4)
     {
       stream->seek(header_start_position+247);
-      if (!stream->put64bitsLE((U8*)&(inventory.extended_number_of_point_records)))
+      if (!stream->put64bitsLE((const U8*)&(inventory.extended_number_of_point_records)))
       {
         fprintf(stderr,"ERROR: updating header->extended_number_of_point_records\n");
         return FALSE;
       }
       for (i = 0; i < 15; i++)
       {
-        if (!stream->put64bitsLE((U8*)&(inventory.extended_number_of_points_by_return[i+1])))
+        if (!stream->put64bitsLE((const U8*)&(inventory.extended_number_of_points_by_return[i+1])))
         {
           fprintf(stderr,"ERROR: updating header->extended_number_of_points_by_return[%d]\n", i);
           return FALSE;
@@ -1055,7 +1055,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
     {
       number = header->number_of_point_records;
     }
-    if (!stream->put32bitsLE((U8*)&number))
+    if (!stream->put32bitsLE((const U8*)&number))
     {
       fprintf(stderr,"ERROR: updating header->number_of_point_records\n");
       return FALSE;
@@ -1071,39 +1071,39 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
       {
         number = header->number_of_points_by_return[i];
       }
-      if (!stream->put32bitsLE((U8*)&number))
+      if (!stream->put32bitsLE((const U8*)&number))
       {
         fprintf(stderr,"ERROR: updating header->number_of_points_by_return[%d]\n", i);
         return FALSE;
       }
     }
     stream->seek(header_start_position+179);
-    if (!stream->put64bitsLE((U8*)&(header->max_x)))
+    if (!stream->put64bitsLE((const U8*)&(header->max_x)))
     {
       fprintf(stderr,"ERROR: updating header->max_x\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->min_x)))
+    if (!stream->put64bitsLE((const U8*)&(header->min_x)))
     {
       fprintf(stderr,"ERROR: updating header->min_x\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->max_y)))
+    if (!stream->put64bitsLE((const U8*)&(header->max_y)))
     {
       fprintf(stderr,"ERROR: updating header->max_y\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->min_y)))
+    if (!stream->put64bitsLE((const U8*)&(header->min_y)))
     {
       fprintf(stderr,"ERROR: updating header->min_y\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->max_z)))
+    if (!stream->put64bitsLE((const U8*)&(header->max_z)))
     {
       fprintf(stderr,"ERROR: updating header->max_z\n");
       return FALSE;
     }
-    if (!stream->put64bitsLE((U8*)&(header->min_z)))
+    if (!stream->put64bitsLE((const U8*)&(header->min_z)))
     {
       fprintf(stderr,"ERROR: updating header->min_z\n");
       return FALSE;
@@ -1120,7 +1120,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
         fprintf(stderr,"WARNING: header->start_of_waveform_data_packet_record is %lld. writing 0 instead.\n", header->start_of_waveform_data_packet_record);
 #endif
         U64 start_of_waveform_data_packet_record = 0;
-        if (!stream->put64bitsLE((U8*)&start_of_waveform_data_packet_record))
+        if (!stream->put64bitsLE((const U8*)&start_of_waveform_data_packet_record))
         {
           fprintf(stderr,"ERROR: updating start_of_waveform_data_packet_record\n");
           return FALSE;
@@ -1128,7 +1128,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
       }
       else
       {
-        if (!stream->put64bitsLE((U8*)&(header->start_of_waveform_data_packet_record)))
+        if (!stream->put64bitsLE((const U8*)&(header->start_of_waveform_data_packet_record)))
         {
           fprintf(stderr,"ERROR: updating header->start_of_waveform_data_packet_record\n");
           return FALSE;
@@ -1139,12 +1139,12 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
     if (header->version_minor >= 4)
     {
       stream->seek(header_start_position+235);
-      if (!stream->put64bitsLE((U8*)&(header->start_of_first_extended_variable_length_record)))
+      if (!stream->put64bitsLE((const U8*)&(header->start_of_first_extended_variable_length_record)))
       {
         fprintf(stderr,"ERROR: updating header->start_of_first_extended_variable_length_record\n");
         return FALSE;
       }
-      if (!stream->put32bitsLE((U8*)&(header->number_of_extended_variable_length_records)))
+      if (!stream->put32bitsLE((const U8*)&(header->number_of_extended_variable_length_records)))
       {
         fprintf(stderr,"ERROR: updating header->number_of_extended_variable_length_records\n");
         return FALSE;
@@ -1154,7 +1154,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
         value = header->number_of_point_records;
       else
         value = header->extended_number_of_point_records;
-      if (!stream->put64bitsLE((U8*)&value))
+      if (!stream->put64bitsLE((const U8*)&value))
       {
         fprintf(stderr,"ERROR: updating header->extended_number_of_point_records\n");
         return FALSE;
@@ -1165,7 +1165,7 @@ BOOL LASwriterLAS::update_header(const LASheader* header, BOOL use_inventory, BO
           value = header->number_of_points_by_return[i];
         else
           value = header->extended_number_of_points_by_return[i];
-        if (!stream->put64bitsLE((U8*)&value))
+        if (!stream->put64bitsLE((const U8*)&value))
         {
           fprintf(stderr,"ERROR: updating header->extended_number_of_points_by_return[%d]\n", i);
           return FALSE;
@@ -1272,27 +1272,27 @@ I64 LASwriterLAS::close(BOOL update_npoints)
 
       // write variable length records variable after variable (to avoid alignment issues)
 
-      if (!stream->put16bitsLE((U8*)&(evlrs[i].reserved)))
+      if (!stream->put16bitsLE((const U8*)&(evlrs[i].reserved)))
       {
         fprintf(stderr,"ERROR: writing evlrs[%d].reserved\n", i);
         return FALSE;
       }
-      if (!stream->putBytes((U8*)evlrs[i].user_id, 16))
+      if (!stream->putBytes((const U8*)evlrs[i].user_id, 16))
       {
         fprintf(stderr,"ERROR: writing evlrs[%d].user_id\n", i);
         return FALSE;
       }
-      if (!stream->put16bitsLE((U8*)&(evlrs[i].record_id)))
+      if (!stream->put16bitsLE((const U8*)&(evlrs[i].record_id)))
       {
         fprintf(stderr,"ERROR: writing evlrs[%d].record_id\n", i);
         return FALSE;
       }
-      if (!stream->put64bitsLE((U8*)&(evlrs[i].record_length_after_header)))
+      if (!stream->put64bitsLE((const U8*)&(evlrs[i].record_length_after_header)))
       {
         fprintf(stderr,"ERROR: writing evlrs[%d].record_length_after_header\n", i);
         return FALSE;
       }
-      if (!stream->putBytes((U8*)evlrs[i].description, 32))
+      if (!stream->putBytes((const U8*)evlrs[i].description, 32))
       {
         fprintf(stderr,"ERROR: writing evlrs[%d].description\n", i);
         return FALSE;
@@ -1304,7 +1304,7 @@ I64 LASwriterLAS::close(BOOL update_npoints)
       {
         if (evlrs[i].data)
         {
-          if (!stream->putBytes((U8*)evlrs[i].data, (U32)evlrs[i].record_length_after_header))
+          if (!stream->putBytes((const U8*)evlrs[i].data, (U32)evlrs[i].record_length_after_header))
           {
             fprintf(stderr,"ERROR: writing %u bytes of data from evlrs[%d].data\n", (U32)evlrs[i].record_length_after_header, i);
             return FALSE;
@@ -1321,8 +1321,8 @@ I64 LASwriterLAS::close(BOOL update_npoints)
       {
           copc_root_hier_size = evlrs[i].record_length_after_header;
           stream->seek(375 + 54 + 40);
-          stream->put64bitsLE((U8*)&copc_root_hier_offset);
-          stream->put64bitsLE((U8*)&copc_root_hier_size);
+          stream->put64bitsLE((const U8*)&copc_root_hier_offset);
+          stream->put64bitsLE((const U8*)&copc_root_hier_size);
           stream->seekEnd();
       }
     }
@@ -1330,7 +1330,7 @@ I64 LASwriterLAS::close(BOOL update_npoints)
     if (real_start_of_first_extended_variable_length_record != start_of_first_extended_variable_length_record)
     {
   	  stream->seek(header_start_position+235);
-  	  stream->put64bitsLE((U8*)&real_start_of_first_extended_variable_length_record);
+  	  stream->put64bitsLE((const U8*)&real_start_of_first_extended_variable_length_record);
       stream->seekEnd();
     }
   }
@@ -1370,11 +1370,11 @@ I64 LASwriterLAS::close(BOOL update_npoints)
           number = (U32)p_count;
         }
 	      stream->seek(header_start_position+107);
-	      stream->put32bitsLE((U8*)&number);
+	      stream->put32bitsLE((const U8*)&number);
         if (writing_las_1_4)
         {
   	      stream->seek(header_start_position+235+12);
-  	      stream->put64bitsLE((U8*)&p_count);
+  	      stream->put64bitsLE((const U8*)&p_count);
         }
         stream->seekEnd();
       }

--- a/LASzip/src/bytestreamin_array.hpp
+++ b/LASzip/src/bytestreamin_array.hpp
@@ -151,7 +151,7 @@ inline void ByteStreamInArray::getBytes(U8* bytes, const U32 num_bytes)
   {
     throw EOF;
   }
-  memcpy((void*)bytes, (void*)(data+curr), num_bytes);
+  memcpy((void*)bytes, (const void*)(data+curr), num_bytes);
   curr += num_bytes;
 }
 

--- a/LASzip/src/lascopc.cpp
+++ b/LASzip/src/lascopc.cpp
@@ -184,7 +184,7 @@ BOOL EPToctree::set_vlr_entries(const U8* data, const U64 offset_to_first_copc_e
   std::vector<LASvlr_copc_entry> page;
   std::vector<LASvlr_copc_entry> entries;
   std::deque<LASvlr_copc_entry> child_entries;
-  LASvlr_copc_entry* payload = (LASvlr_copc_entry*)data;
+  const LASvlr_copc_entry* payload = (const LASvlr_copc_entry*)data;
 
   // Read the root page
   U64 n_root_entries = header.vlr_copc_info->root_hier_size/sizeof(LASvlr_copc_entry);

--- a/LASzip/src/laspoint.hpp
+++ b/LASzip/src/laspoint.hpp
@@ -45,12 +45,12 @@ public:
   LASwavepacket() {zero();};
   void zero() {memset(data, 0, 29);};
   inline U8 getIndex() const {return data[0];};
-  inline U64 getOffset() const {return ((U64*)&(data[1]))[0];};
-  inline U32 getSize() const {return ((U32*)&(data[9]))[0];};
-  inline F32 getLocation() const {return ((F32*)&(data[13]))[0];};
-  inline F32 getXt() const {return ((F32*)&(data[17]))[0];};
-  inline F32 getYt() const {return ((F32*)&(data[21]))[0];};
-  inline F32 getZt() const {return ((F32*)&(data[25]))[0];};
+  inline U64 getOffset() const {return ((const U64*)&(data[1]))[0];};
+  inline U32 getSize() const {return ((const U32*)&(data[9]))[0];};
+  inline F32 getLocation() const {return ((const F32*)&(data[13]))[0];};
+  inline F32 getXt() const {return ((const F32*)&(data[17]))[0];};
+  inline F32 getYt() const {return ((const F32*)&(data[21]))[0];};
+  inline F32 getZt() const {return ((const F32*)&(data[25]))[0];};
   inline void setIndex(U8 index) {data[0] = index;};
   inline void setOffset(U64 offset) {((U64*)&(data[1]))[0] = offset;};
   inline void setSize(U32 size) {((U32*)&(data[9]))[0] = size;};
@@ -220,12 +220,12 @@ public:
     if (extended_point_type)
     {
       memcpy(buffer, &X, 14);
-      buffer[14] = ((U8*)&X)[24]; // extended return number and number of returns
-      buffer[15] = (((U8*)&X)[14] & 0xC0) | (extended_scanner_channel << 4) | (extended_classification_flags & 0x08) | ((((U8*)&X)[15]) >> 5);
-      buffer[16] = ((U8*)&X)[23]; // extended classification
-      buffer[17] = ((U8*)&X)[17]; // user data
-      ((I16*)buffer)[9] = ((I16*)&X)[10]; // extended scan angle
-      ((U16*)buffer)[10] = ((U16*)&X)[9]; // point source ID
+      buffer[14] = ((const U8*)&X)[24]; // extended return number and number of returns
+      buffer[15] = (((const U8*)&X)[14] & 0xC0) | (extended_scanner_channel << 4) | (extended_classification_flags & 0x08) | ((((const U8*)&X)[15]) >> 5);
+      buffer[16] = ((const U8*)&X)[23]; // extended classification
+      buffer[17] = ((const U8*)&X)[17]; // user data
+      ((I16*)buffer)[9] = ((const I16*)&X)[10]; // extended scan angle
+      ((U16*)buffer)[10] = ((const U16*)&X)[9]; // point source ID
       memcpy(buffer+22, &gps_time, 8);
     }
     else
@@ -255,8 +255,8 @@ public:
       ((U8*)&X)[23] = buffer[16]; // extended classification
       if (extended_classification < 32) classification = extended_classification;
       ((U8*)&X)[17] = buffer[17]; // user data
-      ((I16*)&X)[10] = ((I16*)buffer)[9]; // extended scan angle
-      ((U16*)&X)[9] = ((U16*)buffer)[10]; // point source ID
+      ((I16*)&X)[10] = ((const I16*)buffer)[9]; // extended scan angle
+      ((U16*)&X)[9] = ((const U16*)buffer)[10]; // point source ID
       memcpy(&gps_time, buffer+22, 8);
     }
     else

--- a/LASzip/src/lasreaditemcompressed_v1.cpp
+++ b/LASzip/src/lasreaditemcompressed_v1.cpp
@@ -288,7 +288,7 @@ BOOL LASreadItemCompressed_GPSTIME11_v1::init(const U8* item, U32& context)
   ic_gpstime->initDecompressor();
 
   /* init last item */
-  last_gpstime.u64 = *((U64*)item);
+  last_gpstime.u64 = *((const U64*)item);
   return TRUE;
 }
 

--- a/LASzip/src/lasreaditemcompressed_v2.cpp
+++ b/LASzip/src/lasreaditemcompressed_v2.cpp
@@ -287,7 +287,7 @@ BOOL LASreadItemCompressed_GPSTIME11_v2::init(const U8* item, U32& context)
   ic_gpstime->initDecompressor();
 
   /* init last item */
-  last_gpstime[0].u64 = *((U64*)item);
+  last_gpstime[0].u64 = *((const U64*)item);
   last_gpstime[1].u64 = 0;
   last_gpstime[2].u64 = 0;
   last_gpstime[3].u64 = 0;

--- a/LASzip/src/lasreaditemcompressed_v3.cpp
+++ b/LASzip/src/lasreaditemcompressed_v3.cpp
@@ -323,7 +323,7 @@ inline BOOL LASreadItemCompressed_POINT14_v3::createAndInitModelsAndDecompressor
   contexts[context].ic_Z->initDecompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_Z[i] = ((LASpoint14*)item)->Z;
+    contexts[context].last_Z[i] = ((const LASpoint14*)item)->Z;
   }
 
   /* for the classification layer */
@@ -342,7 +342,7 @@ inline BOOL LASreadItemCompressed_POINT14_v3::createAndInitModelsAndDecompressor
   contexts[context].ic_intensity->initDecompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_intensity[i] = ((LASpoint14*)item)->intensity;
+    contexts[context].last_intensity[i] = ((const LASpoint14*)item)->intensity;
   }
 
   /* for the scan_angle layer */
@@ -367,7 +367,7 @@ inline BOOL LASreadItemCompressed_POINT14_v3::createAndInitModelsAndDecompressor
   contexts[context].multi_extreme_counter[1] = 0;
   contexts[context].multi_extreme_counter[2] = 0;
   contexts[context].multi_extreme_counter[3] = 0;
-  contexts[context].last_gpstime[0].f64 = ((LASpoint14*)item)->gps_time;
+  contexts[context].last_gpstime[0].f64 = ((const LASpoint14*)item)->gps_time;
   contexts[context].last_gpstime[1].u64 = 0;
   contexts[context].last_gpstime[2].u64 = 0;
   contexts[context].last_gpstime[3].u64 = 0;
@@ -695,7 +695,7 @@ BOOL LASreadItemCompressed_POINT14_v3::init(const U8* item, U32& context)
 
   /* set scanner channel as current context */
 
-  current_context = ((LASpoint14*)item)->scanner_channel;
+  current_context = ((const LASpoint14*)item)->scanner_channel;
   context = current_context; // the POINT14 reader sets context for all other items
 
   /* create and init models and decompressors */

--- a/LASzip/src/lasreaditemcompressed_v4.cpp
+++ b/LASzip/src/lasreaditemcompressed_v4.cpp
@@ -321,7 +321,7 @@ inline BOOL LASreadItemCompressed_POINT14_v4::createAndInitModelsAndDecompressor
   contexts[context].ic_Z->initDecompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_Z[i] = ((LASpoint14*)item)->Z;
+    contexts[context].last_Z[i] = ((const LASpoint14*)item)->Z;
   }
 
   /* for the classification layer */
@@ -340,7 +340,7 @@ inline BOOL LASreadItemCompressed_POINT14_v4::createAndInitModelsAndDecompressor
   contexts[context].ic_intensity->initDecompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_intensity[i] = ((LASpoint14*)item)->intensity;
+    contexts[context].last_intensity[i] = ((const LASpoint14*)item)->intensity;
   }
 
   /* for the scan_angle layer */
@@ -365,7 +365,7 @@ inline BOOL LASreadItemCompressed_POINT14_v4::createAndInitModelsAndDecompressor
   contexts[context].multi_extreme_counter[1] = 0;
   contexts[context].multi_extreme_counter[2] = 0;
   contexts[context].multi_extreme_counter[3] = 0;
-  contexts[context].last_gpstime[0].f64 = ((LASpoint14*)item)->gps_time;
+  contexts[context].last_gpstime[0].f64 = ((const LASpoint14*)item)->gps_time;
   contexts[context].last_gpstime[1].u64 = 0;
   contexts[context].last_gpstime[2].u64 = 0;
   contexts[context].last_gpstime[3].u64 = 0;
@@ -693,7 +693,7 @@ BOOL LASreadItemCompressed_POINT14_v4::init(const U8* item, U32& context)
 
   /* set scanner channel as current context */
 
-  current_context = ((LASpoint14*)item)->scanner_channel;
+  current_context = ((const LASpoint14*)item)->scanner_channel;
   context = current_context; // the POINT14 reader sets context for all other items
 
   /* create and init models and decompressors */

--- a/LASzip/src/laswriteitemcompressed_v3.cpp
+++ b/LASzip/src/laswriteitemcompressed_v3.cpp
@@ -307,7 +307,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::createAndInitModelsAndCompressors
   contexts[context].ic_Z->initCompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_Z[i] = ((LASpoint14*)item)->Z;
+    contexts[context].last_Z[i] = ((const LASpoint14*)item)->Z;
   }
 
   /* for the classification layer */
@@ -326,7 +326,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::createAndInitModelsAndCompressors
   contexts[context].ic_intensity->initCompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_intensity[i] = ((LASpoint14*)item)->intensity;
+    contexts[context].last_intensity[i] = ((const LASpoint14*)item)->intensity;
   }
 
   /* for the scan_angle layer */
@@ -351,7 +351,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::createAndInitModelsAndCompressors
   contexts[context].multi_extreme_counter[1] = 0;
   contexts[context].multi_extreme_counter[2] = 0;
   contexts[context].multi_extreme_counter[3] = 0;
-  contexts[context].last_gpstime[0].f64 = ((LASpoint14*)item)->gps_time;
+  contexts[context].last_gpstime[0].f64 = ((const LASpoint14*)item)->gps_time;
   contexts[context].last_gpstime[1].u64 = 0;
   contexts[context].last_gpstime[2].u64 = 0;
   contexts[context].last_gpstime[3].u64 = 0;
@@ -456,7 +456,7 @@ BOOL LASwriteItemCompressed_POINT14_v3::init(const U8* item, U32& context)
 
   /* set scanner channel as current context */
 
-  current_context = ((LASpoint14*)item)->scanner_channel;
+  current_context = ((const LASpoint14*)item)->scanner_channel;
   context = current_context; // the POINT14 writer sets context for all other items
 
   /* create and init entropy models and integer compressors (and init context from item) */
@@ -487,7 +487,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
 
   // get the (potentially new) context
 
-  U32 scanner_channel = ((LASpoint14*)item)->scanner_channel;
+  U32 scanner_channel = ((const LASpoint14*)item)->scanner_channel;
 
   // if context has changed (and the new context already exists) get last for new context
 
@@ -501,17 +501,17 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
 
   // determine changed attributes
 
-  BOOL point_source_change = (((LASpoint14*)item)->point_source_ID != ((LASpoint14*)last_item)->point_source_ID);
-  BOOL gps_time_change = (((LASpoint14*)item)->gps_time != ((LASpoint14*)last_item)->gps_time);
-  BOOL scan_angle_change = (((LASpoint14*)item)->scan_angle != ((LASpoint14*)last_item)->scan_angle);
+  BOOL point_source_change = (((const LASpoint14*)item)->point_source_ID != ((LASpoint14*)last_item)->point_source_ID);
+  BOOL gps_time_change = (((const LASpoint14*)item)->gps_time != ((LASpoint14*)last_item)->gps_time);
+  BOOL scan_angle_change = (((const LASpoint14*)item)->scan_angle != ((LASpoint14*)last_item)->scan_angle);
 
   // get last and current return counts
 
   U32 last_n = ((LASpoint14*)last_item)->number_of_returns;
   U32 last_r = ((LASpoint14*)last_item)->return_number;
 
-  U32 n = ((LASpoint14*)item)->number_of_returns;
-  U32 r = ((LASpoint14*)item)->return_number;
+  U32 n = ((const LASpoint14*)item)->number_of_returns;
+  U32 r = ((const LASpoint14*)item)->return_number;
 
   // create the 7 bit mask that encodes various changes (its value ranges from 0 to 127)
 
@@ -623,14 +623,14 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
 
   // compress X coordinate
   median = contexts[current_context].last_X_diff_median5[(m<<1) | gps_time_change].get();
-  diff = ((LASpoint14*)item)->X - ((LASpoint14*)last_item)->X;
+  diff = ((const LASpoint14*)item)->X - ((LASpoint14*)last_item)->X;
   contexts[current_context].ic_dX->compress(median, diff, n==1);
   contexts[current_context].last_X_diff_median5[(m<<1) | gps_time_change].add(diff);
 
   // compress Y coordinate
   k_bits = contexts[current_context].ic_dX->getK();
   median = contexts[current_context].last_Y_diff_median5[(m<<1) | gps_time_change].get();
-  diff = ((LASpoint14*)item)->Y - ((LASpoint14*)last_item)->Y;
+  diff = ((const LASpoint14*)item)->Y - ((LASpoint14*)last_item)->Y;
   contexts[current_context].ic_dY->compress(median, diff, (n==1) + ( k_bits < 20 ? U32_ZERO_BIT_0(k_bits) : 20 ));
   contexts[current_context].last_Y_diff_median5[(m<<1) | gps_time_change].add(diff);
 
@@ -639,15 +639,15 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
   ////////////////////////////////////////
 
   k_bits = (contexts[current_context].ic_dX->getK() + contexts[current_context].ic_dY->getK()) / 2;
-  contexts[current_context].ic_Z->compress(contexts[current_context].last_Z[l], ((LASpoint14*)item)->Z, (n==1) + (k_bits < 18 ? U32_ZERO_BIT_0(k_bits) : 18));
-  contexts[current_context].last_Z[l] = ((LASpoint14*)item)->Z;
+  contexts[current_context].ic_Z->compress(contexts[current_context].last_Z[l], ((const LASpoint14*)item)->Z, (n==1) + (k_bits < 18 ? U32_ZERO_BIT_0(k_bits) : 18));
+  contexts[current_context].last_Z[l] = ((const LASpoint14*)item)->Z;
 
   ////////////////////////////////////////
   // compress classifications layer 
   ////////////////////////////////////////
 
   U32 last_classification = ((LASpoint14*)last_item)->classification;
-  U32 classification = ((LASpoint14*)item)->classification;
+  U32 classification = ((const LASpoint14*)item)->classification;
 
   if (classification != last_classification)
   {
@@ -667,7 +667,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
   ////////////////////////////////////////
 
   U32 last_flags = (((LASpoint14*)last_item)->edge_of_flight_line << 5) | (((LASpoint14*)last_item)->scan_direction_flag << 4) | ((LASpoint14*)last_item)->classification_flags;
-  U32 flags = (((LASpoint14*)item)->edge_of_flight_line << 5) | (((LASpoint14*)item)->scan_direction_flag << 4) | ((LASpoint14*)item)->classification_flags;
+  U32 flags = (((const LASpoint14*)item)->edge_of_flight_line << 5) | (((const LASpoint14*)item)->scan_direction_flag << 4) | ((const LASpoint14*)item)->classification_flags;
 
   if (flags != last_flags)
   {
@@ -685,12 +685,12 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
   // compress intensity layer 
   ////////////////////////////////////////
 
-  if (((LASpoint14*)item)->intensity != ((LASpoint14*)last_item)->intensity)
+  if (((const LASpoint14*)item)->intensity != ((LASpoint14*)last_item)->intensity)
   {
     changed_intensity = TRUE;
   }
-  contexts[current_context].ic_intensity->compress(contexts[current_context].last_intensity[(cpr<<1) | gps_time_change], ((LASpoint14*)item)->intensity, cpr);
-  contexts[current_context].last_intensity[(cpr<<1) | gps_time_change] = ((LASpoint14*)item)->intensity;
+  contexts[current_context].ic_intensity->compress(contexts[current_context].last_intensity[(cpr<<1) | gps_time_change], ((const LASpoint14*)item)->intensity, cpr);
+  contexts[current_context].last_intensity[(cpr<<1) | gps_time_change] = ((const LASpoint14*)item)->intensity;
   
   ////////////////////////////////////////
   // compress scan_angle layer 
@@ -699,14 +699,14 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
   if (scan_angle_change)
   {
     changed_scan_angle = TRUE;
-    contexts[current_context].ic_scan_angle->compress(((LASpoint14*)last_item)->scan_angle, ((LASpoint14*)item)->scan_angle, gps_time_change); // if the GPS time has changed
+    contexts[current_context].ic_scan_angle->compress(((LASpoint14*)last_item)->scan_angle, ((const LASpoint14*)item)->scan_angle, gps_time_change); // if the GPS time has changed
   }
 
   ////////////////////////////////////////
   // compress user_data layer 
   ////////////////////////////////////////
 
-  if (((LASpoint14*)item)->user_data != ((LASpoint14*)last_item)->user_data)
+  if (((const LASpoint14*)item)->user_data != ((LASpoint14*)last_item)->user_data)
   {
     changed_user_data = TRUE;
   }
@@ -715,7 +715,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
     contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4] = enc_user_data->createSymbolModel(256);
     enc_user_data->initSymbolModel(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4]);
   }
-  enc_user_data->encodeSymbol(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4], ((LASpoint14*)item)->user_data);
+  enc_user_data->encodeSymbol(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4], ((const LASpoint14*)item)->user_data);
 
   ////////////////////////////////////////
   // compress point_source layer 
@@ -724,7 +724,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
   if (point_source_change)
   {
     changed_point_source = TRUE;
-    contexts[current_context].ic_point_source_ID->compress(((LASpoint14*)last_item)->point_source_ID, ((LASpoint14*)item)->point_source_ID);
+    contexts[current_context].ic_point_source_ID->compress(((LASpoint14*)last_item)->point_source_ID, ((const LASpoint14*)item)->point_source_ID);
   }
 
   ////////////////////////////////////////
@@ -736,7 +736,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
     changed_gps_time = TRUE;
 
     U64I64F64 gps_time;
-    gps_time.f64 = ((LASpoint14*)item)->gps_time;
+    gps_time.f64 = ((const LASpoint14*)item)->gps_time;
 
     write_gps_time(gps_time);
   }
@@ -1288,46 +1288,46 @@ inline BOOL LASwriteItemCompressed_RGB14_v3::write(const U8* item, U32& context)
   I32 diff_l = 0;
   I32 diff_h = 0;
   I32 corr;
-  U32 sym = ((last_item[0]&0x00FF) != (((U16*)item)[0]&0x00FF)) << 0;
-  sym |= ((last_item[0]&0xFF00) != (((U16*)item)[0]&0xFF00)) << 1;
-  sym |= ((last_item[1]&0x00FF) != (((U16*)item)[1]&0x00FF)) << 2;
-  sym |= ((last_item[1]&0xFF00) != (((U16*)item)[1]&0xFF00)) << 3;
-  sym |= ((last_item[2]&0x00FF) != (((U16*)item)[2]&0x00FF)) << 4;
-  sym |= ((last_item[2]&0xFF00) != (((U16*)item)[2]&0xFF00)) << 5;
-  sym |= (((((U16*)item)[0]&0x00FF) != (((U16*)item)[1]&0x00FF)) || ((((U16*)item)[0]&0x00FF) != (((U16*)item)[2]&0x00FF)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[1]&0xFF00)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[2]&0xFF00))) << 6;
+  U32 sym = ((last_item[0]&0x00FF) != (((const U16*)item)[0]&0x00FF)) << 0;
+  sym |= ((last_item[0]&0xFF00) != (((const U16*)item)[0]&0xFF00)) << 1;
+  sym |= ((last_item[1]&0x00FF) != (((const U16*)item)[1]&0x00FF)) << 2;
+  sym |= ((last_item[1]&0xFF00) != (((const U16*)item)[1]&0xFF00)) << 3;
+  sym |= ((last_item[2]&0x00FF) != (((const U16*)item)[2]&0x00FF)) << 4;
+  sym |= ((last_item[2]&0xFF00) != (((const U16*)item)[2]&0xFF00)) << 5;
+  sym |= (((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[1]&0x00FF)) || ((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[2]&0x00FF)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[1]&0xFF00)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[2]&0xFF00))) << 6;
   enc_RGB->encodeSymbol(contexts[current_context].m_byte_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[0]&255)) - (last_item[0]&255);
+    diff_l = ((int)(((const U16*)item)[0]&255)) - (last_item[0]&255);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[0]>>8)) - (last_item[0]>>8);
+    diff_h = ((int)(((const U16*)item)[0]>>8)) - (last_item[0]>>8);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_1, U8_FOLD(diff_h));
   }
   if (sym & (1 << 6))
   {
     if (sym & (1 << 2))
     {
-      corr = ((int)(((U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
+      corr = ((int)(((const U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_2, U8_FOLD(corr));
     }
     if (sym & (1 << 4))
     {
-      diff_l = (diff_l + (((U16*)item)[1]&255) - (last_item[1]&255)) / 2;
-      corr = ((int)(((U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
+      diff_l = (diff_l + (((const U16*)item)[1]&255) - (last_item[1]&255)) / 2;
+      corr = ((int)(((const U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_4, U8_FOLD(corr));
     }
     if (sym & (1 << 3))
     {
-      corr = ((int)(((U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
+      corr = ((int)(((const U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_3, U8_FOLD(corr));
     }
     if (sym & (1 << 5))
     {
-      diff_h = (diff_h + (((U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
-      corr = ((int)(((U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
+      diff_h = (diff_h + (((const U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
+      corr = ((int)(((const U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_5, U8_FOLD(corr));
     }
   }
@@ -1585,46 +1585,46 @@ inline BOOL LASwriteItemCompressed_RGBNIR14_v3::write(const U8* item, U32& conte
   I32 diff_l = 0;
   I32 diff_h = 0;
   I32 corr;
-  U32 sym = ((last_item[0]&0x00FF) != (((U16*)item)[0]&0x00FF)) << 0;
-  sym |= ((last_item[0]&0xFF00) != (((U16*)item)[0]&0xFF00)) << 1;
-  sym |= ((last_item[1]&0x00FF) != (((U16*)item)[1]&0x00FF)) << 2;
-  sym |= ((last_item[1]&0xFF00) != (((U16*)item)[1]&0xFF00)) << 3;
-  sym |= ((last_item[2]&0x00FF) != (((U16*)item)[2]&0x00FF)) << 4;
-  sym |= ((last_item[2]&0xFF00) != (((U16*)item)[2]&0xFF00)) << 5;
-  sym |= (((((U16*)item)[0]&0x00FF) != (((U16*)item)[1]&0x00FF)) || ((((U16*)item)[0]&0x00FF) != (((U16*)item)[2]&0x00FF)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[1]&0xFF00)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[2]&0xFF00))) << 6;
+  U32 sym = ((last_item[0]&0x00FF) != (((const U16*)item)[0]&0x00FF)) << 0;
+  sym |= ((last_item[0]&0xFF00) != (((const U16*)item)[0]&0xFF00)) << 1;
+  sym |= ((last_item[1]&0x00FF) != (((const U16*)item)[1]&0x00FF)) << 2;
+  sym |= ((last_item[1]&0xFF00) != (((const U16*)item)[1]&0xFF00)) << 3;
+  sym |= ((last_item[2]&0x00FF) != (((const U16*)item)[2]&0x00FF)) << 4;
+  sym |= ((last_item[2]&0xFF00) != (((const U16*)item)[2]&0xFF00)) << 5;
+  sym |= (((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[1]&0x00FF)) || ((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[2]&0x00FF)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[1]&0xFF00)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[2]&0xFF00))) << 6;
   enc_RGB->encodeSymbol(contexts[current_context].m_rgb_bytes_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[0]&255)) - (last_item[0]&255);
+    diff_l = ((int)(((const U16*)item)[0]&255)) - (last_item[0]&255);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[0]>>8)) - (last_item[0]>>8);
+    diff_h = ((int)(((const U16*)item)[0]>>8)) - (last_item[0]>>8);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_1, U8_FOLD(diff_h));
   }
   if (sym & (1 << 6))
   {
     if (sym & (1 << 2))
     {
-      corr = ((int)(((U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
+      corr = ((int)(((const U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_2, U8_FOLD(corr));
     }
     if (sym & (1 << 4))
     {
-      diff_l = (diff_l + (((U16*)item)[1]&255) - (last_item[1]&255)) / 2;
-      corr = ((int)(((U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
+      diff_l = (diff_l + (((const U16*)item)[1]&255) - (last_item[1]&255)) / 2;
+      corr = ((int)(((const U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_4, U8_FOLD(corr));
     }
     if (sym & (1 << 3))
     {
-      corr = ((int)(((U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
+      corr = ((int)(((const U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_3, U8_FOLD(corr));
     }
     if (sym & (1 << 5))
     {
-      diff_h = (diff_h + (((U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
-      corr = ((int)(((U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
+      diff_h = (diff_h + (((const U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
+      corr = ((int)(((const U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_5, U8_FOLD(corr));
     }
   }
@@ -1633,17 +1633,17 @@ inline BOOL LASwriteItemCompressed_RGBNIR14_v3::write(const U8* item, U32& conte
     changed_RGB = TRUE;
   }
 
-  sym = ((last_item[3]&0x00FF) != (((U16*)item)[3]&0x00FF)) << 0;
-  sym |= ((last_item[3]&0xFF00) != (((U16*)item)[3]&0xFF00)) << 1;
+  sym = ((last_item[3]&0x00FF) != (((const U16*)item)[3]&0x00FF)) << 0;
+  sym |= ((last_item[3]&0xFF00) != (((const U16*)item)[3]&0xFF00)) << 1;
   enc_NIR->encodeSymbol(contexts[current_context].m_nir_bytes_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[3]&255)) - (last_item[3]&255);
+    diff_l = ((int)(((const U16*)item)[3]&255)) - (last_item[3]&255);
     enc_NIR->encodeSymbol(contexts[current_context].m_nir_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[3]>>8)) - (last_item[3]>>8);
+    diff_h = ((int)(((const U16*)item)[3]>>8)) - (last_item[3]>>8);
     enc_NIR->encodeSymbol(contexts[current_context].m_nir_diff_1, U8_FOLD(diff_h));
   }
   if (sym)

--- a/LASzip/src/laswriteitemcompressed_v4.cpp
+++ b/LASzip/src/laswriteitemcompressed_v4.cpp
@@ -305,7 +305,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::createAndInitModelsAndCompressors
   contexts[context].ic_Z->initCompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_Z[i] = ((LASpoint14*)item)->Z;
+    contexts[context].last_Z[i] = ((const LASpoint14*)item)->Z;
   }
 
   /* for the classification layer */
@@ -324,7 +324,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::createAndInitModelsAndCompressors
   contexts[context].ic_intensity->initCompressor();
   for (i = 0; i < 8; i++)
   {
-    contexts[context].last_intensity[i] = ((LASpoint14*)item)->intensity;
+    contexts[context].last_intensity[i] = ((const LASpoint14*)item)->intensity;
   }
 
   /* for the scan_angle layer */
@@ -349,7 +349,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::createAndInitModelsAndCompressors
   contexts[context].multi_extreme_counter[1] = 0;
   contexts[context].multi_extreme_counter[2] = 0;
   contexts[context].multi_extreme_counter[3] = 0;
-  contexts[context].last_gpstime[0].f64 = ((LASpoint14*)item)->gps_time;
+  contexts[context].last_gpstime[0].f64 = ((const LASpoint14*)item)->gps_time;
   contexts[context].last_gpstime[1].u64 = 0;
   contexts[context].last_gpstime[2].u64 = 0;
   contexts[context].last_gpstime[3].u64 = 0;
@@ -454,7 +454,7 @@ BOOL LASwriteItemCompressed_POINT14_v4::init(const U8* item, U32& context)
 
   /* set scanner channel as current context */
 
-  current_context = ((LASpoint14*)item)->scanner_channel;
+  current_context = ((const LASpoint14*)item)->scanner_channel;
   context = current_context; // the POINT14 writer sets context for all other items
 
   /* create and init entropy models and integer compressors (and init context from item) */
@@ -485,7 +485,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
 
   // get the (potentially new) context
 
-  U32 scanner_channel = ((LASpoint14*)item)->scanner_channel;
+  U32 scanner_channel = ((const LASpoint14*)item)->scanner_channel;
 
   // if context has changed (and the new context already exists) get last for new context
 
@@ -499,17 +499,17 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
 
   // determine changed attributes
 
-  BOOL point_source_change = (((LASpoint14*)item)->point_source_ID != ((LASpoint14*)last_item)->point_source_ID);
-  BOOL gps_time_change = (((LASpoint14*)item)->gps_time != ((LASpoint14*)last_item)->gps_time);
-  BOOL scan_angle_change = (((LASpoint14*)item)->scan_angle != ((LASpoint14*)last_item)->scan_angle);
+  BOOL point_source_change = (((const LASpoint14*)item)->point_source_ID != ((LASpoint14*)last_item)->point_source_ID);
+  BOOL gps_time_change = (((const LASpoint14*)item)->gps_time != ((LASpoint14*)last_item)->gps_time);
+  BOOL scan_angle_change = (((const LASpoint14*)item)->scan_angle != ((LASpoint14*)last_item)->scan_angle);
 
   // get last and current return counts
 
   U32 last_n = ((LASpoint14*)last_item)->number_of_returns;
   U32 last_r = ((LASpoint14*)last_item)->return_number;
 
-  U32 n = ((LASpoint14*)item)->number_of_returns;
-  U32 r = ((LASpoint14*)item)->return_number;
+  U32 n = ((const LASpoint14*)item)->number_of_returns;
+  U32 r = ((const LASpoint14*)item)->return_number;
 
   // create the 7 bit mask that encodes various changes (its value ranges from 0 to 127)
 
@@ -621,14 +621,14 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
 
   // compress X coordinate
   median = contexts[current_context].last_X_diff_median5[(m<<1) | gps_time_change].get();
-  diff = ((LASpoint14*)item)->X - ((LASpoint14*)last_item)->X;
+  diff = ((const LASpoint14*)item)->X - ((LASpoint14*)last_item)->X;
   contexts[current_context].ic_dX->compress(median, diff, n==1);
   contexts[current_context].last_X_diff_median5[(m<<1) | gps_time_change].add(diff);
 
   // compress Y coordinate
   k_bits = contexts[current_context].ic_dX->getK();
   median = contexts[current_context].last_Y_diff_median5[(m<<1) | gps_time_change].get();
-  diff = ((LASpoint14*)item)->Y - ((LASpoint14*)last_item)->Y;
+  diff = ((const LASpoint14*)item)->Y - ((LASpoint14*)last_item)->Y;
   contexts[current_context].ic_dY->compress(median, diff, (n==1) + ( k_bits < 20 ? U32_ZERO_BIT_0(k_bits) : 20 ));
   contexts[current_context].last_Y_diff_median5[(m<<1) | gps_time_change].add(diff);
 
@@ -637,15 +637,15 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
   ////////////////////////////////////////
 
   k_bits = (contexts[current_context].ic_dX->getK() + contexts[current_context].ic_dY->getK()) / 2;
-  contexts[current_context].ic_Z->compress(contexts[current_context].last_Z[l], ((LASpoint14*)item)->Z, (n==1) + (k_bits < 18 ? U32_ZERO_BIT_0(k_bits) : 18));
-  contexts[current_context].last_Z[l] = ((LASpoint14*)item)->Z;
+  contexts[current_context].ic_Z->compress(contexts[current_context].last_Z[l], ((const LASpoint14*)item)->Z, (n==1) + (k_bits < 18 ? U32_ZERO_BIT_0(k_bits) : 18));
+  contexts[current_context].last_Z[l] = ((const LASpoint14*)item)->Z;
 
   ////////////////////////////////////////
   // compress classifications layer 
   ////////////////////////////////////////
 
   U32 last_classification = ((LASpoint14*)last_item)->classification;
-  U32 classification = ((LASpoint14*)item)->classification;
+  U32 classification = ((const LASpoint14*)item)->classification;
 
   if (classification != last_classification)
   {
@@ -665,7 +665,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
   ////////////////////////////////////////
 
   U32 last_flags = (((LASpoint14*)last_item)->edge_of_flight_line << 5) | (((LASpoint14*)last_item)->scan_direction_flag << 4) | ((LASpoint14*)last_item)->classification_flags;
-  U32 flags = (((LASpoint14*)item)->edge_of_flight_line << 5) | (((LASpoint14*)item)->scan_direction_flag << 4) | ((LASpoint14*)item)->classification_flags;
+  U32 flags = (((const LASpoint14*)item)->edge_of_flight_line << 5) | (((const LASpoint14*)item)->scan_direction_flag << 4) | ((const LASpoint14*)item)->classification_flags;
 
   if (flags != last_flags)
   {
@@ -683,12 +683,12 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
   // compress intensity layer 
   ////////////////////////////////////////
 
-  if (((LASpoint14*)item)->intensity != ((LASpoint14*)last_item)->intensity)
+  if (((const LASpoint14*)item)->intensity != ((LASpoint14*)last_item)->intensity)
   {
     changed_intensity = TRUE;
   }
-  contexts[current_context].ic_intensity->compress(contexts[current_context].last_intensity[(cpr<<1) | gps_time_change], ((LASpoint14*)item)->intensity, cpr);
-  contexts[current_context].last_intensity[(cpr<<1) | gps_time_change] = ((LASpoint14*)item)->intensity;
+  contexts[current_context].ic_intensity->compress(contexts[current_context].last_intensity[(cpr<<1) | gps_time_change], ((const LASpoint14*)item)->intensity, cpr);
+  contexts[current_context].last_intensity[(cpr<<1) | gps_time_change] = ((const LASpoint14*)item)->intensity;
   
   ////////////////////////////////////////
   // compress scan_angle layer 
@@ -697,14 +697,14 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
   if (scan_angle_change)
   {
     changed_scan_angle = TRUE;
-    contexts[current_context].ic_scan_angle->compress(((LASpoint14*)last_item)->scan_angle, ((LASpoint14*)item)->scan_angle, gps_time_change); // if the GPS time has changed
+    contexts[current_context].ic_scan_angle->compress(((LASpoint14*)last_item)->scan_angle, ((const LASpoint14*)item)->scan_angle, gps_time_change); // if the GPS time has changed
   }
 
   ////////////////////////////////////////
   // compress user_data layer 
   ////////////////////////////////////////
 
-  if (((LASpoint14*)item)->user_data != ((LASpoint14*)last_item)->user_data)
+  if (((const LASpoint14*)item)->user_data != ((LASpoint14*)last_item)->user_data)
   {
     changed_user_data = TRUE;
   }
@@ -713,7 +713,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
     contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4] = enc_user_data->createSymbolModel(256);
     enc_user_data->initSymbolModel(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4]);
   }
-  enc_user_data->encodeSymbol(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4], ((LASpoint14*)item)->user_data);
+  enc_user_data->encodeSymbol(contexts[current_context].m_user_data[((LASpoint14*)last_item)->user_data/4], ((const LASpoint14*)item)->user_data);
 
   ////////////////////////////////////////
   // compress point_source layer 
@@ -722,7 +722,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
   if (point_source_change)
   {
     changed_point_source = TRUE;
-    contexts[current_context].ic_point_source_ID->compress(((LASpoint14*)last_item)->point_source_ID, ((LASpoint14*)item)->point_source_ID);
+    contexts[current_context].ic_point_source_ID->compress(((LASpoint14*)last_item)->point_source_ID, ((const LASpoint14*)item)->point_source_ID);
   }
 
   ////////////////////////////////////////
@@ -734,7 +734,7 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
     changed_gps_time = TRUE;
 
     U64I64F64 gps_time;
-    gps_time.f64 = ((LASpoint14*)item)->gps_time;
+    gps_time.f64 = ((const LASpoint14*)item)->gps_time;
 
     write_gps_time(gps_time);
   }
@@ -1286,46 +1286,46 @@ inline BOOL LASwriteItemCompressed_RGB14_v4::write(const U8* item, U32& context)
   I32 diff_l = 0;
   I32 diff_h = 0;
   I32 corr;
-  U32 sym = ((last_item[0]&0x00FF) != (((U16*)item)[0]&0x00FF)) << 0;
-  sym |= ((last_item[0]&0xFF00) != (((U16*)item)[0]&0xFF00)) << 1;
-  sym |= ((last_item[1]&0x00FF) != (((U16*)item)[1]&0x00FF)) << 2;
-  sym |= ((last_item[1]&0xFF00) != (((U16*)item)[1]&0xFF00)) << 3;
-  sym |= ((last_item[2]&0x00FF) != (((U16*)item)[2]&0x00FF)) << 4;
-  sym |= ((last_item[2]&0xFF00) != (((U16*)item)[2]&0xFF00)) << 5;
-  sym |= (((((U16*)item)[0]&0x00FF) != (((U16*)item)[1]&0x00FF)) || ((((U16*)item)[0]&0x00FF) != (((U16*)item)[2]&0x00FF)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[1]&0xFF00)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[2]&0xFF00))) << 6;
+  U32 sym = ((last_item[0]&0x00FF) != (((const U16*)item)[0]&0x00FF)) << 0;
+  sym |= ((last_item[0]&0xFF00) != (((const U16*)item)[0]&0xFF00)) << 1;
+  sym |= ((last_item[1]&0x00FF) != (((const U16*)item)[1]&0x00FF)) << 2;
+  sym |= ((last_item[1]&0xFF00) != (((const U16*)item)[1]&0xFF00)) << 3;
+  sym |= ((last_item[2]&0x00FF) != (((const U16*)item)[2]&0x00FF)) << 4;
+  sym |= ((last_item[2]&0xFF00) != (((const U16*)item)[2]&0xFF00)) << 5;
+  sym |= (((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[1]&0x00FF)) || ((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[2]&0x00FF)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[1]&0xFF00)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[2]&0xFF00))) << 6;
   enc_RGB->encodeSymbol(contexts[current_context].m_byte_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[0]&255)) - (last_item[0]&255);
+    diff_l = ((int)(((const U16*)item)[0]&255)) - (last_item[0]&255);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[0]>>8)) - (last_item[0]>>8);
+    diff_h = ((int)(((const U16*)item)[0]>>8)) - (last_item[0]>>8);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_1, U8_FOLD(diff_h));
   }
   if (sym & (1 << 6))
   {
     if (sym & (1 << 2))
     {
-      corr = ((int)(((U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
+      corr = ((int)(((const U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_2, U8_FOLD(corr));
     }
     if (sym & (1 << 4))
     {
-      diff_l = (diff_l + (((U16*)item)[1]&255) - (last_item[1]&255)) / 2;
-      corr = ((int)(((U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
+      diff_l = (diff_l + (((const U16*)item)[1]&255) - (last_item[1]&255)) / 2;
+      corr = ((int)(((const U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_4, U8_FOLD(corr));
     }
     if (sym & (1 << 3))
     {
-      corr = ((int)(((U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
+      corr = ((int)(((const U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_3, U8_FOLD(corr));
     }
     if (sym & (1 << 5))
     {
-      diff_h = (diff_h + (((U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
-      corr = ((int)(((U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
+      diff_h = (diff_h + (((const U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
+      corr = ((int)(((const U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_5, U8_FOLD(corr));
     }
   }
@@ -1583,46 +1583,46 @@ inline BOOL LASwriteItemCompressed_RGBNIR14_v4::write(const U8* item, U32& conte
   I32 diff_l = 0;
   I32 diff_h = 0;
   I32 corr;
-  U32 sym = ((last_item[0]&0x00FF) != (((U16*)item)[0]&0x00FF)) << 0;
-  sym |= ((last_item[0]&0xFF00) != (((U16*)item)[0]&0xFF00)) << 1;
-  sym |= ((last_item[1]&0x00FF) != (((U16*)item)[1]&0x00FF)) << 2;
-  sym |= ((last_item[1]&0xFF00) != (((U16*)item)[1]&0xFF00)) << 3;
-  sym |= ((last_item[2]&0x00FF) != (((U16*)item)[2]&0x00FF)) << 4;
-  sym |= ((last_item[2]&0xFF00) != (((U16*)item)[2]&0xFF00)) << 5;
-  sym |= (((((U16*)item)[0]&0x00FF) != (((U16*)item)[1]&0x00FF)) || ((((U16*)item)[0]&0x00FF) != (((U16*)item)[2]&0x00FF)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[1]&0xFF00)) || ((((U16*)item)[0]&0xFF00) != (((U16*)item)[2]&0xFF00))) << 6;
+  U32 sym = ((last_item[0]&0x00FF) != (((const U16*)item)[0]&0x00FF)) << 0;
+  sym |= ((last_item[0]&0xFF00) != (((const U16*)item)[0]&0xFF00)) << 1;
+  sym |= ((last_item[1]&0x00FF) != (((const U16*)item)[1]&0x00FF)) << 2;
+  sym |= ((last_item[1]&0xFF00) != (((const U16*)item)[1]&0xFF00)) << 3;
+  sym |= ((last_item[2]&0x00FF) != (((const U16*)item)[2]&0x00FF)) << 4;
+  sym |= ((last_item[2]&0xFF00) != (((const U16*)item)[2]&0xFF00)) << 5;
+  sym |= (((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[1]&0x00FF)) || ((((const U16*)item)[0]&0x00FF) != (((const U16*)item)[2]&0x00FF)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[1]&0xFF00)) || ((((const U16*)item)[0]&0xFF00) != (((const U16*)item)[2]&0xFF00))) << 6;
   enc_RGB->encodeSymbol(contexts[current_context].m_rgb_bytes_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[0]&255)) - (last_item[0]&255);
+    diff_l = ((int)(((const U16*)item)[0]&255)) - (last_item[0]&255);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[0]>>8)) - (last_item[0]>>8);
+    diff_h = ((int)(((const U16*)item)[0]>>8)) - (last_item[0]>>8);
     enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_1, U8_FOLD(diff_h));
   }
   if (sym & (1 << 6))
   {
     if (sym & (1 << 2))
     {
-      corr = ((int)(((U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
+      corr = ((int)(((const U16*)item)[1]&255)) - U8_CLAMP(diff_l + (last_item[1]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_2, U8_FOLD(corr));
     }
     if (sym & (1 << 4))
     {
-      diff_l = (diff_l + (((U16*)item)[1]&255) - (last_item[1]&255)) / 2;
-      corr = ((int)(((U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
+      diff_l = (diff_l + (((const U16*)item)[1]&255) - (last_item[1]&255)) / 2;
+      corr = ((int)(((const U16*)item)[2]&255)) - U8_CLAMP(diff_l + (last_item[2]&255));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_4, U8_FOLD(corr));
     }
     if (sym & (1 << 3))
     {
-      corr = ((int)(((U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
+      corr = ((int)(((const U16*)item)[1]>>8)) - U8_CLAMP(diff_h + (last_item[1]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_3, U8_FOLD(corr));
     }
     if (sym & (1 << 5))
     {
-      diff_h = (diff_h + (((U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
-      corr = ((int)(((U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
+      diff_h = (diff_h + (((const U16*)item)[1]>>8) - (last_item[1]>>8)) / 2;
+      corr = ((int)(((const U16*)item)[2]>>8)) - U8_CLAMP(diff_h + (last_item[2]>>8));
       enc_RGB->encodeSymbol(contexts[current_context].m_rgb_diff_5, U8_FOLD(corr));
     }
   }
@@ -1631,17 +1631,17 @@ inline BOOL LASwriteItemCompressed_RGBNIR14_v4::write(const U8* item, U32& conte
     changed_RGB = TRUE;
   }
 
-  sym = ((last_item[3]&0x00FF) != (((U16*)item)[3]&0x00FF)) << 0;
-  sym |= ((last_item[3]&0xFF00) != (((U16*)item)[3]&0xFF00)) << 1;
+  sym = ((last_item[3]&0x00FF) != (((const U16*)item)[3]&0x00FF)) << 0;
+  sym |= ((last_item[3]&0xFF00) != (((const U16*)item)[3]&0xFF00)) << 1;
   enc_NIR->encodeSymbol(contexts[current_context].m_nir_bytes_used, sym);
   if (sym & (1 << 0))
   {
-    diff_l = ((int)(((U16*)item)[3]&255)) - (last_item[3]&255);
+    diff_l = ((int)(((const U16*)item)[3]&255)) - (last_item[3]&255);
     enc_NIR->encodeSymbol(contexts[current_context].m_nir_diff_0, U8_FOLD(diff_l));
   }
   if (sym & (1 << 1))
   {
-    diff_h = ((int)(((U16*)item)[3]>>8)) - (last_item[3]>>8);
+    diff_h = ((int)(((const U16*)item)[3]>>8)) - (last_item[3]>>8);
     enc_NIR->encodeSymbol(contexts[current_context].m_nir_diff_1, U8_FOLD(diff_h));
   }
   if (sym)

--- a/LASzip/src/laswriteitemraw.hpp
+++ b/LASzip/src/laswriteitemraw.hpp
@@ -59,7 +59,7 @@ public:
     ENDIAN_SWAP_32(&item[ 4], &swapped[ 4]);    // Y
     ENDIAN_SWAP_32(&item[ 8], &swapped[ 8]);    // Z
     ENDIAN_SWAP_16(&item[12], &swapped[12]);    // intensity
-    *((U32*)&swapped[14]) = *((U32*)&item[14]); // bitfield, classification, scan_angle_rank, user_data
+    *((U32*)&swapped[14]) = *((const U32*)&item[14]); // bitfield, classification, scan_angle_rank, user_data
     ENDIAN_SWAP_16(&item[18], &swapped[18]);    // point_source_ID
     return outstream->putBytes(swapped, 20);
   };
@@ -218,35 +218,35 @@ public:
   LASwriteItemRaw_POINT14_LE(){};
   inline BOOL write(const U8* item, U32& context)
   {
-    ((LAStempWritePoint14*)buffer)->X = ((LAStempWritePoint10*)item)->X;
-    ((LAStempWritePoint14*)buffer)->Y = ((LAStempWritePoint10*)item)->Y;
-    ((LAStempWritePoint14*)buffer)->Z = ((LAStempWritePoint10*)item)->Z;
-    ((LAStempWritePoint14*)buffer)->intensity = ((LAStempWritePoint10*)item)->intensity;
-    ((LAStempWritePoint14*)buffer)->scan_direction_flag = ((LAStempWritePoint10*)item)->scan_direction_flag;
-    ((LAStempWritePoint14*)buffer)->edge_of_flight_line = ((LAStempWritePoint10*)item)->edge_of_flight_line;
-    ((LAStempWritePoint14*)buffer)->classification = (((LAStempWritePoint10*)item)->classification & 31);
-    ((LAStempWritePoint14*)buffer)->user_data = ((LAStempWritePoint10*)item)->user_data;
-    ((LAStempWritePoint14*)buffer)->point_source_ID = ((LAStempWritePoint10*)item)->point_source_ID;
+    ((LAStempWritePoint14*)buffer)->X = ((const LAStempWritePoint10*)item)->X;
+    ((LAStempWritePoint14*)buffer)->Y = ((const LAStempWritePoint10*)item)->Y;
+    ((LAStempWritePoint14*)buffer)->Z = ((const LAStempWritePoint10*)item)->Z;
+    ((LAStempWritePoint14*)buffer)->intensity = ((const LAStempWritePoint10*)item)->intensity;
+    ((LAStempWritePoint14*)buffer)->scan_direction_flag = ((const LAStempWritePoint10*)item)->scan_direction_flag;
+    ((LAStempWritePoint14*)buffer)->edge_of_flight_line = ((const LAStempWritePoint10*)item)->edge_of_flight_line;
+    ((LAStempWritePoint14*)buffer)->classification = (((const LAStempWritePoint10*)item)->classification & 31);
+    ((LAStempWritePoint14*)buffer)->user_data = ((const LAStempWritePoint10*)item)->user_data;
+    ((LAStempWritePoint14*)buffer)->point_source_ID = ((const LAStempWritePoint10*)item)->point_source_ID;
 
-    if (((LAStempWritePoint10*)item)->extended_point_type)
+    if (((const LAStempWritePoint10*)item)->extended_point_type)
     {
-      ((LAStempWritePoint14*)buffer)->classification_flags = (((LAStempWritePoint10*)item)->extended_classification_flags & 8) | (((LAStempWritePoint10*)item)->classification >> 5);
-      if (((LAStempWritePoint14*)buffer)->classification == 0) ((LAStempWritePoint14*)buffer)->classification = ((LAStempWritePoint10*)item)->extended_classification;
-      ((LAStempWritePoint14*)buffer)->scanner_channel = ((LAStempWritePoint10*)item)->extended_scanner_channel;
-      ((LAStempWritePoint14*)buffer)->return_number = ((LAStempWritePoint10*)item)->extended_return_number;
-      ((LAStempWritePoint14*)buffer)->number_of_returns = ((LAStempWritePoint10*)item)->extended_number_of_returns;
-      ((LAStempWritePoint14*)buffer)->scan_angle = ((LAStempWritePoint10*)item)->extended_scan_angle;
+      ((LAStempWritePoint14*)buffer)->classification_flags = (((const LAStempWritePoint10*)item)->extended_classification_flags & 8) | (((const LAStempWritePoint10*)item)->classification >> 5);
+      if (((LAStempWritePoint14*)buffer)->classification == 0) ((LAStempWritePoint14*)buffer)->classification = ((const LAStempWritePoint10*)item)->extended_classification;
+      ((LAStempWritePoint14*)buffer)->scanner_channel = ((const LAStempWritePoint10*)item)->extended_scanner_channel;
+      ((LAStempWritePoint14*)buffer)->return_number = ((const LAStempWritePoint10*)item)->extended_return_number;
+      ((LAStempWritePoint14*)buffer)->number_of_returns = ((const LAStempWritePoint10*)item)->extended_number_of_returns;
+      ((LAStempWritePoint14*)buffer)->scan_angle = ((const LAStempWritePoint10*)item)->extended_scan_angle;
     }
     else
     {
-      ((LAStempWritePoint14*)buffer)->classification_flags = (((LAStempWritePoint10*)item)->classification >> 5);
+      ((LAStempWritePoint14*)buffer)->classification_flags = (((const LAStempWritePoint10*)item)->classification >> 5);
       ((LAStempWritePoint14*)buffer)->scanner_channel = 0;
-      ((LAStempWritePoint14*)buffer)->return_number = ((LAStempWritePoint10*)item)->return_number;
-      ((LAStempWritePoint14*)buffer)->number_of_returns = ((LAStempWritePoint10*)item)->number_of_returns;
-      ((LAStempWritePoint14*)buffer)->scan_angle = I16_QUANTIZE(((LAStempWritePoint10*)item)->scan_angle_rank/0.006f);
+      ((LAStempWritePoint14*)buffer)->return_number = ((const LAStempWritePoint10*)item)->return_number;
+      ((LAStempWritePoint14*)buffer)->number_of_returns = ((const LAStempWritePoint10*)item)->number_of_returns;
+      ((LAStempWritePoint14*)buffer)->scan_angle = I16_QUANTIZE(((const LAStempWritePoint10*)item)->scan_angle_rank/0.006f);
     }
 
-    *((F64*)&buffer[22]) = ((LAStempWritePoint10*)item)->gps_time;
+    *((F64*)&buffer[22]) = ((const LAStempWritePoint10*)item)->gps_time;
     return outstream->putBytes(buffer, 30);
   }
 private:
@@ -263,31 +263,31 @@ public:
     ENDIAN_SWAP_32(&item[ 4], &swapped[ 4]);    // Y
     ENDIAN_SWAP_32(&item[ 8], &swapped[ 8]);    // Z
     ENDIAN_SWAP_16(&item[12], &swapped[12]);    // intensity
-    ((LAStempWritePoint14*)swapped)->scan_direction_flag = ((LAStempWritePoint10*)item)->scan_direction_flag;
-    ((LAStempWritePoint14*)swapped)->edge_of_flight_line = ((LAStempWritePoint10*)item)->edge_of_flight_line;
-    ((LAStempWritePoint14*)swapped)->classification = (((LAStempWritePoint10*)item)->classification & 31);
-    ((LAStempWritePoint14*)swapped)->user_data = ((LAStempWritePoint10*)item)->user_data;
+    ((LAStempWritePoint14*)swapped)->scan_direction_flag = ((const LAStempWritePoint10*)item)->scan_direction_flag;
+    ((LAStempWritePoint14*)swapped)->edge_of_flight_line = ((const LAStempWritePoint10*)item)->edge_of_flight_line;
+    ((LAStempWritePoint14*)swapped)->classification = (((const LAStempWritePoint10*)item)->classification & 31);
+    ((LAStempWritePoint14*)swapped)->user_data = ((const LAStempWritePoint10*)item)->user_data;
     ENDIAN_SWAP_16(&item[18], &swapped[20]); // point_source_ID
 
-    if (((LAStempWritePoint10*)item)->extended_point_type)
+    if (((const LAStempWritePoint10*)item)->extended_point_type)
     {
-      ((LAStempWritePoint14*)swapped)->classification_flags = (((LAStempWritePoint10*)item)->extended_classification_flags & 8) | (((LAStempWritePoint10*)item)->classification >> 5);
-      if (((LAStempWritePoint14*)swapped)->classification == 0) ((LAStempWritePoint14*)swapped)->classification = ((LAStempWritePoint10*)item)->extended_classification;
-      ((LAStempWritePoint14*)swapped)->scanner_channel = ((LAStempWritePoint10*)item)->extended_scanner_channel;
-      ((LAStempWritePoint14*)swapped)->return_number = ((LAStempWritePoint10*)item)->extended_return_number;
-      ((LAStempWritePoint14*)swapped)->number_of_returns = ((LAStempWritePoint10*)item)->extended_number_of_returns;
+      ((LAStempWritePoint14*)swapped)->classification_flags = (((const LAStempWritePoint10*)item)->extended_classification_flags & 8) | (((const LAStempWritePoint10*)item)->classification >> 5);
+      if (((LAStempWritePoint14*)swapped)->classification == 0) ((LAStempWritePoint14*)swapped)->classification = ((const LAStempWritePoint10*)item)->extended_classification;
+      ((LAStempWritePoint14*)swapped)->scanner_channel = ((const LAStempWritePoint10*)item)->extended_scanner_channel;
+      ((LAStempWritePoint14*)swapped)->return_number = ((const LAStempWritePoint10*)item)->extended_return_number;
+      ((LAStempWritePoint14*)swapped)->number_of_returns = ((const LAStempWritePoint10*)item)->extended_number_of_returns;
       ENDIAN_SWAP_16(&item[20], &swapped[18]); // scan_angle
     }
     else
     {
-      ((LAStempWritePoint14*)swapped)->classification_flags = (((LAStempWritePoint10*)item)->classification >> 5);
+      ((LAStempWritePoint14*)swapped)->classification_flags = (((const LAStempWritePoint10*)item)->classification >> 5);
       ((LAStempWritePoint14*)swapped)->scanner_channel = 0;
-      ((LAStempWritePoint14*)swapped)->return_number = ((LAStempWritePoint10*)item)->return_number;
-      ((LAStempWritePoint14*)swapped)->number_of_returns = ((LAStempWritePoint10*)item)->number_of_returns;
-      I16 scan_angle = I16_QUANTIZE(((LAStempWritePoint10*)item)->scan_angle_rank/0.006f);
+      ((LAStempWritePoint14*)swapped)->return_number = ((const LAStempWritePoint10*)item)->return_number;
+      ((LAStempWritePoint14*)swapped)->number_of_returns = ((const LAStempWritePoint10*)item)->number_of_returns;
+      I16 scan_angle = I16_QUANTIZE(((const LAStempWritePoint10*)item)->scan_angle_rank/0.006f);
       ENDIAN_SWAP_16((U8*)(&scan_angle), &swapped[18]); // scan_angle
     }
-    ENDIAN_SWAP_64((U8*)&(((LAStempWritePoint10*)item)->gps_time), &swapped[22]);
+    ENDIAN_SWAP_64((const U8*)&(((const LAStempWritePoint10*)item)->gps_time), &swapped[22]);
     return outstream->putBytes(swapped, 30);
   }
 private:

--- a/LASzip/src/laszip.cpp
+++ b/LASzip/src/laszip.cpp
@@ -94,33 +94,33 @@ bool LASzip::unpack(const U8* bytes, const I32 num)
   // do the unpacking
   U16 i;
   const U8* b = bytes;
-  compressor = *((U16*)b);
+  compressor = *((const U16*)b);
   b += 2;
-  coder = *((U16*)b);
+  coder = *((const U16*)b);
   b += 2;
-  version_major = *((U8*)b);
+  version_major = *((const U8*)b);
   b += 1;
-  version_minor = *((U8*)b);
+  version_minor = *((const U8*)b);
   b += 1;
-  version_revision = *((U16*)b);
+  version_revision = *((const U16*)b);
   b += 2;
-  options = *((U32*)b);
+  options = *((const U32*)b);
   b += 4;
-  chunk_size = *((U32*)b);
+  chunk_size = *((const U32*)b);
   b += 4;
-  number_of_special_evlrs = *((I64*)b);
+  number_of_special_evlrs = *((const I64*)b);
   b += 8;
-  offset_to_special_evlrs = *((I64*)b);
+  offset_to_special_evlrs = *((const I64*)b);
   b += 8;
-  num_items = *((U16*)b);
+  num_items = *((const U16*)b);
   b += 2;
   for (i = 0; i < num_items; i++)
   {
-    items[i].type = (LASitem::Type)*((U16*)b);
+    items[i].type = (LASitem::Type)*((const U16*)b);
     b += 2;
-    items[i].size = *((U16*)b);
+    items[i].size = *((const U16*)b);
     b += 2;
-    items[i].version = *((U16*)b);
+    items[i].version = *((const U16*)b);
     b += 2;
   }
   assert((bytes + num) == b);

--- a/LASzip/src/laszip_dll.cpp
+++ b/LASzip/src/laszip_dll.cpp
@@ -1261,7 +1261,7 @@ laszip_set_geodouble_params(
 
     // add the VLR
 
-    if (laszip_add_vlr(laszip_dll, "LASF_Projection", 34736, (laszip_U16)(number*8), 0, (laszip_U8*)geodouble_params))
+    if (laszip_add_vlr(laszip_dll, "LASF_Projection", 34736, (laszip_U16)(number*8), 0, (const laszip_U8*)geodouble_params))
     {
       sprintf(laszip_dll->error, "setting %u geodouble_params", number);
       return 1;
@@ -1316,7 +1316,7 @@ laszip_set_geoascii_params(
 
     // add the VLR
 
-    if (laszip_add_vlr(laszip_dll, "LASF_Projection", 34737, (laszip_U16)(number), 0, (laszip_U8*)geoascii_params))
+    if (laszip_add_vlr(laszip_dll, "LASF_Projection", 34737, (laszip_U16)(number), 0, (const laszip_U8*)geoascii_params))
     {
       sprintf(laszip_dll->error, "setting %u geoascii_params", number);
       return 1;

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # makefile for LGPL-licensed LAStools
 #
 #COPTS    = -g -Wall -Wno-deprecated -DDEBUG 
-COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -DNDEBUG -std=c++14
+COPTS     = -O3 -Wall -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-unused-result -Wcast-qual -DNDEBUG -std=c++14
 #COMPILER  = CC
 COMPILER  = g++
 LINKER  = g++

--- a/src/lascopcindex.cpp
+++ b/src/lascopcindex.cpp
@@ -123,16 +123,16 @@ static U64 taketime()
   return (U64)time(NULL); // using time instead of clock to get wall clock
 }
 
-static inline F64 get_gps_time(const U8* buf) { return *((F64*)&buf[22]); };
+static inline F64 get_gps_time(const U8* buf) { return *((const F64*)&buf[22]); };
 static inline U8 get_scanner_channel(const U8* buf) { return (buf[15] >> 4) & 0x03; };
 static inline U8 get_return_number(const U8* buf) { return buf[14] & 0x0F; };
 static int compare_buffers(const void *a, const void *b)
 {
-  if (get_gps_time((U8*)a) < get_gps_time((U8*)b)) return -1;
-  if (get_gps_time((U8*)a) > get_gps_time((U8*)b)) return 1;
-  if (get_scanner_channel((U8*)a) < get_scanner_channel((U8*)b)) return -1;
-  if (get_scanner_channel((U8*)a) > get_scanner_channel((U8*)b)) return 1;
-  if (get_return_number((U8*)a) < get_return_number((U8*)b)) return -1;
+  if (get_gps_time((const U8*)a) < get_gps_time((const U8*)b)) return -1;
+  if (get_gps_time((const U8*)a) > get_gps_time((const U8*)b)) return 1;
+  if (get_scanner_channel((const U8*)a) < get_scanner_channel((const U8*)b)) return -1;
+  if (get_scanner_channel((const U8*)a) > get_scanner_channel((const U8*)b)) return 1;
+  if (get_return_number((const U8*)a) < get_return_number((const U8*)b)) return -1;
   return 1;
 }
 


### PR DESCRIPTION
[LasZip PR #65](https://github.com/LASzip/LASzip/pull/65) is a large set of changes.   We also observe numerous warnings in our laszip builds and would prefer to see fewer of those if possible.  So I cherry-picked the const related commit and reviewed each line of change.  It does look fine, and I'll put it through our internal test coverage to get some more confidence that at least this part ought to be merged to the mainline.

Makefile updated to use -Wcast-qual flag.

See also [LasZip PR #83](https://github.com/LASzip/LASzip/pull/83)