### PR TITLE
Fix insecure printf

### DIFF
--- a/src/geoprojectionconverter.cpp
+++ b/src/geoprojectionconverter.cpp
@@ -4370,7 +4370,7 @@ bool GeoProjectionConverter::set_VerticalCSTypeGeoKey(short value, char* descrip
             // this is where the name ends
             line[run] = '\0';
           }
-          if (description) sprintf(description, name);
+          if (description) sprintf(description, "%s", name);
           run++;
           // skip two commas
           while (line[run] != ',') run++;


### PR DESCRIPTION
Second argument shall be const. Fixes compiler complaints.

Using the same pattern as already uses in other parts of the file. Alternative: `strcpy(description, name)`.