### PR TITLE
Fix reading of embeded lax in LASreaderMerged

### DIFF
--- a/LASlib/src/lasreadermerged.cpp
+++ b/LASlib/src/lasreadermerged.cpp
@@ -1503,14 +1503,14 @@ BOOL LASreaderMerged::open_next_file()
     // open the lasreader with the next file name
     if (lasreaderlas)
     {
+      lasreaderlas->set_index(0);
+      lasreaderlas->set_copcindex(0);
+
       if (!lasreaderlas->open(file_names[file_name_current], io_ibuffer_size))
       {
         LASMessage(LAS_ERROR, "could not open lasreaderlas for file '%s'", file_names[file_name_current]);
         return FALSE;
       }
-
-      lasreaderlas->set_index(0);
-      lasreaderlas->set_copcindex(0);
 
       LASindex *index = new LASindex;
       if (index->read(file_names[file_name_current]))


### PR DESCRIPTION
In my fix #182 I fixed an issue and introduced another one. Indexes must be deleted before `lasreeaderlas->open()` because `open()` can create an index in the case of embedded lax in laz. This fixes the capacity to read embedded laz embeded lax in `lasreadermerged`.