### PR TITLE
Export writer interfaces to dll

### DIFF
--- a/LASlib/inc/laswriter_bin.hpp
+++ b/LASlib/inc/laswriter_bin.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswriter_bin.hpp
-  
+
   CONTENTS:
-  
+
     Writes LIDAR points from to ASCII through on-the-fly conversion from LAS.
 
   PROGRAMMERS:
@@ -21,13 +21,13 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
     13 October 2014 -- changed default IO buffer size with setvbuf() to 262144
     5 November 2011 -- changed default IO buffer size with setvbuf() to 65536
-    5 September 2011 -- created after sampling grapes in the sommerhausen hills  
-  
+    5 September 2011 -- created after sampling grapes in the sommerhausen hills
+
 ===============================================================================
 */
 #ifndef LAS_WRITER_BIN_HPP
@@ -39,7 +39,7 @@
 
 class ByteStreamOut;
 
-class LASwriterBIN : public LASwriter
+class LASLIB_DLL LASwriterBIN : public LASwriter
 {
 public:
 

--- a/LASlib/inc/laswriter_las.hpp
+++ b/LASlib/inc/laswriter_las.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswriter_las.hpp
-  
+
   CONTENTS:
-  
+
     Writes LiDAR points to the LAS format (Version 1.x).
 
   PROGRAMMERS:
@@ -21,7 +21,7 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
     04 August 2023 -- set default of VLR header "reserved" to 0 instead of 0xAABB
     29 March 2017 -- read and write support "native LAS 1.4 extension" for LASzip
@@ -33,9 +33,9 @@
     23 April 2011 -- added additional open parameters to support chunking
     21 January 2011 -- adapted from laswriter to create abstract reader class
     3 December 2010 -- updated to (somewhat) support LAS format 1.3
-    7 September 2008 -- updated to support LAS format 1.2 
+    7 September 2008 -- updated to support LAS format 1.2
     21 February 2007 -- created after eating Sarah's veggies with peanutsauce
-  
+
 ===============================================================================
 */
 #ifndef LAS_WRITER_LAS_HPP
@@ -55,7 +55,7 @@
 class ByteStreamOut;
 class LASwritePoint;
 
-class LASwriterLAS : public LASwriter
+class LASLIB_DLL LASwriterLAS : public LASwriter
 {
 public:
 

--- a/LASlib/inc/laswriter_qfit.hpp
+++ b/LASlib/inc/laswriter_qfit.hpp
@@ -2,9 +2,9 @@
 ===============================================================================
 
   FILE:  laswriter_qfit.hpp
-  
+
   CONTENTS:
-  
+
     Writes LIDAR points from to ASCII through on-the-fly conversion from LAS.
 
   PROGRAMMERS:
@@ -21,11 +21,11 @@
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
-    23 December 2011 -- created after by new OGIO laptop bagpack arrived 
-  
+
+    23 December 2011 -- created after by new OGIO laptop bagpack arrived
+
 ===============================================================================
 */
 #ifndef LAS_WRITER_QFIT_HPP
@@ -37,7 +37,7 @@
 
 class ByteStreamOut;
 
-class LASwriterQFIT : public LASwriter
+class LASLIB_DLL LASwriterQFIT : public LASwriter
 {
 public:
 

--- a/LASlib/inc/laswriter_txt.hpp
+++ b/LASlib/inc/laswriter_txt.hpp
@@ -36,7 +36,7 @@
 
 #include <stdio.h>
 
-class LASwriterTXT : public LASwriter
+class LASLIB_DLL LASwriterTXT : public LASwriter
 {
 public:
 

--- a/LASlib/inc/laswriter_wrl.hpp
+++ b/LASlib/inc/laswriter_wrl.hpp
@@ -35,7 +35,7 @@
 
 #include <stdio.h>
 
-class LASwriterWRL : public LASwriter
+class LASLIB_DLL LASwriterWRL : public LASwriter
 {
 public:
 


### PR DESCRIPTION
Currently, the interfaces of the writer classes are not exported to DLL.

Without exported interfaces, export into an already opened stream is not possible as LASwriteOpener does not accept std::ifstream. It only offers to open by filename.