### PR TITLE
Resolve Compiler Warnings and Support Umlauts in Filenames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 set(CMAKE_SUPPRESS_REGENERATION true)
 set(CMAKE_CXX_STANDARD 17)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-security -Wno-format-truncation")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-security -Wno-format-truncation")
+endif()
 project("LAStools" CXX C)
 
 if (!MSVC)

--- a/LASlib/CMakeLists.txt
+++ b/LASlib/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 set(CMAKE_SUPPRESS_REGENERATION true)
 project("LASlib")
-
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-security -Wno-format-truncation")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-security -Wno-format-truncation")
+endif()
 if (!MSVC)
 	add_compile_options(-O3 -Wall -Wno-strict-aliasing)
 else()

--- a/LASlib/LASlib.vcxproj
+++ b/LASlib/LASlib.vcxproj
@@ -10,6 +10,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>src;inc;..\LASzip\inc;..\LASzip\src;..\LASzip\include\laszip;</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>

--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -595,7 +595,7 @@ public:
     }
     memset((void*)&(vlrs[i]), 0, sizeof(LASvlr));
     vlrs[i].reserved = 0; // used to be 0xAABB
-    strncpy(vlrs[i].user_id, user_id, 16);
+    strncpy_las(vlrs[i].user_id, sizeof(vlrs[i].user_id), user_id, 16);
     vlrs[i].record_id = record_id;
     vlrs[i].record_length_after_header = record_length_after_header;
     if (keep_description && found_description)
@@ -604,11 +604,11 @@ public:
     }
     else if (description)
     {
-      sprintf(vlrs[i].description, "%.31s", description);
+      snprintf(vlrs[i].description, sizeof(vlrs[i].description), "%.31s", description);
     }
     else
     {
-      sprintf(vlrs[i].description, "by LAStools of rapidlasso GmbH");
+      snprintf(vlrs[i].description, sizeof(vlrs[i].description), "by LAStools of rapidlasso GmbH");
     }
     if (record_length_after_header)
     {
@@ -720,7 +720,7 @@ public:
       evlrs = (LASevlr*)malloc(sizeof(LASevlr)*number_of_extended_variable_length_records);
     }
     evlrs[i].reserved = 0; // used to be 0xAABB
-    strncpy(evlrs[i].user_id, user_id, 16);
+    strncpy_las(evlrs[i].user_id, sizeof(evlrs[i].user_id), user_id, 16);
     evlrs[i].record_id = record_id;
     evlrs[i].record_length_after_header = record_length_after_header;
     if (keep_description && found_description)
@@ -729,11 +729,11 @@ public:
     }
     else if (description)
     {
-      sprintf(evlrs[i].description, "%.31s", description);
+      snprintf(evlrs[i].description, sizeof(evlrs[i].description), "%.31s", description);
     }
     else
     {
-      sprintf(evlrs[i].description, "by LAStools of rapidlasso GmbH");
+      snprintf(evlrs[i].description, sizeof(evlrs[i].description), "by LAStools of rapidlasso GmbH");
     }
     if (record_length_after_header)
     {

--- a/LASlib/inc/lastransform.hpp
+++ b/LASlib/inc/lastransform.hpp
@@ -84,7 +84,9 @@ class LASoperationTransformMatrix : public LASoperation
 {
 public:
 	inline const CHAR* name() const { return "transform_matrix"; };
-	inline I32 get_command(CHAR* string) const { return sprintf(string, "-%s %lf,%lf,%lf %lf,%lf,%lf %lf,%lf,%lf %lf,%lf,%lf", name(), r11, r12, r13, r21, r22, r23, r31, r32, r33, tr1, tr2, tr3); };
+	inline I32 get_command(CHAR* string) const { 
+		constexpr size_t buffer_size = 330; //Maximum expected length for 12xF64(double), name() + safety margin
+		return snprintf(string, buffer_size, "-%s %lf,%lf,%lf %lf,%lf,%lf %lf,%lf,%lf %lf,%lf,%lf", name(), r11, r12, r13, r21, r22, r23, r31, r32, r33, tr1, tr2, tr3); };
 	inline U32 get_decompress_selective() const { return LASZIP_DECOMPRESS_SELECTIVE_CHANNEL_RETURNS_XY | LASZIP_DECOMPRESS_SELECTIVE_Z; };
 	inline void transform(LASpoint* point) {
 		F64 x = point->get_x();

--- a/LASlib/src/fopen_compressed.cpp
+++ b/LASlib/src/fopen_compressed.cpp
@@ -155,7 +155,7 @@ static FILE* fopenGzipped(const char* filename, const char* mode)
 	if (mode[0] == 'r')
 	{
 		// open input file
-		FILE* gzipInput = fopen(filename, mode);
+		FILE* gzipInput = LASfopen(filename, mode);
 		if (!gzipInput) return NULL;
 
 		// create the pipe
@@ -378,7 +378,7 @@ FILE* fopen_compressed(const char* filename, const char* mode, bool* piped)
   }
   else
   {
-    file = fopen(filename, mode);
+		file = LASfopen(filename, mode);
     if (piped) *piped = false;
   }
   return file;

--- a/LASlib/src/lasreader.cpp
+++ b/LASlib/src/lasreader.cpp
@@ -2896,10 +2896,11 @@ BOOL LASreadOpener::add_file_name(const CHAR* file_name, BOOL unique)
 		{
 			len++;
 			CHAR full_file_name[512];
-			strncpy(full_file_name, file_name, len);
+			strncpy_las(full_file_name, sizeof(full_file_name), file_name, len);
+			size_t remaining_size = (sizeof(full_file_name) > len) ? (sizeof(full_file_name) - len) : 0;
 			do
 			{
-				sprintf(&full_file_name[len], "%s", info.cFileName);
+				snprintf(&full_file_name[len], remaining_size, "%s", info.cFileName);
 				if (add_file_name_single(full_file_name, unique)) r = TRUE;
 			} while (FindNextFile(h, &info));
 		}
@@ -3096,7 +3097,7 @@ BOOL LASreadOpener::add_file_name(const CHAR* file_name, U32 ID, I64 npoints, F6
 
 BOOL LASreadOpener::add_list_of_files(const CHAR* list_of_files, BOOL unique)
 {
-	FILE* file = fopen(list_of_files, "r");
+	FILE* file = LASfopen(list_of_files, "r");
 	if (file == 0)
 	{
 		laserror("cannot open '%s'", list_of_files);
@@ -3252,7 +3253,7 @@ BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, I64 n
 
 BOOL LASreadOpener::add_neighbor_list_of_files(const CHAR* neighbor_list_of_files, BOOL unique)
 {
-	FILE* file = fopen(neighbor_list_of_files, "r");
+	FILE* file = LASfopen(neighbor_list_of_files, "r");
 	if (file == 0)
 	{
 		laserror("cannot open '%s'", neighbor_list_of_files);
@@ -3353,10 +3354,11 @@ BOOL LASreadOpener::add_neighbor_file_name(const CHAR* neighbor_file_name, BOOL 
 		{
 			len++;
 			CHAR full_neighbor_file_name[512];
-			strncpy(full_neighbor_file_name, neighbor_file_name, len);
+			strncpy_las(full_neighbor_file_name, sizeof(full_neighbor_file_name), neighbor_file_name, len);
+			size_t remaining_size = (sizeof(full_neighbor_file_name) > len) ? (sizeof(full_neighbor_file_name) - len) : 0;
 			do
 			{
-				sprintf(&full_neighbor_file_name[len], "%s", info.cFileName);
+				snprintf(&full_neighbor_file_name[len], remaining_size, "%s", info.cFileName);
 				if (add_neighbor_file_name_single(full_neighbor_file_name, unique)) r = TRUE;
 			} while (FindNextFile(h, &info));
 		}

--- a/LASlib/src/lasreader_asc.cpp
+++ b/LASlib/src/lasreader_asc.cpp
@@ -71,8 +71,8 @@ BOOL LASreaderASC::open(const CHAR* file_name, BOOL comma_not_point)
 
   // populate the header as much as it makes sense
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderASC (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderASC (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 

--- a/LASlib/src/lasreader_bil.cpp
+++ b/LASlib/src/lasreader_bil.cpp
@@ -94,8 +94,7 @@ BOOL LASreaderBIL::open(const CHAR* file_name)
   }
 
   // open the BIL file
-
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot open file '%s'", file_name);
@@ -109,8 +108,8 @@ BOOL LASreaderBIL::open(const CHAR* file_name)
 
   // populate the header as much as it makes sense
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderBIL (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderBIL (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 
@@ -384,7 +383,7 @@ BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
   file_name_hdr[len+2] = 'd';
   file_name_hdr[len+3] = 'r';
 
-  FILE* file = fopen(file_name_hdr, "r");
+  FILE* file = LASfopen(file_name_hdr, "r");
 
   if (file == 0)
   {
@@ -392,7 +391,7 @@ BOOL LASreaderBIL::read_hdr_file(const CHAR* file_name)
     file_name_hdr[len+2] = 'D';
     file_name_hdr[len+3] = 'R';
 
-    file = fopen(file_name_hdr, "r");
+    file = LASfopen(file_name_hdr, "r");
     free(file_name_hdr);
 
     if (file == 0)
@@ -558,7 +557,7 @@ BOOL LASreaderBIL::read_blw_file(const CHAR* file_name)
   file_name_bwl[len+2] = 'l';
   file_name_bwl[len+3] = 'w';
 
-  FILE* file = fopen(file_name_bwl, "r");
+  FILE* file = LASfopen(file_name_bwl, "r");
 
   if (file == 0)
   {
@@ -566,7 +565,7 @@ BOOL LASreaderBIL::read_blw_file(const CHAR* file_name)
     file_name_bwl[len+2] = 'L';
     file_name_bwl[len+3] = 'W';
 
-    file = fopen(file_name_bwl, "r");
+    file = LASfopen(file_name_bwl, "r");
 
     if (file == 0)
     {
@@ -808,7 +807,7 @@ BOOL LASreaderBIL::reopen(const CHAR* file_name)
     return FALSE;
   }
 
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot reopen file '%s'", file_name);

--- a/LASlib/src/lasreader_bin.cpp
+++ b/LASlib/src/lasreader_bin.cpp
@@ -88,8 +88,7 @@ BOOL LASreaderBIN::open(const char* file_name)
   }
 
   // open file
-
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot open file '%s'", file_name);
@@ -178,8 +177,8 @@ BOOL LASreaderBIN::open(ByteStreamIn* stream)
 
   // populate the header as much as possible
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderBIN (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderBIN (%d)", LAS_TOOLS_VERSION);
 
   if (tsheader.time)
   {

--- a/LASlib/src/lasreader_dtm.cpp
+++ b/LASlib/src/lasreader_dtm.cpp
@@ -301,8 +301,7 @@ BOOL LASreaderDTM::open(const CHAR* file_name)
   clean();
 
   // open the DTM file
-
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot open file '%s'", file_name);
@@ -997,8 +996,8 @@ BOOL LASreaderDTM::open(const CHAR* file_name)
 
   // populate the header as much as it makes sense
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderDTM (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderDTM (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 
@@ -1354,7 +1353,7 @@ BOOL LASreaderDTM::reopen(const CHAR* file_name)
     file = 0;
   }
 
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot reopen file '%s'", file_name);

--- a/LASlib/src/lasreader_las.cpp
+++ b/LASlib/src/lasreader_las.cpp
@@ -53,18 +53,7 @@ BOOL LASreaderLAS::open(const char* file_name, I32 io_buffer_size, BOOL peek_onl
     laserror("file name pointer is zero");
     return FALSE;
   }
-
-#ifdef _MSC_VER
-  wchar_t* utf16_file_name = UTF8toUTF16(file_name);
-  file = _wfopen(utf16_file_name, L"rb");
-  if (file == 0)
-  {
-    laserror("cannot open file '%ws' for read", utf16_file_name);
-  }
-  delete [] utf16_file_name;
-#else
-  file = fopen(file_name, "rb");
-#endif
+  file = LASfopen(file_name, "rb");
 
   if (file == 0)
   {

--- a/LASlib/src/lasreader_ply.cpp
+++ b/LASlib/src/lasreader_ply.cpp
@@ -106,8 +106,8 @@ BOOL LASreaderPLY::open(FILE* file, const CHAR* file_name, U8 point_type, BOOL p
   header.number_of_point_records = (npoints > U32_MAX ? 0 : (U32)npoints);
   header.extended_number_of_point_records = npoints;
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderPLY (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderPLY (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 
@@ -563,7 +563,7 @@ void LASreaderPLY::add_attribute(I32 attribute_type, const char* name, const cha
   else
   {
     char temp[32];
-    sprintf(temp, "attribute %d", number_attributes);
+    snprintf(temp, sizeof(temp), "attribute %d", number_attributes);
     attribute_names[number_attributes] = LASCopyString(temp);
   }
   if (description)

--- a/LASlib/src/lasreader_qfit.cpp
+++ b/LASlib/src/lasreader_qfit.cpp
@@ -50,8 +50,7 @@ BOOL LASreaderQFIT::open(const char* file_name)
   }
 
   // open file
-
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot open file '%s'", file_name);
@@ -189,8 +188,8 @@ BOOL LASreaderQFIT::open(ByteStreamIn* stream)
 
   // populate the header as much as possible
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderQFIT (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderQFIT (%d)", LAS_TOOLS_VERSION);
 
   header.number_of_point_records = (U32)npoints;
   header.number_of_points_by_return[0] = header.number_of_point_records;
@@ -408,8 +407,7 @@ BOOL LASreaderQFIT::reopen(const char* file_name)
   }
 
   // open file
-
-  file = fopen(file_name, "rb");
+  file = LASfopen(file_name, "rb");
   if (file == 0)
   {
     laserror("cannot open file '%s'", file_name);

--- a/LASlib/src/lasreader_shp.cpp
+++ b/LASlib/src/lasreader_shp.cpp
@@ -126,8 +126,8 @@ BOOL LASreaderSHP::open(const char* file_name)
 
   // populate the header as much as it makes sense
 
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderSHP (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderSHP (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 

--- a/LASlib/src/lasreader_txt.cpp
+++ b/LASlib/src/lasreader_txt.cpp
@@ -154,8 +154,8 @@ BOOL LASreaderTXT::open(FILE* file, const CHAR* file_name, U8 point_type, const 
   }
 
   // populate the header as much as it makes sense
-  sprintf(header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-  sprintf(header.generating_software, "via LASreaderTXT (%d)", LAS_TOOLS_VERSION);
+  snprintf(header.system_identifier, sizeof(header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+  snprintf(header.generating_software, sizeof(header.generating_software), "via LASreaderTXT (%d)", LAS_TOOLS_VERSION);
 
   // maybe set creation date
 #ifdef _WIN32
@@ -1103,7 +1103,7 @@ void LASreaderTXT::add_attribute(I32 data_type, const char* name, const char* de
   else
   {
     char temp[32];
-    sprintf(temp, "attribute %d", number_attributes);
+    snprintf(temp, sizeof(temp), "attribute %d", number_attributes);
     attribute_names[number_attributes] = LASCopyString(temp);
   }
   if (description)

--- a/LASlib/src/lasreaderbuffered.cpp
+++ b/LASlib/src/lasreaderbuffered.cpp
@@ -101,7 +101,7 @@ BOOL LASreaderBuffered::set_file_name(const char* file_name)
     return FALSE;
   }
   // does the file exist
-  FILE* file = fopen(file_name, "r");
+  FILE* file = LASfopen(file_name, "r");
   if (file == 0)
   {
     laserror("file '%s' cannot be opened", file_name);
@@ -122,7 +122,7 @@ BOOL LASreaderBuffered::add_neighbor_file_name(const char* file_name)
     return FALSE;
   }
   // does the file exist
-  FILE* file = fopen(file_name, "r");
+  FILE* file = LASfopen(file_name, "r");
   if (file == 0)
   {
     laserror("file '%s' cannot be opened", file_name);

--- a/LASlib/src/lasreadermerged.cpp
+++ b/LASlib/src/lasreadermerged.cpp
@@ -53,7 +53,7 @@ BOOL LASreaderMerged::add_file_name(const CHAR* file_name)
     return FALSE;
   }
   // does the file exist
-  FILE* file = fopen(file_name, "r");
+  FILE* file = LASfopen(file_name, "r");
   if (file == 0)
   {
     laserror("file '%s' cannot be opened", file_name);

--- a/LASlib/src/lastransform.cpp
+++ b/LASlib/src/lastransform.cpp
@@ -740,7 +740,7 @@ public:
 		{
 			map[u] = u;
 		}
-		FILE* file = fopen(file_name, "r");
+		FILE* file = LASfopen(file_name, "r");
 		if (file)
 		{
 			U32 from, to;
@@ -1538,7 +1538,7 @@ public:
 		{
 			map[u] = u;
 		}
-		FILE* file = fopen(file_name, "r");
+		FILE* file = LASfopen(file_name, "r");
 		if (file)
 		{
 			U32 from, to;
@@ -1691,7 +1691,7 @@ public:
 		{
 			map[u] = u;
 		}
-		FILE* file = fopen(file_name, "r");
+		FILE* file = LASfopen(file_name, "r");
 		if (file)
 		{
 			U32 from, to;
@@ -2137,7 +2137,7 @@ public:
 		F64 value;
 		U32 R, G, B;
 		CHAR line[256];
-		FILE* file = fopen(file_name, "r");
+		FILE* file = LASfopen(file_name, "r");
 		size = 0;
 		if (file)
 		{
@@ -2160,7 +2160,7 @@ public:
 			Rs = new U8[size];
 			Gs = new U8[size];
 			Bs = new U8[size];
-			file = fopen(file_name, "r");
+			file = LASfopen(file_name, "r");
 			while (fgets(line, 256, file))
 			{
 				if (sscanf(line, "%lf %u %u %u", &value, &R, &G, &B) == 4)
@@ -2214,12 +2214,12 @@ public:
 			file = 0;
 		}
 	};
-	void reset() { if (file) fclose(file); file = fopen(file_name, "r"); };
+	void reset() { if (file) fclose(file); file = LASfopen(file_name, "r"); };
 	LASoperationLoadAttributeFromText(const U32 index, const CHAR* file_name)
 	{
 		this->index = index;
 		this->file_name = LASCopyString(file_name);
-		file = fopen(this->file_name, "r");
+		file = LASfopen(this->file_name, "r");
 	};
 	~LASoperationLoadAttributeFromText() { if (file) fclose(file); if (file_name) free(file_name); };
 private:
@@ -5658,7 +5658,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
 					laserror("'%s' needs 1 argument: map_file_name.txt", argv[i]);
 					return FALSE;
 				}
-				FILE* file = fopen(argv[i + 1], "r");
+				FILE* file = LASfopen(argv[i + 1], "r");
 				if (file == 0)
 				{
 					laserror("cannot '%s' needs text file with map but '%s' cannot be opened", argv[i], argv[i + 1]);
@@ -5678,7 +5678,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
 					laserror("'%s' needs 1 argument: map_file_name.txt", argv[i]);
 					return FALSE;
 				}
-				FILE* file = fopen(argv[i + 1], "r");
+				FILE* file = LASfopen(argv[i + 1], "r");
 				if (file == 0)
 				{
 					laserror("'%s' needs text file with map but '%s' cannot be opened", argv[i], argv[i + 1]);
@@ -5698,7 +5698,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
 					laserror("'%s' needs 1 argument: map_file_name.txt", argv[i]);
 					return FALSE;
 				}
-				FILE* file = fopen(argv[i + 1], "r");
+				FILE* file = LASfopen(argv[i + 1], "r");
 				if (file == 0)
 				{
 					laserror("'%s' needs text file with map but '%s' cannot be opened", argv[i], argv[i + 1]);
@@ -5724,7 +5724,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
 					laserror("'%s' needs 2 arguments: attribute_index map_file_name.txt but '%s' is no valid attribute_index", argv[i], argv[i + 1]);
 					return FALSE;
 				}
-				FILE* file = fopen(argv[i + 2], "r");
+				FILE* file = LASfopen(argv[i + 2], "r");
 				if (file == 0)
 				{
 					laserror("'%s' needs text file with map but '%s' cannot be opened", argv[i], argv[i + 2]);
@@ -5753,7 +5753,7 @@ BOOL LAStransform::parse(int argc, char* argv[])
 					laserror("'%s' needs 2 arguments: attribute_index attribute_file_name.txt but '%s' is no valid attribute_index", argv[i], argv[i + 1]);
 					return FALSE;
 				}
-				FILE* file = fopen(argv[i + 2], "r");
+				FILE* file = LASfopen(argv[i + 2], "r");
 				if (file == 0)
 				{
 					laserror("'%s' needs text file with attribute values but '%s' cannot be opened", argv[i], argv[i + 2]);

--- a/LASlib/src/lasutility.cpp
+++ b/LASlib/src/lasutility.cpp
@@ -1643,7 +1643,7 @@ void LASoccupancyGrid::reset()
 
 BOOL LASoccupancyGrid::write_asc_grid(const CHAR* file_name) const
 {
-  FILE* file = fopen(file_name, "w");
+  FILE* file = LASfopen(file_name, "w");
   if (file == 0) return FALSE;
   fprintf(file, "ncols %d\012", max_x-min_x+1);
   fprintf(file, "nrows %d\012", max_y-min_y+1);

--- a/LASlib/src/laswaveform13reader.cpp
+++ b/LASlib/src/laswaveform13reader.cpp
@@ -121,11 +121,11 @@ BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data
   {
     if (!compressed && (strstr(".wdp", file_name) || strstr(".WDP", file_name)))
     {
-      file = fopen(file_name, "rb");
+      file = LASfopen(file_name, "rb");
     }
     else if (compressed && (strstr(".wdz", file_name) || strstr(".WDZ", file_name)))
     {
-      file = fopen(file_name, "rb");
+      file = LASfopen(file_name, "rb");
     }
     else
     {
@@ -143,13 +143,13 @@ BOOL LASwaveform13reader::open(const char* file_name, I64 start_of_waveform_data
         file_name_temp[len-2] = 'd';
         file_name_temp[len-1] = (compressed ? 'z' : 'p');
       }
-      file = fopen(file_name_temp, "rb");
+      file = LASfopen(file_name_temp, "rb");
       free(file_name_temp);
     }
   }
   else
   {
-    file = fopen(file_name, "rb");
+    file = LASfopen(file_name, "rb");
   }
 
   if (file == 0)

--- a/LASlib/src/laswaveform13writer.cpp
+++ b/LASlib/src/laswaveform13writer.cpp
@@ -146,7 +146,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
     file_name_temp[len-2] = 'd';
     file_name_temp[len-1] = (compressed ? 'z' : 'p');
   }
-  file = fopen(file_name_temp, "wb");
+  file = LASfopen(file_name_temp, "wb");
 
   if (file == 0)
   {
@@ -197,7 +197,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
   }
   I8 description[32];
   memset(description, 0, 32);
-  sprintf(description, "%s by LAStools (%d)", (compressed ? "compressed" : "created"), LAS_TOOLS_VERSION);
+  snprintf(description, sizeof(description), "%s by LAStools (%d)", (compressed ? "compressed" : "created"), LAS_TOOLS_VERSION);
   if (!stream->putBytes((U8*)description, 32))
   {
     laserror("writing EVLR description");
@@ -207,7 +207,7 @@ BOOL LASwaveform13writer::open(const char* file_name, const LASvlr_wave_packet_d
   // write waveform descriptor cross-check
 
   char magic[25];
-  sprintf(magic, "LAStools waveform %d", LAS_TOOLS_VERSION);
+  snprintf(magic, sizeof(magic), "LAStools waveform %d", LAS_TOOLS_VERSION);
 
   if (!stream->putBytes((U8*)magic, 24))
   {

--- a/LASlib/src/laswriter.cpp
+++ b/LASlib/src/laswriter.cpp
@@ -954,7 +954,7 @@ CHAR* LASwriteOpener::get_file_name_base() const
   {
     I32 len = (I32)strlen(directory);
     file_name_base = (CHAR*)malloc(len+2);
-    sprintf(file_name_base, "%s%c", directory, DIRECTORY_SLASH);
+    snprintf(file_name_base, len + 2, "%s%c", directory, DIRECTORY_SLASH);
   }
 
   return file_name_base;
@@ -1089,7 +1089,7 @@ void LASwriteOpener::add_directory(const CHAR* directory)
     while ((len > 0) && (file_name[len] != '\\') && (file_name[len] != '/') && (file_name[len] != ':')) len--;
     if (len > 0) len++;
     CHAR* new_file_name = (CHAR*)malloc(strlen(directory) + strlen(&(file_name[len])) + 5);
-    sprintf(new_file_name, "%s%c%s", directory, DIRECTORY_SLASH, &(file_name[len]));
+    snprintf(new_file_name, strlen(directory) + strlen(&(file_name[len])) + 5, "%s%c%s", directory, DIRECTORY_SLASH, &(file_name[len]));
     free(file_name);
     file_name = new_file_name;
   }
@@ -1107,12 +1107,12 @@ void LASwriteOpener::add_appendix(const CHAR* appendix)
 
     if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
     {
-      sprintf(new_file_name, "%s%s", file_name, appendix);
+      snprintf(new_file_name, strlen(appendix) + 5, "%s%s", file_name, appendix);
     }
-    else
+    else if (new_file_name) 
     {
-      strncpy(new_file_name, file_name, len);
-      sprintf(&(new_file_name[len]), "%s%s", appendix, &(file_name[len]));
+      strncpy_las(new_file_name, len + strlen(appendix) + 5, file_name, len);
+      snprintf(&(new_file_name[len]), len + strlen(appendix) + 5, "%s%s", appendix, &(file_name[len]));
     }
     free(file_name);
     file_name = new_file_name;
@@ -1126,18 +1126,22 @@ void LASwriteOpener::cut_characters(U32 cut)
   if (file_name && cut)
   {
     I32 len = (I32)strlen(file_name);
-    CHAR* new_file_name = (CHAR*)malloc(len - cut + 5);
+    I32 new_len = (len > cut) ? (len - cut) : 0;
+    CHAR* new_file_name = (CHAR*)malloc(new_len + 5);
     while ((len > 0) && (file_name[len] != '.') && (file_name[len] != '\\') && (file_name[len] != '/') && (file_name[len] != ':')) len--;
 
-    if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
+    if (new_file_name)
     {
-      len = (I32)strlen(file_name);
-      memcpy(new_file_name, file_name, len-cut);
-    }
-    else
-    {
-      strncpy(new_file_name, file_name, len-cut);
-      sprintf(&(new_file_name[len-cut]), "%s", &(file_name[len]));
+      if ((len == 0) || (file_name[len] == '\\') || (file_name[len] == '/') || (file_name[len] == ':'))
+      {
+        len = (I32)strlen(file_name);
+        memcpy(new_file_name, file_name, new_len);
+      }
+      else
+      {
+        strncpy_las(new_file_name, new_len + 5, file_name, new_len);
+        snprintf(&(new_file_name[new_len]), new_len + 5, "%s", &(file_name[len]));
+      }
     }
     free(file_name);
     file_name = new_file_name;

--- a/LASlib/src/laswriter_bin.cpp
+++ b/LASlib/src/laswriter_bin.cpp
@@ -94,7 +94,7 @@ BOOL LASwriterBIN::open(const char* file_name, const LASheader* header, const ch
     return FALSE;
   }
 
-  file = fopen(file_name, "wb");
+  file = LASfopen(file_name, "wb");
 
   if (file == 0)
   {
@@ -171,7 +171,7 @@ BOOL LASwriterBIN::open(ByteStreamOut* stream, const LASheader* header, const ch
   tsheader.size = sizeof(TSheader);
   tsheader.version = this->version;
   tsheader.recog_val = 970401;
-  strncpy(tsheader.recog_str, "CXYZ", 4);
+  strncpy_las(tsheader.recog_str, sizeof(tsheader.recog_str), "CXYZ", 4);
   tsheader.npoints = (header->number_of_point_records ? header->number_of_point_records : (U32)header->extended_number_of_point_records);
   double scale = header->x_scale_factor;
   if (header->y_scale_factor < scale) scale = header->y_scale_factor; 

--- a/LASlib/src/laswriter_las.cpp
+++ b/LASlib/src/laswriter_las.cpp
@@ -65,17 +65,7 @@ BOOL LASwriterLAS::open(const char* file_name, const LASheader* header, U32 comp
     return FALSE;
   }
 
-#ifdef _MSC_VER
-  wchar_t* utf16_file_name = UTF8toUTF16(file_name);
-  file = _wfopen(utf16_file_name, L"wb");
-  if (file == 0)
-  {
-    laserror("cannot open file '%ws' for write", utf16_file_name);
-  }
-  delete[] utf16_file_name;
-#else
-  file = fopen(file_name, "wb");
-#endif
+  file = LASfopen(file_name, "wb");
 
   if (file == 0)
   {
@@ -604,7 +594,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
     }
     char description[32];
     memset(description, 0, 32);
-    sprintf(description, "by laszip of LAStools (%d)", LAS_TOOLS_VERSION);
+    snprintf(description, sizeof(description), "by laszip of LAStools (%d)", LAS_TOOLS_VERSION);
     if (!stream->putBytes((const U8*)description, 32))
     {
       laserror("writing description %s", description);
@@ -730,7 +720,7 @@ BOOL LASwriterLAS::open(ByteStreamOut* stream, const LASheader* header, U32 comp
       return FALSE;
     }
     CHAR description[33] = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-    sprintf(description, "tile %s buffer %s", (header->vlr_lastiling->buffer ? "with" : "without"), (header->vlr_lastiling->reversible ? ", reversible" : ""));
+    snprintf(description, sizeof(description), "tile %s buffer %s", (header->vlr_lastiling->buffer ? "with" : "without"), (header->vlr_lastiling->reversible ? ", reversible" : ""));
     if (!stream->putBytes((const U8*)description, 32))
     {
       laserror("writing description %s", description);

--- a/LASlib/src/laswriter_qfit.cpp
+++ b/LASlib/src/laswriter_qfit.cpp
@@ -56,7 +56,7 @@ BOOL LASwriterQFIT::open(const char* file_name, const LASheader* header, I32 ver
     return FALSE;
   }
 
-  file = fopen(file_name, "wb");
+  file = LASfopen(file_name, "wb");
 
   if (file == 0)
   {
@@ -182,7 +182,7 @@ BOOL LASwriterQFIT::open(ByteStreamOut* stream, const LASheader* header, I32 ver
   // populate some ASCII into the remainder of first header record
 
   memset(buffer, 0, 48);
-  sprintf((char*)buffer, "via LASwriterQFIT (version %d)", LAS_TOOLS_VERSION);
+  snprintf((char*)buffer, sizeof(buffer), "via LASwriterQFIT (version %d)", LAS_TOOLS_VERSION);
 
   if (!stream->putBytes((U8*)buffer, version-4))
   {
@@ -209,7 +209,7 @@ BOOL LASwriterQFIT::open(ByteStreamOut* stream, const LASheader* header, I32 ver
   // populate some ASCII into the remainder of second header record
 
   memset(buffer, 0, 48);
-  sprintf((char*)buffer, "LAStools by rapidlasso GmbH");
+  snprintf((char*)buffer, sizeof(buffer), "LAStools by rapidlasso GmbH");
   if (!stream->putBytes((U8*)buffer, version-8))
   {
     laserror("writing second header record of QFIT header");

--- a/LASlib/src/laswriter_txt.cpp
+++ b/LASlib/src/laswriter_txt.cpp
@@ -64,7 +64,7 @@ BOOL LASwriterTXT::open(const CHAR* file_name, const LASheader* header, const CH
     return FALSE;
   }
 
-  file = fopen(file_name, "w");
+  file = LASfopen(file_name, "w");
 
   if (file == 0)
   {
@@ -443,8 +443,7 @@ BOOL LASwriterTXT::write_point(const LASpoint* point)
         fprintf(file, "%d", -2048 + point->get_intensity());
       else if (optx)
       {
-        int len;
-        len = sprintf(printstring, "%.3f", 1.0f/4095.0f * point->get_intensity()) - 1;
+        int len = snprintf(printstring, sizeof(printstring), "%.3f", 1.0f/4095.0f * point->get_intensity()) - 1;
         while (printstring[len] == '0') len--;
         if (printstring[len] != '.') len++;
         printstring[len] = '\0';

--- a/LASlib/src/laswriter_wrl.cpp
+++ b/LASlib/src/laswriter_wrl.cpp
@@ -44,7 +44,7 @@ BOOL LASwriterWRL::open(const CHAR* file_name, const LASheader* header, const CH
     return FALSE;
   }
 
-  file = fopen(file_name, "w");
+  file = LASfopen(file_name, "w");
 
   if (file == 0)
   {

--- a/LASzip/CMakeLists.txt
+++ b/LASzip/CMakeLists.txt
@@ -6,6 +6,11 @@ string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 set(ROOT_DIR "${PROJECT_SOURCE_DIR}")
 
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-security -Wno-format-truncation")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-security -Wno-format-truncation")
+endif()
+
 # the next line is the ONLY place in the entire laszip system where
 # the version info is hard-coded
 set(LASZIP_API_VERSION_STRING "3.5.1" CACHE STRING "LASzip version" FORCE)

--- a/LASzip/liblaszip.vcxproj
+++ b/LASzip/liblaszip.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>src;inc;..\LASlib\inc;..\LASlib\src;include\laszip</AdditionalIncludeDirectories>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\laslib64.lib;..\$(Platform)\$(Configuration)\lassrclib64.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/LASzip/src/lasattributer.hpp
+++ b/LASzip/src/lasattributer.hpp
@@ -78,8 +78,8 @@ public:
     memset(this, 0, sizeof(LASattribute));
     scale[0] = scale[1] = scale[2] = 1.0;
     this->data_type = type+1;
-    strncpy(this->name, name, 32);
-    if (description) strncpy(this->description, description, 32);
+    strncpy_las(this->name, sizeof(this->name), name, 32);
+    if (description) strncpy_las(this->description, sizeof(this->description), description, 32);
   };
 
   inline BOOL set_no_data(U8  no_data) { if (0 == get_type()) { this->no_data[0].u64 = no_data; options |= 0x01; return TRUE; } return FALSE; };

--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -336,13 +336,8 @@ BOOL LASindex::read(const char* file_name)
     name[strlen(name)-2] = 'a';
     name[strlen(name)-1] = 'x';
   }
-#ifdef _MSC_VER
-  wchar_t* utf16_name = UTF8toUTF16(name);
-  FILE* file = _wfopen(utf16_name, L"rb");
-  delete[] utf16_name;
-#else
-  FILE* file = fopen(name, "rb");
-#endif
+  FILE* file = LASfopen(name, "rb");
+
   if (file == 0)
   {
     free(name);
@@ -379,17 +374,8 @@ BOOL LASindex::append(const char* file_name) const
 
   lasreader->close();
 
-#ifdef _MSC_VER
-  wchar_t* utf16_file_name = UTF8toUTF16(file_name);
-  FILE* file = _wfopen(utf16_file_name, L"rb");
-  if (file == 0)
-  {
-    laserror("cannot open file '%ws'", utf16_file_name);
-  }
-  delete [] utf16_file_name;
-#else
-  FILE* file = fopen(file_name, "rb");
-#endif
+  FILE* file = LASfopen(file_name, "rb");
+
   ByteStreamIn* bytestreamin = 0;
   if (IS_LITTLE_ENDIAN())
     bytestreamin = new ByteStreamInFileLE(file);
@@ -453,17 +439,8 @@ BOOL LASindex::append(const char* file_name) const
   fclose(file);
 
   ByteStreamOut* bytestreamout;
-#ifdef _MSC_VER
-  utf16_file_name = UTF8toUTF16(file_name);
-  file = _wfopen(utf16_file_name, L"rb+");
-  if (file == 0)
-  {
-    laserror("cannot open file '%ws'", utf16_file_name);
-  }
-  delete [] utf16_file_name;
-#else
-  file = fopen(file_name, "rb+");
-#endif
+  file = LASfopen(file_name, "rb+");
+
   if (IS_LITTLE_ENDIAN())
     bytestreamout = new ByteStreamOutFileLE(file);
   else
@@ -471,9 +448,9 @@ BOOL LASindex::append(const char* file_name) const
   bytestreamout->seek(offset_to_special_evlrs);
 
   LASevlr lax_evlr;
-  sprintf(lax_evlr.user_id, "LAStools");
+  snprintf(lax_evlr.user_id, sizeof(lax_evlr.user_id), "LAStools");
   lax_evlr.record_id = 30;
-  sprintf(lax_evlr.description, "LAX spatial indexing (LASindex)");
+  snprintf(lax_evlr.description, sizeof(lax_evlr.description), "LAX spatial indexing (LASindex)");
 
   bytestreamout->put16bitsLE((const U8*)&(lax_evlr.reserved));
   bytestreamout->putBytes((const U8*)lax_evlr.user_id, 16);
@@ -537,17 +514,8 @@ BOOL LASindex::write(const char* file_name) const
     name[strlen(name)-2] = 'a';
     name[strlen(name)-1] = 'x';
   }
-#ifdef _MSC_VER
-  wchar_t* utf16_file_name = UTF8toUTF16(name);
-  FILE* file = _wfopen(utf16_file_name, L"wb");
-  if (file == 0)
-  {
-    laserror("(LASindex): cannot open file '%ws' for write", utf16_file_name);
-  }
-  delete [] utf16_file_name;
-#else
-  FILE* file = fopen(name, "wb");
-#endif
+  FILE* file = LASfopen(name, "wb");
+
   if (file == 0)
   {
     laserror("(LASindex): cannot open file '%s' for write", name);

--- a/LASzip/src/lasreadpoint.cpp
+++ b/LASzip/src/lasreadpoint.cpp
@@ -511,17 +511,17 @@ BOOL LASreadPoint::read(U8* const * point)
       // end-of-file
       if (dec)
       {
-        sprintf(last_error, "end-of-file during chunk with index %u", current_chunk);
+        snprintf(last_error, 128, "end-of-file during chunk with index %u", current_chunk);
       }
       else
       {
-        sprintf(last_error, "end-of-file");
+        snprintf(last_error, 128, "end-of-file");
       }
     }
     else
     {
       // decompression error
-      sprintf(last_error, "chunk with index %u of %u is corrupt", current_chunk, tabled_chunks);
+      snprintf(last_error, 128, "chunk with index %u of %u is corrupt", current_chunk, tabled_chunks);
       // if we know where the next chunk starts ...
       if ((current_chunk+1) < tabled_chunks)
       {
@@ -553,7 +553,7 @@ BOOL LASreadPoint::check_end()
           // create error string
           if (last_error == 0) last_error = new CHAR[128];
           // report error
-          sprintf(last_error, "chunk with index %u of %u is corrupt", current_chunk, tabled_chunks);
+          snprintf(last_error, 128, "chunk with index %u of %u is corrupt", current_chunk, tabled_chunks);
           return FALSE;
         }
       }
@@ -609,7 +609,7 @@ BOOL LASreadPoint::read_chunk_table()
       // create error string
       if (last_error == 0) last_error = new CHAR[128];
       // report error
-      sprintf(last_error, "compressor was interrupted before writing adaptive chunk table of LAZ file");
+      snprintf(last_error, 128, "compressor was interrupted before writing adaptive chunk table of LAZ file");
       return FALSE;
     }
     // otherwise we build the chunk table as we read the file
@@ -624,7 +624,7 @@ BOOL LASreadPoint::read_chunk_table()
     // create warning string
     if (last_warning == 0) last_warning = new CHAR[128];
     // report warning
-    sprintf(last_warning, "compressor was interrupted before writing chunk table of LAZ file");
+    snprintf(last_warning, 128, "compressor was interrupted before writing chunk table of LAZ file");
     return TRUE;
   }
 
@@ -762,17 +762,17 @@ BOOL LASreadPoint::read_chunk_table()
       // report warning
       if (last_position == chunk_table_start_position)
       {
-        sprintf(last_warning, "chunk table is missing. improper use of LAZ compressor?");
+        snprintf(last_warning, 128, "chunk table is missing. improper use of LAZ compressor?");
       }
       else
       {
-        sprintf(last_warning, "chunk table and %lld bytes are missing. LAZ file truncated during copy or transfer?", chunk_table_start_position - last_position);
+        snprintf(last_warning, 128, "chunk table and %lld bytes are missing. LAZ file truncated during copy or transfer?", chunk_table_start_position - last_position);
       }
     }
     else
     {
       // report warning
-      sprintf(last_warning, "corrupt chunk table");
+      snprintf(last_warning, 128, "corrupt chunk table");
     }
   }
   if (!instream->seek(chunks_start))

--- a/LASzip/src/laszip.cpp
+++ b/LASzip/src/laszip.cpp
@@ -197,7 +197,7 @@ bool LASzip::return_error(const char* error)
 #define CopyString strdup
 #endif
   char err[256];
-  sprintf(err, "%s (LASzip v%d.%dr%d)", error, LASZIP_VERSION_MAJOR, LASZIP_VERSION_MINOR, LASZIP_VERSION_REVISION);
+  snprintf(err, sizeof(err), "%s (LASzip v%d.%dr%d)", error, LASZIP_VERSION_MAJOR, LASZIP_VERSION_MINOR, LASZIP_VERSION_REVISION);
   if (error_string) free(error_string);
   error_string = CopyString(err);
   return false;
@@ -207,7 +207,7 @@ bool LASzip::check_compressor(const U16 compressor)
 {
   if (compressor < LASZIP_COMPRESSOR_TOTAL_NUMBER_OF) return true;
   char error[64];
-  sprintf(error, "compressor %d not supported", compressor);
+  snprintf(error, sizeof(error), "compressor %d not supported", compressor);
   return return_error(error);
 }
 
@@ -215,7 +215,7 @@ bool LASzip::check_coder(const U16 coder)
 {
   if (coder < LASZIP_CODER_TOTAL_NUMBER_OF) return true;
   char error[64];
-  sprintf(error, "coder %d not supported", coder);
+  snprintf(error, sizeof(error), "coder %d not supported", coder);
   return return_error(error);
 }
 
@@ -267,7 +267,7 @@ bool LASzip::check_item(const LASitem* item)
     if (1)
     {
       char error[64];
-      sprintf(error, "item unknown (%d,%d,%d)", item->type, item->size, item->version);
+      snprintf(error, sizeof(error), "item unknown (%d,%d,%d)", item->type, item->size, item->version);
       return return_error(error);
     }
   }
@@ -288,7 +288,7 @@ bool LASzip::check_items(const U16 num_items, const LASitem* items, const U16 po
   if (point_size && (point_size != size))
   {
     CHAR temp[66];
-    sprintf(temp, "point has size of %d but items only add up to %d bytes", point_size, size);
+    snprintf(temp, sizeof(temp), "point has size of %d but items only add up to %d bytes", point_size, size);
     return return_error(temp);
   }
   return true;
@@ -490,7 +490,7 @@ bool LASzip::setup(U16* num_items, LASitem** items, const U8 point_type, const U
     if (1)
     {
       char error[64];
-      sprintf(error, "point type %d unknown", point_type);
+      snprintf(error, sizeof(error), "point type %d unknown", point_type);
       return return_error(error);
     }
   }

--- a/LASzip/src/mydefs.cpp
+++ b/LASzip/src/mydefs.cpp
@@ -36,15 +36,25 @@
 
 #if defined(_MSC_VER)
 #include <windows.h>
+/// Converting UTF-8 to UTF-16
 wchar_t* UTF8toUTF16(const char* utf8)
 {
-  wchar_t* utf16 = 0;
-  int len = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, 0, 0);
-  if (len > 0)
-  {
-    utf16 = new wchar_t[len];
-    MultiByteToWideChar(CP_UTF8, 0, utf8, -1, utf16, len);
-  }
+  if (utf8 == nullptr) return nullptr;
+  int len = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, nullptr, 0);
+  if (len <= 0) return nullptr;
+  wchar_t* utf16 = new wchar_t[len];
+  MultiByteToWideChar(CP_UTF8, 0, utf8, -1, utf16, len);
+  return utf16;
+}
+
+/// Converting ANSI to UTF-16
+wchar_t* ANSItoUTF16(const char* ansi)
+{
+  if (ansi == nullptr) return nullptr;
+  int len = MultiByteToWideChar(CP_ACP, 0, ansi, -1, nullptr, 0);
+  if (len <= 0) return nullptr;
+  wchar_t* utf16 = new wchar_t[len];
+  MultiByteToWideChar(CP_ACP, 0, ansi, -1, utf16, len);
   return utf16;
 }
 #endif
@@ -99,3 +109,97 @@ void byebye()
   }
   exit(code);
 }
+
+/// Validates whether a given string is UTF-8 encoded.
+bool validate_utf8(const char* utf8) noexcept
+{
+  if (utf8 == nullptr) return false;
+
+  while (*utf8)
+  {
+    if ((*utf8 & 0b10000000) != 0)
+    {
+      if ((*utf8 & 0b01000000) == 0) return false;
+      if ((*utf8 & 0b00100000) != 0) {
+        if ((*utf8 & 0b00010000) != 0) {
+          if ((*utf8 & 0b00001000) != 0) 
+            return false;
+          if ((*++utf8 & 0b11000000) != 0b10000000) 
+            return false;
+        }
+        if ((*++utf8 & 0b11000000) != 0b10000000)
+          return false;
+      }
+      if ((*++utf8 & 0b11000000) != 0b10000000)
+        return false;
+    }
+    ++utf8;
+  }
+  return true;
+}
+
+// To re-enable, change #if 0 to #if 1.
+#if 0
+  /// Non Windows - specific conversion ANSI to UTF-8
+  char* ANSItoUTF8(const char* ansi)
+  {
+    if (ansi == nullptr) return nullptr;
+  
+    // Non-Windows-specific conversion
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+    std::wstring utf16 = converter.from_bytes(ansi);
+    size_t len = utf16.length() + 1;
+  
+    char* utf8 = new char[len];
+    std::wcstombs(utf8, utf16.c_str(), len);
+  
+    return utf8;
+  }
+#endif
+
+/// Opens a file with the specified filename and mode, converting filename and mode to UTF-16 on Windows.
+FILE* LASfopen(const char* const filename, const char* const mode)
+{
+  if (filename == nullptr || mode == nullptr || mode[0] == '\0') {
+    return nullptr;
+  }
+  FILE* file = nullptr;
+
+#ifdef _MSC_VER
+  wchar_t* utf16_file_name = nullptr;
+  wchar_t* utf16_mode = nullptr;
+
+  if (validate_utf8(filename)) {
+    utf16_file_name = UTF8toUTF16(filename);
+  } else {
+    utf16_file_name = ANSItoUTF16(filename);
+  }
+  //mode can be converted with UTF8toUTF16, as it contains only ASCII characters
+  utf16_mode = UTF8toUTF16(mode);
+
+  if (utf16_file_name && utf16_mode) {
+    file = _wfopen(utf16_file_name, utf16_mode);
+  }
+  delete[] utf16_file_name;
+  delete[] utf16_mode;
+#else
+  // The following block of code is deactivated as it is very unlikely to be needed under non-Windows systems.
+  // To re-enable, change #if 0 to #if 1.
+  #if 0
+    char* utf8_file_name = nullptr;
+  
+    if (validate_utf8(filename)) {
+      file = fopen(filename, mode);
+    } else {
+      utf8_file_name = ANSItoUTF8(filename);
+      file = fopen(utf8_file_name, mode);
+    }
+    delete[] utf8_file_name;
+  #else
+    file = fopen(filename, mode);
+  #endif
+#endif
+
+  return file;
+}
+

--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -188,6 +188,30 @@ typedef union I64U32I32F32 { I64 i64; U32 u32[2]; I32 i32[2]; F32 f32[2]; } I64U
 #define NULL    0
 #endif
 
+#ifdef _MSC_VER
+#define strncpy_las(dest, destsz, src, count) strncpy_s((dest), (destsz), (src), (count))
+#else
+#define strncpy_las(dest, destsz, src, count) strncpy((dest), (src), (count)) 
+#endif
+
+#ifdef _MSC_VER
+#define strcpy_las(dest, destsz, src) strcpy_s((dest), (destsz), (src))
+#else
+#define strcpy_las(dest, destsz, src) strcpy((dest), (src))
+#endif
+
+#ifdef _MSC_VER
+#define sscanf_las(buf, format, ...) sscanf_s((buf), (format), __VA_ARGS__)
+#else
+#define sscanf_las(buf, format, ...) sscanf((buf), (format), __VA_ARGS__)
+#endif
+
+#ifdef _MSC_VER
+#define strcat_las(dest, destsz, src) strcat_s((dest), (destsz), (src))
+#else
+#define strcat_las(dest, destsz, src) strcat((dest), (src))
+#endif
+
 inline BOOL IS_LITTLE_ENDIAN()
 {
   const U32 i = 1;
@@ -268,6 +292,7 @@ inline void ENDIAN_SWAP_64(const U8* from, U8* to)
 #if defined(_MSC_VER)
 #include <windows.h>
 wchar_t* UTF8toUTF16(const char* utf8);
+wchar_t* ANSItoUTF16(const char* ansi);
 #endif
 
 /// <summary>
@@ -298,6 +323,15 @@ LAS_EXIT_CODE las_exit_code(bool error);
 
 // void byebye(LAS_EXIT_CODE code = LAS_EXIT_OK);
 void byebye();
+
+#if 0
+  // Non Windows - specific conversion ANSI to UTF-8
+  char* ANSItoUTF8(const char* ansi);
+#endif
+// Validates whether a given string is UTF-8 encoded.
+bool validate_utf8(const char* utf8) noexcept;
+// Opens a file with the specified filename and mode, converting filename and mode to UTF-16 on Windows.
+FILE* LASfopen(const char* const filename, const char* const mode);
 
 // las error message function which leads to an immediate program stop by default
 template<typename... Args>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-security -Wno-format-truncation")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-security -Wno-format-truncation")
+endif()
 if (!MSVC)
 add_compile_options(-Wno-deprecated -Wno-write-strings -Wno-unused-result)
 endif()

--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -108,10 +108,9 @@ static double taketime()
 static bool save_vlrs_to_file(const LASheader* header)
 {
   U32 i;
-  FILE* file = fopen("vlrs.vlr", "wb");
-  if (file == 0)
-  {
-    return false;
+  FILE* file =  LASfopen("vlrs.vlr", "wb");
+  if (file == 0) {
+      return false;
   }
   ByteStreamOut* out;
   if (IS_LITTLE_ENDIAN())
@@ -172,10 +171,9 @@ static bool save_vlrs_to_file(const LASheader* header)
 static bool load_vlrs_from_file(LASheader* header)
 {
   U32 i;
-  FILE* file = fopen("vlrs.vlr", "rb");
-  if (file == 0)
-  {
-    return false;
+  FILE* file = LASfopen("vlrs.vlr", "rb");
+  if (file == 0) {
+      return false;
   }
   ByteStreamIn* in;
   if (IS_LITTLE_ENDIAN())
@@ -373,11 +371,11 @@ int main(int argc, char* argv[])
     if (strcmp(argv[i], "-subseq") == 0)
     {
       lastool.parse_arg_cnt_check(i, 2, "start stop");
-      if (sscanf(argv[i + 1], "%lld", &subsequence_start) != 1)
+      if (sscanf_las(argv[i + 1], "%lld", &subsequence_start) != 1)
       {
         lastool.error_parse_arg_n_invalid(i, 1);
       }
-      if (sscanf(argv[i + 2], "%lld", &subsequence_stop) != 1)
+      if (sscanf_las(argv[i + 2], "%lld", &subsequence_stop) != 1)
       {
         lastool.error_parse_arg_n_invalid(i, 2);
       }
@@ -386,7 +384,7 @@ int main(int argc, char* argv[])
     else if (strcmp(argv[i], "-start_at_point") == 0)
     {
       lastool.parse_arg_cnt_check(i, 1, "index of start point");
-      if (sscanf(argv[i + 1], "%lld", &subsequence_start) != 1)
+      if (sscanf_las(argv[i + 1], "%lld", &subsequence_start) != 1)
       {
         lastool.error_parse_arg_n_invalid(i, 1);
       }
@@ -395,7 +393,7 @@ int main(int argc, char* argv[])
     else if (strcmp(argv[i], "-stop_at_point") == 0)
     {
       lastool.parse_arg_cnt_check(i, 1, "index of stop point");
-      if (sscanf(argv[i + 1], "%lld", &subsequence_stop) != 1)
+      if (sscanf_las(argv[i + 1], "%lld", &subsequence_stop) != 1)
       {
         lastool.error_parse_arg_n_invalid(i, 1);
       }
@@ -408,7 +406,7 @@ int main(int argc, char* argv[])
         if (strcmp(argv[i], "-set_point_type") == 0 || strcmp(argv[i], "-set_point_data_format") == 0)
         {
           lastool.parse_arg_cnt_check(i, 1, "type");
-          if (sscanf(argv[i + 1], "%u", &set_point_data_format) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &set_point_data_format) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
@@ -417,7 +415,7 @@ int main(int argc, char* argv[])
         else if (strcmp(argv[i], "-set_point_data_record_length") == 0 || strcmp(argv[i], "-set_point_size") == 0)
         {
           lastool.parse_arg_cnt_check(i, 1, "size");
-          if (sscanf(argv[i + 1], "%u", &set_point_data_record_length) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &set_point_data_record_length) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
@@ -431,7 +429,7 @@ int main(int argc, char* argv[])
       else if (strcmp(argv[i], "-set_global_encoding_gps_bit") == 0)
       {
         lastool.parse_arg_cnt_check(i, 1, "0 or 1");
-        if (sscanf(argv[i + 1], "%u", &set_global_encoding_gps_bit) != 1)
+        if (sscanf_las(argv[i + 1], "%u", &set_global_encoding_gps_bit) != 1)
         {
           lastool.error_parse_arg_n_invalid(i, 1);
         }
@@ -440,7 +438,7 @@ int main(int argc, char* argv[])
       else if (strcmp(argv[i], "-set_version") == 0)
       {
         lastool.parse_arg_cnt_check(i, 1, "major.minor");
-        if (sscanf(argv[i + 1], "%u.%u", &set_version_major, &set_version_minor) != 2)
+        if (sscanf_las(argv[i + 1], "%u.%u", &set_version_major, &set_version_minor) != 2)
         {
           lastool.error_parse_arg_n_invalid(i, 1);
         }
@@ -449,7 +447,7 @@ int main(int argc, char* argv[])
       else if (strcmp(argv[i], "-set_version_major") == 0)
       {
         lastool.parse_arg_cnt_check(i, 1, "major");
-        if (sscanf(argv[i + 1], "%u", &set_version_major) != 1)
+        if (sscanf_las(argv[i + 1], "%u", &set_version_major) != 1)
         {
           lastool.error_parse_arg_n_invalid(i, 1);
         }
@@ -458,7 +456,7 @@ int main(int argc, char* argv[])
       else if (strcmp(argv[i], "-set_version_minor") == 0)
       {
         lastool.parse_arg_cnt_check(i, 1, "minor");
-        if (sscanf(argv[i + 1], "%u", &set_version_minor) != 1)
+        if (sscanf_las(argv[i + 1], "%u", &set_version_minor) != 1)
         {
           lastool.error_parse_arg_n_invalid(i, 1);
         }
@@ -467,7 +465,7 @@ int main(int argc, char* argv[])
       else if (strcmp(argv[i], "-set_lastiling_buffer_flag") == 0)
       {
         lastool.parse_arg_cnt_check(i, 1, "0 or 1");
-        if (sscanf(argv[i + 1], "%u", &set_lastiling_buffer_flag) != 1)
+        if (sscanf_las(argv[i + 1], "%u", &set_lastiling_buffer_flag) != 1)
         {
           lastool.error_parse_arg_n_invalid(i, 1);
         }
@@ -507,11 +505,11 @@ int main(int argc, char* argv[])
         lastool.parse_arg_cnt_check(i, 2, "index scale");
         if (set_attribute_scales < 5)
         {
-          if (sscanf(argv[i + 1], "%u", &(set_attribute_scale_index[set_attribute_scales])) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &(set_attribute_scale_index[set_attribute_scales])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
-          if (sscanf(argv[i + 2], "%lf", &(set_attribute_scale_scale[set_attribute_scales])) != 1)
+          if (sscanf_las(argv[i + 2], "%lf", &(set_attribute_scale_scale[set_attribute_scales])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 2);
           }
@@ -528,11 +526,11 @@ int main(int argc, char* argv[])
         lastool.parse_arg_cnt_check(i, 2, "index offset");
         if (set_attribute_offsets < 5)
         {
-          if (sscanf(argv[i + 1], "%u", &(set_attribute_offset_index[set_attribute_offsets])) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &(set_attribute_offset_index[set_attribute_offsets])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
-          if (sscanf(argv[i + 2], "%lf", &(set_attribute_offset_offset[set_attribute_offsets])) != 1)
+          if (sscanf_las(argv[i + 2], "%lf", &(set_attribute_offset_offset[set_attribute_offsets])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 2);
           }
@@ -663,7 +661,7 @@ int main(int argc, char* argv[])
         lastool.parse_arg_cnt_check(i, 1, "index");
         if (unset_attribute_scales < 5)
         {
-          if (sscanf(argv[i + 1], "%u", &(unset_attribute_scale_index[unset_attribute_scales])) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &(unset_attribute_scale_index[unset_attribute_scales])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
@@ -680,7 +678,7 @@ int main(int argc, char* argv[])
         lastool.parse_arg_cnt_check(i, 1, "index");
         if (unset_attribute_offsets < 5)
         {
-          if (sscanf(argv[i + 1], "%u", &(unset_attribute_offset_index[unset_attribute_offsets])) != 1)
+          if (sscanf_las(argv[i + 1], "%u", &(unset_attribute_offset_index[unset_attribute_offsets])) != 1)
           {
             lastool.error_parse_arg_n_invalid(i, 1);
           }
@@ -714,7 +712,7 @@ int main(int argc, char* argv[])
       lastool.parse_arg_cnt_check(i, 1, "file name");
       if ((argv[i + 1][0] != '-') && (argv[i + 1][0] != '\0'))
       {
-        FILE* file = fopen(argv[i + 1], "r");
+        FILE* file = LASfopen(argv[i + 1], "r");
 
         if (file)
         {
@@ -1694,12 +1692,12 @@ int main(int argc, char* argv[])
 
       // prepare the header for the surviving points
 
-      strncpy(lasreader->header.system_identifier, "LAStools (c) by rapidlasso GmbH", 32);
+      strncpy_las(lasreader->header.system_identifier, sizeof(lasreader->header.system_identifier), "LAStools (c) by rapidlasso GmbH", 32);
       lasreader->header.system_identifier[31] = '\0';
       char temp[64];
-      sprintf(temp, "las2las%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
+      snprintf(temp, sizeof(temp), "las2las%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
       memset(lasreader->header.generating_software, 0, 32);
-      strncpy(lasreader->header.generating_software, temp, 32);
+      strncpy_las(lasreader->header.generating_software, sizeof(lasreader->header.generating_software), temp, 32);
       lasreader->header.generating_software[31] = '\0';
 
       // open laswriter

--- a/src/las2las.vcxproj
+++ b/src/las2las.vcxproj
@@ -37,8 +37,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/las2txt.cpp
+++ b/src/las2txt.cpp
@@ -973,15 +973,12 @@ int main(int argc, char* argv[])
         }
         laswriteopener.make_file_name(lasreadopener.get_file_name(), -2);
       }
-
       const CHAR* file_name_out = laswriteopener.get_file_name();
 
       // open output file
-
-      file_out = fopen(file_name_out, "w");
+      file_out = LASfopen(file_name_out, "w");
 
       // fail if output file does not open
-
       if (file_out == 0)
       {
         laserror("could not open '%s' for write", file_name_out);

--- a/src/las2txt.vcxproj
+++ b/src/las2txt.vcxproj
@@ -36,8 +36,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lascopcindex.vcxproj
+++ b/src/lascopcindex.vcxproj
@@ -37,8 +37,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lasdiff.cpp
+++ b/src/lasdiff.cpp
@@ -1115,8 +1115,8 @@ int main(int argc, char *argv[])
         // prepare the header
         memset(lasreader1->header.system_identifier, 0, 32);
         memset(lasreader1->header.generating_software, 0, 32);
-        sprintf(lasreader1->header.system_identifier, "LAStools (c) by rapidlasso GmbH");
-        sprintf(lasreader1->header.generating_software, "lasdiff%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
+        snprintf(lasreader1->header.system_identifier, sizeof(lasreader1->header.system_identifier), "LAStools (c) by rapidlasso GmbH");
+        snprintf(lasreader1->header.generating_software, sizeof(lasreader1->header.generating_software), "lasdiff%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
         laswriter = laswriteopener.open(&lasreader1->header);
         if (laswriter == 0)
         {

--- a/src/lasdiff.vcxproj
+++ b/src/lasdiff.vcxproj
@@ -36,8 +36,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lasindex.cpp
+++ b/src/lasindex.cpp
@@ -295,15 +295,15 @@ int main(int argc, char *argv[])
     CHAR* meta_file_name = (CHAR*)malloc(len + 9);
     if (len)
     {
-      sprintf(meta_file_name, "%s\\lax.txt", meta_file_name_base);
+      snprintf(meta_file_name, len + 9, "%s\\lax.txt", meta_file_name_base);
     }
     else
     {
-      sprintf(meta_file_name, "lax.txt");
+      snprintf(meta_file_name, 9, "lax.txt");
     }
     free(meta_file_name_base);
 
-    file_meta = fopen(meta_file_name, "w");
+    file_meta = LASfopen(meta_file_name, "w");
 
     if (file_meta == 0)
     {

--- a/src/lasindex.vcxproj
+++ b/src/lasindex.vcxproj
@@ -36,8 +36,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lasinfo.cpp
+++ b/src/lasinfo.cpp
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
       {
         laserror("'%s' needs 2 arguments: start stop", argv[i]);
       }
-      if (sscanf(argv[i+1], "%lld", &subsequence_start) != 1)
+      if (sscanf_las(argv[i+1], "%lld", &subsequence_start) != 1)
       {
         laserror("'%s' needs 2 arguments: start stop but '%s' is not a valid start", argv[i], argv[i+1]);
       }
@@ -377,7 +377,7 @@ int main(int argc, char *argv[])
       {
         laserror("'%s' needs 2 arguments: start stop but '%lld' is not a valid start", argv[i], subsequence_start);
       }
-      if (sscanf(argv[i+2], "%lld", &subsequence_stop) != 1)
+      if (sscanf_las(argv[i+2], "%lld", &subsequence_stop) != 1)
       {
         laserror("'%s' needs 2 arguments: start stop but '%s' is not a valid stop", argv[i], argv[i+2]);
       }
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
       {
         laserror("'%s' needs 1 argument: start", argv[i]);
       }
-      if (sscanf(argv[i+1], "%lld", &subsequence_start) != 1)
+      if (sscanf_las(argv[i+1], "%lld", &subsequence_start) != 1)
       {
         laserror("'%s' needs 1 argument: start but '%s' is not a valid start", argv[i], argv[i+1]);
       }
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
       {
         laserror("'%s' needs 1 argument: stop", argv[i]);
       }
-      if (sscanf(argv[i+1], "%lld", &subsequence_stop) != 1)
+      if (sscanf_las(argv[i+1], "%lld", &subsequence_stop) != 1)
       {
         laserror("'%s' needs 1 argument: start but '%s' is not a valid stop", argv[i], argv[i+1]);
       }
@@ -455,7 +455,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 1 argument: index", argv[i]);
         }
-        if (sscanf(argv[i+1], "%u", &set_file_source_ID) != 1)
+        if (sscanf_las(argv[i+1], "%u", &set_file_source_ID) != 1)
         {
           laserror("'%s' needs 1 argument: index but '%s' is no valid index", argv[i], argv[i+1]);
         }
@@ -479,9 +479,9 @@ int main(int argc, char *argv[])
         }
 			  i++;
 #ifdef _WIN32
-        if (sscanf(argv[i], "%I64x-%x-%x-%x-%I64x", &set_project_ID_GUID_data_1, &set_project_ID_GUID_data_2, &set_project_ID_GUID_data_3, &set_project_ID_GUID_data_4a, &set_project_ID_GUID_data_4b) != 5)
+        if (sscanf_las(argv[i], "%I64x-%x-%x-%x-%I64x", &set_project_ID_GUID_data_1, &set_project_ID_GUID_data_2, &set_project_ID_GUID_data_3, &set_project_ID_GUID_data_4a, &set_project_ID_GUID_data_4b) != 5)
 #else
-        if (sscanf(argv[i], "%llx-%x-%x-%x-%llx", &set_project_ID_GUID_data_1, &set_project_ID_GUID_data_2, &set_project_ID_GUID_data_3, &set_project_ID_GUID_data_4a, &set_project_ID_GUID_data_4b) != 5)
+        if (sscanf_las(argv[i], "%llx-%x-%x-%x-%llx", &set_project_ID_GUID_data_1, &set_project_ID_GUID_data_2, &set_project_ID_GUID_data_3, &set_project_ID_GUID_data_4a, &set_project_ID_GUID_data_4b) != 5)
 #endif
         {
           if ((i+1) >= argc)
@@ -500,7 +500,7 @@ int main(int argc, char *argv[])
 			  i++;
 			  set_system_identifier = new I8[32];
         memset(set_system_identifier, 0, 32);
-        strncpy(set_system_identifier, argv[i], 32);
+        strncpy_las(set_system_identifier, 32, argv[i], 32);
         edit_header = true;
 		  }
       else if (strcmp(argv[i],"-set_generating_software") == 0)
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 			  i++;
 			  set_generating_software = new I8[32];
         memset(set_generating_software, 0, 32);
-        strncpy(set_generating_software, argv[i], 32);
+        strncpy_las(set_generating_software, 32, argv[i], 32);
         edit_header = true;
 		  }
       else if (strcmp(argv[i],"-set_bb") == 0 || strcmp(argv[i],"-set_bounding_box") == 0)
@@ -585,7 +585,7 @@ int main(int argc, char *argv[])
         i++;
         int major;
         int minor;
-        if (sscanf(argv[i],"%d.%d",&major,&minor) != 2)
+        if (sscanf_las(argv[i],"%d.%d",&major,&minor) != 2)
         {
           laserror("cannot understand argument '%s' of '%s'", argv[i], argv[i-1]);
         }
@@ -699,7 +699,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 2 arguments: index user_id", argv[i]);
         }
-        if (sscanf(argv[i+1], "%d", &set_vlr_user_id_index) != 1)
+        if (sscanf_las(argv[i+1], "%d", &set_vlr_user_id_index) != 1)
         {
           laserror("'%s' needs 2 arguments: index user_ID but '%s' is no valid index", argv[i], argv[i+1]);
         }
@@ -718,7 +718,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 2 arguments: index record_ID", argv[i]);
         }
-        if (sscanf(argv[i+1], "%d", &set_vlr_record_id_index) != 1)
+        if (sscanf_las(argv[i+1], "%d", &set_vlr_record_id_index) != 1)
         {
           laserror("'%s' needs 2 arguments: index record_ID but '%s' is no valid index", argv[i], argv[i+1]);
         }
@@ -726,7 +726,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 2 arguments: index record_ID, but index %d is out of range", argv[i], set_vlr_record_id_index);
         }
-        if (sscanf(argv[i+2], "%d", &set_vlr_record_id) != 1)
+        if (sscanf_las(argv[i+2], "%d", &set_vlr_record_id) != 1)
         {
           laserror("'%s' needs 2 arguments: index record_ID but '%s' is no valid record ID", argv[i], argv[i+2]);
         }
@@ -744,7 +744,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 2 arguments: index description", argv[i]);
         }
-        if (sscanf(argv[i+1], "%d", &set_vlr_description_index) != 1)
+        if (sscanf_las(argv[i+1], "%d", &set_vlr_description_index) != 1)
         {
           laserror("'%s' needs 2 arguments: index description but '%s' is no valid index", argv[i], argv[i+1]);
         }
@@ -784,7 +784,7 @@ int main(int argc, char *argv[])
         {
           laserror("'%s' needs 1 argument: code", argv[i]);
         }
-        if (sscanf(argv[i+1], "%u", &set_geotiff_epsg) != 1)
+        if (sscanf_las(argv[i+1], "%u", &set_geotiff_epsg) != 1)
         {
           laserror("'%s' needs 1 argument: code but '%s' is no valid code", argv[i], argv[i+1]);
         }
@@ -858,7 +858,7 @@ int main(int argc, char *argv[])
       {
         laserror("'%s' needs 1 argument: every", argv[i]);
       }
-      if (sscanf(argv[i+1], "%u", &progress) != 1)
+      if (sscanf_las(argv[i+1], "%u", &progress) != 1)
       {
         laserror("'%s' needs 1 argument: every but '%s' is no valid number", argv[i], argv[i+1]);
       }
@@ -1129,7 +1129,7 @@ int main(int argc, char *argv[])
         lasreader->close();
         delete lasreader;
       }
-      FILE* file = fopen(file_name, "rb+");
+      FILE* file = LASfopen(file_name, "rb+");
       if (file == 0)
       {
         laserror("could not open file '%s' for edit of header", file_name);
@@ -1416,7 +1416,7 @@ int main(int argc, char *argv[])
         lasreader->close();
 
         char command[2048];
-        sprintf(command, "del \"%s\"", lasreadopener.get_file_name());
+        snprintf(command, sizeof(command), "del \"%s\"", lasreadopener.get_file_name());
         LASMessage(LAS_VERBOSE, "executing '%s'", command);
 
         if (system(command) != 0)
@@ -1448,11 +1448,11 @@ int main(int argc, char *argv[])
       char command[2048];
       if (strlen(base_name))
       {
-        sprintf(command, "rename \"%s\" \"%s_%d_%d.xxx\"", lasreadopener.get_file_name(), base_name, I32_QUANTIZE(lasheader->min_x), I32_QUANTIZE(lasheader->min_y));
+        snprintf(command, sizeof(command), "rename \"%s\" \"%s_%d_%d.xxx\"", lasreadopener.get_file_name(), base_name, I32_QUANTIZE(lasheader->min_x), I32_QUANTIZE(lasheader->min_y));
       }
       else
       {
-        sprintf(command, "rename \"%s\" \"%d_%d.xxx\"", lasreadopener.get_file_name(), I32_QUANTIZE(lasheader->min_x), I32_QUANTIZE(lasheader->min_y));
+        snprintf(command,sizeof(command), "rename \"%s\" \"%d_%d.xxx\"", lasreadopener.get_file_name(), I32_QUANTIZE(lasheader->min_x), I32_QUANTIZE(lasheader->min_y));
       }
       int len1 = (int)strlen(lasreadopener.get_file_name());
       int len2 = (int)strlen(command);
@@ -1503,7 +1503,7 @@ int main(int argc, char *argv[])
         laserror("input and output file name for '%s' are identical", lasreadopener.get_file_name());
       }
       // open the text output file
-      file_out = fopen(laswriteopener.get_file_name(), "w");
+      file_out = LASfopen(laswriteopener.get_file_name(), "w");
       if (file_out == 0)
       {
         LASMessage(LAS_WARNING, "could not open output text file '%s'", laswriteopener.get_file_name());
@@ -1661,7 +1661,7 @@ int main(int argc, char *argv[])
                   if (lasreader->header.vlr_geo_ascii_params)
                   {
                     char dummy[256];
-                    strncpy(dummy, &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
+                    strncpy_las(dummy, sizeof(dummy), &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
                     dummy[lasreader->header.vlr_geo_key_entries[j].count-1] = '\0';
                     fprintf(file_out, "GTCitationGeoKey: %s\012",dummy);
                   }
@@ -1794,7 +1794,7 @@ int main(int argc, char *argv[])
                   if (lasreader->header.vlr_geo_ascii_params)
                   {
                     char dummy[256];
-                    strncpy(dummy, &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
+                    strncpy_las(dummy, sizeof(dummy), &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
                     dummy[lasreader->header.vlr_geo_key_entries[j].count-1] = '\0';
                     fprintf(file_out, "GeogCitationGeoKey: %s\012",dummy);
                   }
@@ -2206,7 +2206,7 @@ int main(int argc, char *argv[])
                   if (lasreader->header.vlr_geo_ascii_params)
                   {
                     char dummy[256];
-                    strncpy(dummy, &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
+                    strncpy_las(dummy, sizeof(dummy), &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
                     dummy[lasreader->header.vlr_geo_key_entries[j].count-1] = '\0';
                     fprintf(file_out, "PCSCitationGeoKey: %s\012",dummy);
                   }
@@ -3573,7 +3573,7 @@ int main(int argc, char *argv[])
                   if (lasreader->header.vlr_geo_ascii_params)
                   {
                     char dummy[256];
-                    strncpy(dummy, &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
+                    strncpy_las(dummy, sizeof(dummy), &(lasreader->header.vlr_geo_ascii_params[lasreader->header.vlr_geo_key_entries[j].value_offset]), lasreader->header.vlr_geo_key_entries[j].count);
                     dummy[lasreader->header.vlr_geo_key_entries[j].count-1] = '\0';
                     fprintf(file_out, "VerticalCitationGeoKey: %s\012",dummy);
                   }
@@ -4214,7 +4214,7 @@ int main(int argc, char *argv[])
         laserror("can only repair header for LAS or LAZ files, not for '%s'", lasreadopener.get_file_name());
         repair_bb = repair_counters = false;
       }
-      file = fopen(lasreadopener.get_file_name(), "rb+");
+      file = LASfopen(lasreadopener.get_file_name(), "rb+");
       if (file == 0)
       {
         laserror("could not reopen file '%s' for repair of header", lasreadopener.get_file_name());

--- a/src/lasinfo.vcxproj
+++ b/src/lasinfo.vcxproj
@@ -41,8 +41,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lasmerge.cpp
+++ b/src/lasmerge.cpp
@@ -221,12 +221,12 @@ int main(int argc, char *argv[])
 
   // prepare the header for the surviving points
 
-  strncpy(lasreader->header.system_identifier, "LAStools (c) by rapidlasso GmbH", 32);
+  strncpy_las(lasreader->header.system_identifier, sizeof(lasreader->header.system_identifier), "LAStools (c) by rapidlasso GmbH", 32);
   lasreader->header.system_identifier[31] = '\0';
   char temp[64];
-  sprintf(temp, "lasmerge%s (version %d)", (IS64?"64":""), LAS_TOOLS_VERSION);
+  snprintf(temp, sizeof(temp), "lasmerge%s (version %d)", (IS64?"64":""), LAS_TOOLS_VERSION);
   memset(lasreader->header.generating_software, 0, 32);
-  strncpy(lasreader->header.generating_software, temp, 32);
+  strncpy_las(lasreader->header.generating_software, sizeof(lasreader->header.generating_software), temp, 32);
   lasreader->header.generating_software[31] = '\0';
 
   if (projection_was_set)

--- a/src/lasmerge.vcxproj
+++ b/src/lasmerge.vcxproj
@@ -43,8 +43,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lasprecision.cpp
+++ b/src/lasprecision.cpp
@@ -773,12 +773,11 @@ int main(int argc, char *argv[])
       }
 
       // prepare the header for the surviving points
-
-      strncpy(lasreader->header.system_identifier, "LAStools (c) by rapidlasso GmbH", 32);
+      strncpy_las(lasreader->header.system_identifier, sizeof(lasreader->header.system_identifier), "LAStools (c) by rapidlasso GmbH", 32);
       lasreader->header.system_identifier[31] = '\0';
       char temp[64];
-      sprintf(temp, "lasprecision (%d)", LAS_TOOLS_VERSION);
-      strncpy(lasreader->header.generating_software, temp, 32);
+      snprintf(temp, sizeof(temp), "lasprecision (%d)", LAS_TOOLS_VERSION);
+      strncpy_las(lasreader->header.generating_software, sizeof(lasreader->header.generating_software), temp, 32);
       lasreader->header.generating_software[31] = '\0';
 
       if (projection_was_set)

--- a/src/lasprecision.vcxproj
+++ b/src/lasprecision.vcxproj
@@ -37,8 +37,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/lassrclib.vcxproj
+++ b/src/lassrclib.vcxproj
@@ -40,8 +40,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\src;..\LASzip\include\laszip;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/laszip.cpp
+++ b/src/laszip.cpp
@@ -863,7 +863,7 @@ int main(int argc, char *argv[])
         {
           wave_form_file_name = LASCopyString("wave_form.wdp");
         }
-        FILE* file = fopen(wave_form_file_name, "wb");
+        FILE* file = LASfopen(wave_form_file_name, "wb");
         if (file)
         {
           LASMessage(LAS_VERBOSE, "writing waveforms to '%s'", wave_form_file_name);

--- a/src/laszip.vcxproj
+++ b/src/laszip.vcxproj
@@ -36,8 +36,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/txt2las.cpp
+++ b/src/txt2las.cpp
@@ -244,7 +244,7 @@ int main(int argc, char* argv[])
       }
       i++;
       I32 point_type;
-      if (sscanf(argv[i], "%d", &point_type) != 1)
+      if (sscanf_las(argv[i], "%d", &point_type) != 1)
       {
         laserror("cannot understand argument '%s' of '%s'", argv[i], argv[i - 1]);
       }
@@ -271,17 +271,17 @@ int main(int argc, char* argv[])
       }
       F64 scale_factor[3];
       i++;
-      if (sscanf(argv[i], "%lf", &(scale_factor[0])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(scale_factor[0])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 1]);
       }
       i++;
-      if (sscanf(argv[i], "%lf", &(scale_factor[1])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(scale_factor[1])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 2]);
       }
       i++;
-      if (sscanf(argv[i], "%lf", &(scale_factor[2])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(scale_factor[2])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 3]);
       }
@@ -295,17 +295,17 @@ int main(int argc, char* argv[])
       }
       F64 offset[3];
       i++;
-      if (sscanf(argv[i], "%lf", &(offset[0])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(offset[0])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 1]);
       }
       i++;
-      if (sscanf(argv[i], "%lf", &(offset[1])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(offset[1])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 2]);
       }
       i++;
-      if (sscanf(argv[i], "%lf", &(offset[2])) != 1)
+      if (sscanf_las(argv[i], "%lf", &(offset[2])) != 1)
       {
         laserror("'%s' needs 3 arguments: x y z", argv[i - 3]);
       }
@@ -367,12 +367,12 @@ int main(int argc, char* argv[])
         laserror("'%s' needs 2 arguments: day year", argv[i]);
       }
       i++;
-      if (sscanf(argv[i], "%d", &file_creation_day) != 1)
+      if (sscanf_las(argv[i], "%d", &file_creation_day) != 1)
       {
         laserror("'%s' needs 2 arguments: day year", argv[i - 1]);
       }
       i++;
-      if (sscanf(argv[i], "%d", &file_creation_year) != 1)
+      if (sscanf_las(argv[i], "%d", &file_creation_year) != 1)
       {
         laserror("'%s' needs 2 arguments: day year", argv[i - 2]);
       }
@@ -384,7 +384,7 @@ int main(int argc, char* argv[])
         laserror("'%s' needs 1 argument: value", argv[i]);
       }
       i++;
-      if (sscanf(argv[i], "%d", &set_global_encoding) != 1)
+      if (sscanf_las(argv[i], "%d", &set_global_encoding) != 1)
       {
         laserror("'%s' needs 1 argument: value", argv[i - 1]);
       }
@@ -418,7 +418,7 @@ int main(int argc, char* argv[])
         laserror("'%s' needs 1 argument: major.minor", argv[i]);
       }
       i++;
-      if (sscanf(argv[i], "%d.%d", &set_version_major, &set_version_minor) != 2)
+      if (sscanf_las(argv[i], "%d.%d", &set_version_major, &set_version_minor) != 2)
       {
         laserror("cannot understand argument '%s' of '%s'", argv[i], argv[i - 1]);
       }
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
       {
         laserror("'%s' needs 1 argument: every", argv[i]);
       }
-      if (sscanf(argv[i + 1], "%u", &progress) != 1)
+      if (sscanf_las(argv[i + 1], "%u", &progress) != 1)
       {
         laserror("'%s' needs 1 argument: every but '%s' is no valid number", argv[i], argv[i + 1]);
       }
@@ -568,25 +568,24 @@ int main(int argc, char* argv[])
 
     if (set_system_identifier)
     {
-      strncpy(lasreader->header.system_identifier, set_system_identifier, 32);
-      lasreader->header.system_identifier[31] = '\0';
+      strncpy_las(lasreader->header.system_identifier, sizeof(lasreader->header.system_identifier), set_system_identifier, 32);
     }
     else
     {
-      strncpy(lasreader->header.system_identifier, "LAStools (c) by rapidlasso GmbH", 32);
-      lasreader->header.system_identifier[31] = '\0';
+      strncpy_las(lasreader->header.system_identifier, sizeof(lasreader->header.system_identifier), "LAStools (c) by rapidlasso GmbH", 32);
     }
+    lasreader->header.system_identifier[31] = '\0';
 
     memset(lasreader->header.generating_software, 0, 32);
     if (set_generating_software)
     {
-      strncpy(lasreader->header.generating_software, set_generating_software, 32);
+      strncpy_las(lasreader->header.generating_software, sizeof(lasreader->header.generating_software), set_generating_software, 32);
     }
     else
     {
       char temp[64];
-      sprintf(temp, "txt2las%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
-      strncpy(lasreader->header.generating_software, temp, 32);
+      snprintf(temp, sizeof(temp), "txt2las%s (version %d)", (IS64 ? "64" : ""), LAS_TOOLS_VERSION);
+      strncpy_las(lasreader->header.generating_software, sizeof(lasreader->header.generating_software), temp, 32);
     }
     lasreader->header.generating_software[31] = '\0';
 

--- a/src/txt2las.vcxproj
+++ b/src/txt2las.vcxproj
@@ -36,8 +36,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>..\LASzip\include\laszip;..\LASzip\src;..\LASlib\inc;..\LASlib\src;..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
- Removed or disabled all compiler warnings to ensure clean builds and better code quality. On Windows, replaced unsafe functions related to buffer overflow where possible.
- Added support for umlauts in filenames for both loading and writing files. Previously, there were issues due to ANSI encoded filenames being incorrectly converted.