### PR TITLE
fix clang warning Wtautological-constant-out-of-range-compare

### DIFF
--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
 #endif
   bool error = false;
   bool force = false;
-  // fixed header changes 
+  // fixed header changes
   int set_version_major = -1;
   int set_version_minor = -1;
   int set_point_data_format = -1;
@@ -385,7 +385,7 @@ int main(int argc, char* argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
       if (strcmp(argv[i], "-week_to_adjusted") == 0)
       {
         set_global_encoding_gps_bit = 1;
@@ -1320,14 +1320,14 @@ int main(int argc, char* argv[])
           }
           if (lasreader->header.get_global_encoding_bit(LAS_TOOLS_GLOBAL_ENCODING_BIT_OGC_WKT_CRS))
           {
-            LASMessage(LAS_WARNING, "unsetting global encoding bit %d when downgrading from version 1.%d to version 1.%d", 
+            LASMessage(LAS_WARNING, "unsetting global encoding bit %d when downgrading from version 1.%d to version 1.%d",
               LAS_TOOLS_GLOBAL_ENCODING_BIT_OGC_WKT_CRS, lasreader->header.version_minor, set_version_minor);
             lasreader->header.unset_global_encoding_bit(LAS_TOOLS_GLOBAL_ENCODING_BIT_OGC_WKT_CRS);
           }
           if (lasreader->header.number_of_extended_variable_length_records)
           {
-            LASMessage(LAS_WARNING, "loosing %d EVLR%s when downgrading from version 1.%d to version 1.%d. attempting to move %s to the VLR section ...", 
-              lasreader->header.number_of_extended_variable_length_records, (lasreader->header.number_of_extended_variable_length_records > 1 ? "s" : ""), 
+            LASMessage(LAS_WARNING, "loosing %d EVLR%s when downgrading from version 1.%d to version 1.%d. attempting to move %s to the VLR section ...",
+              lasreader->header.number_of_extended_variable_length_records, (lasreader->header.number_of_extended_variable_length_records > 1 ? "s" : ""),
               lasreader->header.version_minor, set_version_minor, (lasreader->header.number_of_extended_variable_length_records > 1 ? "them" : "it"));
             U32 u;
             for (u = 0; u < lasreader->header.number_of_extended_variable_length_records; u++)
@@ -1699,7 +1699,7 @@ int main(int argc, char* argv[])
           }
         }
       }
-      else if (set_ogc_wkt) // maybe only set the OCG WKT 
+      else if (set_ogc_wkt) // maybe only set the OCG WKT
       {
         CHAR* ogc_wkt = set_ogc_wkt_string;
         I32 len = (ogc_wkt ? (I32)strlen(ogc_wkt) : 0);

--- a/src/las2txt.cpp
+++ b/src/las2txt.cpp
@@ -643,7 +643,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
       if (strcmp(argv[i],"-opts") == 0)
       {
         opts = TRUE;
@@ -1140,7 +1140,7 @@ int main(int argc, char *argv[])
         fprintf(file_out, "%g %g %g %g\012", ((F64*)payload)[18], ((F64*)payload)[19], ((F64*)payload)[20], ((F64*)payload)[21]); // r11 r12 r13 - rotation matrix
         fprintf(file_out, "%g %g %g %g\012", ((F64*)payload)[22], ((F64*)payload)[23], ((F64*)payload)[24], ((F64*)payload)[25]); // r21 r22 r23
         fprintf(file_out, "%g %g %g %g\012", ((F64*)payload)[26], ((F64*)payload)[27], ((F64*)payload)[28], ((F64*)payload)[29]); // r31 r32 r33
-        fprintf(file_out, "%g %g %g %g\012", ((F64*)payload)[30], ((F64*)payload)[31], ((F64*)payload)[32], ((F64*)payload)[33]); // tr1 tr2 tr3 - transformation 
+        fprintf(file_out, "%g %g %g %g\012", ((F64*)payload)[30], ((F64*)payload)[31], ((F64*)payload)[32], ((F64*)payload)[33]); // tr1 tr2 tr3 - transformation
       }
       else
       {

--- a/src/lascopcindex.cpp
+++ b/src/lascopcindex.cpp
@@ -69,7 +69,7 @@
 #include "lasprogress.hpp"
 #include "geoprojectionconverter.hpp"
 
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
 #define strcasecmp _stricmp
 #endif
 
@@ -301,7 +301,7 @@ struct OctantInMemory : public Octant
     occupancy.reserve(point_capacity);
   };
 
-  // No copy constructor. We don't want any copy of dynamically allocated U8* point_buffer. 
+  // No copy constructor. We don't want any copy of dynamically allocated U8* point_buffer.
   // Desallocation is performed manually with clean() at appropriate places.
 
   void insert(const U8* buffer, const I32 cell, const U16 chunk)
@@ -387,7 +387,7 @@ struct OctantOnDisk : public Octant
     occupancy.reserve(25000);
   };
 
-  // No copy constructor. We don't want any copy of dynamically allocated U8* point_buffer. 
+  // No copy constructor. We don't want any copy of dynamically allocated U8* point_buffer.
   // Desallocation is performed manually with clean() at appropriate places
 
   void insert(const U8* buffer, const I32 cell, const U16 chunk)
@@ -630,7 +630,7 @@ int main(int argc, char* argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96)
+      if ((unsigned char)argv[i][0] == 0x96)
         argv[i][0] = '-';
     }
     if (!geoprojectionconverter.parse(1, argv)) byebye(true);

--- a/src/lasdiff.cpp
+++ b/src/lasdiff.cpp
@@ -913,7 +913,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
     }
     if (!lasreadopener.parse(argc, argv)) byebye(true);
     if (!laswriteopener.parse(argc, argv)) byebye(true);
@@ -999,7 +999,7 @@ int main(int argc, char *argv[])
   int different_header;
 
   // possibly loop over two wild cards
-  
+
   if (wildcard1 && wildcard2)
   {
     LASreadOpener lasreadopener1;
@@ -1025,7 +1025,7 @@ int main(int argc, char *argv[])
       LASMessage(LAS_ERROR, "wildcard1 (%u) and wildcard2 (%u) specify different number of files", lasreadopener1.get_file_name_number(), lasreadopener2.get_file_name_number());
       byebye(true, argc==1);
     }
-    
+
     // possibly multiple input files
 
     while (lasreadopener1.active())

--- a/src/lasindex.cpp
+++ b/src/lasindex.cpp
@@ -2,14 +2,14 @@
 ===============================================================================
 
   FILE:  lasindex.cpp
-  
+
   CONTENTS:
-  
+
     This tool creates a *.lax file for a given *.las or *.laz file that contains
     a spatial indexing. When this LAX file is present it will be used to speed up
     access to the relevant areas of the LAS/LAZ file whenever a spatial queries
     of the type
-    
+
       -inside_tile ll_x ll_y size
       -inside_circle center_x center_y radius
       -inside_rectangle min_x min_y max_x max_y  (or simply -inside)
@@ -27,11 +27,11 @@
      indexing information in the LAX file created by lasindex.
 
   PROGRAMMERS:
-  
+
     info@rapidlasso.de  -  https://rapidlasso.de
-  
+
   COPYRIGHT:
-  
+
     (c) 2011-2019, rapidlasso GmbH - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -40,15 +40,15 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
 
 
-    22 March 2022 -- Add -o parameter for user defined output file  
-     1 May 2017 -- 2nd example for selective decompression for new LAS 1.4 points 
+    22 March 2022 -- Add -o parameter for user defined output file
+     1 May 2017 -- 2nd example for selective decompression for new LAS 1.4 points
     17 May 2011 -- enabling batch processing with wildcards or multiple file names
     29 April 2011 -- created after cable outage during the royal wedding (-:
-  
+
 ===============================================================================
 */
 
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
     }
     if (!lasreadopener.parse(argc, argv)) byebye(true);
   }
@@ -378,11 +378,11 @@ int main(int argc, char *argv[])
     CHAR* meta_file_name = (CHAR*)malloc(len + 9);
     if (len)
     {
-      sprintf(meta_file_name, "%s\\lax.txt", meta_file_name_base); 
+      sprintf(meta_file_name, "%s\\lax.txt", meta_file_name_base);
     }
     else
     {
-      sprintf(meta_file_name, "lax.txt"); 
+      sprintf(meta_file_name, "lax.txt");
     }
     free(meta_file_name_base);
 
@@ -463,9 +463,9 @@ int main(int argc, char *argv[])
     LASindex lasindex;
     lasindex.prepare(lasquadtree, threshold);
     while (lasreader->read_point()) lasindex.add(lasreader->point.get_x(), lasreader->point.get_y(), (U32)(lasreader->p_count-1));
-  
+
     // delete the reader
-    
+
     lasreader->close();
     delete lasreader;
 
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
     fclose(file_meta);
     file_meta = 0;
   }
-  
+
   if (lasreadopener.get_file_name_number() > 1)
   {
     if (dont_reindex)

--- a/src/lasinfo.cpp
+++ b/src/lasinfo.cpp
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
     }
     if (!lashistogram.parse(argc, argv)) byebye(true);
     if (!lasreadopener.parse(argc, argv)) byebye(true);

--- a/src/lasmerge.cpp
+++ b/src/lasmerge.cpp
@@ -2,19 +2,19 @@
 ===============================================================================
 
   FILE:  lasmerge.cpp
-  
+
   CONTENTS:
-  
+
     This tool merges multiple LAS file into a single LAS file and outputs it in
     the LAS format. As input the user either provides multiple LAS file names or
     a text file containing a list of LAS file names.
 
   PROGRAMMERS:
-  
+
     info@rapidlasso.de  -  https://rapidlasso.de
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-12, rapidlasso GmbH - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -23,18 +23,18 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     20 August 2014 -- new option '-keep_lastiling' to preserve the LAStiling VLR
     20 August 2014 -- copy VLRs from empty (zero points) LAS/LAZ files to others
      5 August 2011 -- possible to add/change projection info in command line
     13 May 2011 -- moved indexing, filtering, transforming into LASreader
-    21 January 2011 -- added LASreadOpener and reading of multiple LAS files 
-     7 January 2011 -- added the LASfilter to drop or keep points 
-    12 March 2009 -- updated to ask for input if started without arguments 
+    21 January 2011 -- added LASreadOpener and reading of multiple LAS files
+     7 January 2011 -- added the LASfilter to drop or keep points
+    12 March 2009 -- updated to ask for input if started without arguments
     07 November 2007 -- created after email from luis.viveros@digimapas.cl
-  
+
 ===============================================================================
 */
 
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
     }
     if (!geoprojectionconverter.parse(argc, argv)) byebye(true);
     if (!lasreadopener.parse(argc, argv)) byebye(true);
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  // maybe we want to keep the lastiling 
+  // maybe we want to keep the lastiling
 
   if (keep_lastiling)
   {
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
   }
 
   LASMessage(LAS_VERBOSE, "merging headers took %g sec. there are %lld points in total.", taketime()-start_time, lasreader->npoints);
-  start_time = taketime(); 
+  start_time = taketime();
 
   // prepare the header for the surviving points
 
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
         laswriter->update_header(&lasreader->header, TRUE);
         laswriter->close();
         LASMessage(LAS_VERBOSE, "splitting file '%s' took %g sec.", laswriteopener.get_file_name(), taketime()-start_time);
-  start_time = taketime(); 
+  start_time = taketime();
         delete laswriter;
         laswriter = 0;
       }
@@ -339,7 +339,7 @@ int main(int argc, char *argv[])
       laswriter->update_header(&lasreader->header, TRUE);
       laswriter->close();
       LASMessage(LAS_VERBOSE, "splitting file '%s' took %g sec.", laswriteopener.get_file_name(), taketime()-start_time);
-  start_time = taketime(); 
+  start_time = taketime();
       delete laswriter;
       laswriter = 0;
     }
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
     // close the writer
     laswriter->update_header(&lasreader->header, TRUE);
     laswriter->close();
-    LASMessage(LAS_VERBOSE, "merging files took %g sec.", taketime()-start_time); 
+    LASMessage(LAS_VERBOSE, "merging files took %g sec.", taketime()-start_time);
     delete laswriter;
   }
   lasreader->close();

--- a/src/lasprecision.cpp
+++ b/src/lasprecision.cpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  lasprecision.cpp
-  
+
   CONTENTS:
-  
+
     This tool computes statistics about the coordinates in a LAS/LAZ file that
     tell us whether the precision "advertised" in the header is really in the
     data. Often I find that the scaling factors in the header are miss-leading
@@ -28,11 +28,11 @@
      - Palm Beach Pre Hurricane.las
 
   PROGRAMMERS:
-  
+
     info@rapidlasso.de  -  https://rapidlasso.de
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-17, rapidlasso GmbH - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
@@ -41,12 +41,12 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
-     1 May 2017 -- 3rd example for selective decompression for new LAS 1.4 points 
+
+     1 May 2017 -- 3rd example for selective decompression for new LAS 1.4 points
     30 November 2010 -- created spotting few paper cups at Starbuck's Offenbach
-  
+
 ===============================================================================
 */
 
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
       if (strcmp(argv[i],"-o") == 0 || strcmp(argv[i],"-olas") == 0 || strcmp(argv[i],"-olaz") == 0 || strcmp(argv[i],"-obin") == 0 || strcmp(argv[i],"-otxt") == 0 || strcmp(argv[i],"-reoffset") == 0 || strcmp(argv[i],"-rescale") == 0)
       {
         output = true;
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
       array_max = array_count;
 
       // sort values
-  
+
       if (report_x)
       {
         quicksort_for_ints(array_x, 0, array_max-1);
@@ -525,7 +525,7 @@ int main(int argc, char *argv[])
       {
         quicksort_for_ints(array_z, 0, array_max-1);
       }
-  
+
       if (report_gps && lasreader->point.have_gps_time)
       {
         quicksort_for_doubles(array_gps, 0, array_max-1);
@@ -598,7 +598,7 @@ int main(int argc, char *argv[])
       {
         quicksort_for_ints(array_z, 0, array_max-2);
       }
-  
+
       if (report_gps && lasreader->point.have_gps_time)
       {
         quicksort_for_doubles(array_gps, 0, array_max-2);
@@ -616,7 +616,7 @@ int main(int argc, char *argv[])
       // first for X & Y & Z
 
       unsigned int count_lines, array_last, array_first;
-  
+
       if (report_x)
       {
         if (report_diff) fprintf(stdout, "X differences \n");
@@ -653,7 +653,7 @@ int main(int argc, char *argv[])
           if (array_y[array_last] != array_y[array_count])
           {
             if (report_diff && (count_lines < report_lines)) { count_lines++; fprintf(stdout, " %10d : %10d   %g\n", array_y[array_last], array_count - array_last, lasreader->header.y_scale_factor*array_y[array_last]); }
-            array_y[array_first] = array_y[array_count] - array_y[array_last]; 
+            array_y[array_first] = array_y[array_count] - array_y[array_last];
             array_last = array_count;
             array_first++;
           }
@@ -681,7 +681,7 @@ int main(int argc, char *argv[])
           if (array_z[array_last] != array_z[array_count])
           {
             if (report_diff && (count_lines < report_lines)) { count_lines++; fprintf(stdout, " %10d : %10d   %g\n", array_z[array_last], array_count - array_last, lasreader->header.z_scale_factor*array_z[array_last]); }
-            array_z[array_first] = array_z[array_count] - array_z[array_last]; 
+            array_z[array_first] = array_z[array_count] - array_z[array_last];
             array_last = array_count;
             array_first++;
           }
@@ -711,7 +711,7 @@ int main(int argc, char *argv[])
           if (array_gps[array_last] != array_gps[array_count])
           {
             if (report_diff) fprintf(stdout, "  %.10g : %10d\n", array_gps[array_last], array_count - array_last);
-            array_gps[array_first] = array_gps[array_count] - array_gps[array_last]; 
+            array_gps[array_first] = array_gps[array_count] - array_gps[array_last];
             array_last = array_count;
             array_first++;
           }
@@ -741,7 +741,7 @@ int main(int argc, char *argv[])
           if (array_r[array_last] != array_r[array_count])
           {
             if (report_diff) fprintf(stdout, "  %10d : %10d\n", array_r[array_last], array_count - array_last);
-            array_r[array_first] = array_r[array_count] - array_r[array_last]; 
+            array_r[array_first] = array_r[array_count] - array_r[array_last];
             array_last = array_count;
             array_first++;
           }
@@ -766,7 +766,7 @@ int main(int argc, char *argv[])
           if (array_g[array_last] != array_g[array_count])
           {
             if (report_diff) fprintf(stdout, "  %10d : %10d\n", array_g[array_last], array_count - array_last);
-            array_g[array_first] = array_g[array_count] - array_g[array_last]; 
+            array_g[array_first] = array_g[array_count] - array_g[array_last];
             array_last = array_count;
             array_first++;
           }
@@ -791,7 +791,7 @@ int main(int argc, char *argv[])
           if (array_b[array_last] != array_b[array_count])
           {
             if (report_diff) fprintf(stdout, "  %10d : %10d\n", array_b[array_last], array_count - array_last);
-            array_b[array_first] = array_b[array_count] - array_b[array_last]; 
+            array_b[array_first] = array_b[array_count] - array_b[array_last];
             array_last = array_count;
             array_first++;
           }

--- a/src/laszip.cpp
+++ b/src/laszip.cpp
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
   {
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
     }
     if (!geoprojectionconverter.parse(argc, argv)) byebye(true);
     if (!lasreadopener.parse(argc, argv)) byebye(true);

--- a/src/txt2las.cpp
+++ b/src/txt2las.cpp
@@ -193,10 +193,10 @@ int main(int argc, char* argv[])
   }
   else
   {
-    // need to get those before lastransform->parse() routine gets them 
+    // need to get those before lastransform->parse() routine gets them
     for (i = 1; i < argc; i++)
     {
-      if (argv[i][0] == 0x96) argv[i][0] = '-';
+      if ((unsigned char)argv[i][0] == 0x96) argv[i][0] = '-';
       if (strcmp(argv[i], "-scale_intensity") == 0)
       {
         if ((i + 1) >= argc)
@@ -801,7 +801,7 @@ int main(int argc, char* argv[])
       }
       lasreader->header.del_geo_ascii_params();
 
-      if (set_ogc_wkt) // maybe also set the OCG WKT 
+      if (set_ogc_wkt) // maybe also set the OCG WKT
       {
         I32 len = 0;
         CHAR* ogc_wkt = 0;


### PR DESCRIPTION
fix: [`-Wtautological-constant-out-of-range-compare`](https://clang.llvm.org/docs/DiagnosticsReference.html#wtautological-constant-out-of-range-compare)

[On x86/x64 platform, the default `char` is typically signed.](https://en.cppreference.com/w/cpp/language/types#Character_types) So the comparison with `–` (0x96) is always unequal.

Example:
https://godbolt.org/z/8c9xer95x