### PR TITLE
fix LASattribute memory leak

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -324,6 +324,7 @@ public:
   void clean_las_header()
   {
     memset((void*)this, 0, sizeof(LASheader));
+    attributes_linked = TRUE;
     file_signature[0] = 'L'; file_signature[1] = 'A'; file_signature[2] = 'S'; file_signature[3] = 'F';
     version_major = 1;
     version_minor = 2;


### PR DESCRIPTION
clean_las_header function's memset ignores LasAttributer constructor's attributes_linked default value, which is supposed to be true. This in turn causes a leak for LASattribute malloc/realloc calls, they are not cleaned up from attributes_linked function.

I noticed this when running address sanitizer build on a simple example, like this:

```
void test_laswrite()
{
    LASwriteOpener laswriteopener;
    laswriteopener.set_file_name("test.las");

    LASheader lasheader;
    // lasheader.attributes_linked = true; workaround
    lasheader.point_data_format = 1;
    lasheader.point_data_record_length = 28;
    LASattribute attribute(2, "echo width", "full width at half maximum [ns]");
    lasheader.add_attribute(attribute);
    lasheader.update_extra_bytes_vlr();
    lasheader.point_data_record_length += lasheader.get_attributes_size();

    LASwriter* laswriter = laswriteopener.open(&lasheader);
    laswriter->close();
    delete laswriter;
}
```

I have a workaround commented out in this example: set attributes_linked to true. But it would be better if it was part of lasdefinitions.hpp's clean_las_header function like in my pull request.