### PR TITLE
Integrate PROJ library into LAStools for CRS transformations and meta data querying

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -50,7 +50,7 @@
 #ifndef LAS_DEFINITIONS_HPP
 #define LAS_DEFINITIONS_HPP
 
-#define LAS_TOOLS_VERSION 240805
+#define LAS_TOOLS_VERSION 240810
 
 #include <stdio.h>
 #include <string.h>

--- a/LASlib/src/lasfilter.cpp
+++ b/LASlib/src/lasfilter.cpp
@@ -2231,7 +2231,7 @@ BOOL LASfilter::parse(int argc, char* argv[])
             }
             if (classification > 31)
             {
-              laserror("'%s' needs arguments between 0 and 31 but '%u' is out of range", argv[i_in], classification);
+              laserror("'%s' needs arguments between 0 and 31 but '%u' is out of range (see -keep_extended_class)", argv[i_in], classification);
               return FALSE;
             }
             keep_classification_mask |= (1u << classification);

--- a/LASzip/liblaszip_static.vcxproj
+++ b/LASzip/liblaszip_static.vcxproj
@@ -30,6 +30,24 @@
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>src;inc;..\LASlib\inc;..\LASlib\src;include\laszip</AdditionalIncludeDirectories>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>..\$(Platform)\$(Configuration)\laslib64.lib;..\$(Platform)\$(Configuration)\lassrclib64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\lasmessage.cpp" />
     <ClCompile Include="src\mydefs.cpp" />

--- a/LASzip/src/mydefs.cpp
+++ b/LASzip/src/mydefs.cpp
@@ -30,6 +30,7 @@
 */
 #include "mydefs.hpp"
 #include <stdio.h>
+#include <cstring>
 #include <stdarg.h>
 #include "laszip_common.h"
 #include "lasmessage.hpp"
@@ -203,3 +204,40 @@ FILE* LASfopen(const char* const filename, const char* const mode)
   return file;
 }
 
+/// !!The caller is responsible for managing the memory of the returned const char*
+/// using 'delete[]' when done!!
+/// Indents each line of content by the given 'indent'
+const char* indent_text(const char* text, const char* indent)
+{
+  if (text == nullptr || indent == nullptr) return nullptr;
+
+  size_t indent_len = strlen(indent);
+  size_t text_len = strlen(text);
+
+  // Count the number of line breaks and calculate the length of the new buffer
+  size_t num_lines = 1;
+  for (size_t i = 0; i < text_len; ++i) {
+    if (text[i] == '\n') ++num_lines;
+  }
+  size_t new_len = text_len + num_lines * indent_len;
+  char* result = new char[new_len + 1];
+
+  const char* src = text;
+  char* dest = result;
+
+  // Add indentation prefix before each line
+  while (*src) {
+    // Add the indentation prefix
+    memcpy(dest, indent, indent_len);
+    dest += indent_len;
+
+    while (*src && *src != '\n') {
+      *dest++ = *src++;
+    }
+    // Add the line break, if available
+    if (*src == '\n') *dest++ = *src++;
+  }
+  *dest = '\0';
+
+  return result;
+}

--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -332,6 +332,7 @@ void byebye();
 bool validate_utf8(const char* utf8) noexcept;
 // Opens a file with the specified filename and mode, converting filename and mode to UTF-16 on Windows.
 FILE* LASfopen(const char* const filename, const char* const mode);
+const char* indent_text(const char* text, const char* indent);
 
 // las error message function which leads to an immediate program stop by default
 template<typename... Args>

--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -212,6 +212,12 @@ typedef union I64U32I32F32 { I64 i64; U32 u32[2]; I32 i32[2]; F32 f32[2]; } I64U
 #define strcat_las(dest, destsz, src) strcat((dest), (src))
 #endif
 
+#ifdef _MSC_VER
+#define strdup_las(string) _strdup(string);
+#else
+#define strdup_las(string) strdup(string);
+#endif
+
 inline BOOL IS_LITTLE_ENDIAN()
 {
   const U32 i = 1;

--- a/bin/las2iso_README.md
+++ b/bin/las2iso_README.md
@@ -133,7 +133,7 @@ the result in ESRI's Shapefile format.
 -simplify_area [n]         : simplify area contours < area of [n] (but may lead to crossing contours)  
 -simplify_length [n]       : simplify individual contours < length [n] (but may lead to crossing contours)  
 -smooth [n]                : do [n] smooth iterations (typical 2..20; default=0)  
--tin                       : write output.shp TIN  
+-tin                       : write output.shp TIN for lake breakline (require -lakes argument)  
 -use_orig_bb               : raster tile without buffer added by on-the-fly buffering  
 -use_tile_bb               : raster tile without buffer added by lastile  
 -week_to_adjusted [n]      : converts time stamps from GPS week [n] to Adjusted Standard GPS  

--- a/bin/las2las_README.md
+++ b/bin/las2las_README.md
@@ -197,8 +197,14 @@ point.Z<1000 or point.Z>4000 and stores all surviving points to out.las
 
 Available options for using the PROJ library for transformations between 
 Coordinate Reference Systems (CRSs). Specifying the source CRS is optional 
-for all commands. If no source CRS is specified, the tool will attempt to 
-extract this information from the header of the input file in.las.
+for all commands. If no source CRS is specified, the tool will attempt to extract this 
+information from the header of the input file in.las, which is recommended.
+There is a hierarchy for determining the source CRS for the PROJ transformation:
+1. the source CRS is passed as an argument.
+2. if not, the WKT is searched for in the header of the source file.
+3. if no WKT is available, it is generated from the GeoTIFF data.
+4. if this is not possible, the EPSG code from the GeoTIFF is used, which can lead to inaccuracies as GeoTIFF arguments could be ignored.
+
 Files with CompoundCRS are not yet supported for transformations using PROJ in LAStools.
 The recommended methods for specifying CRSs are the use of EPSG codes or 
 WKT representations, as these adhere to well-defined standards:

--- a/bin/las2las_README.md
+++ b/bin/las2las_README.md
@@ -195,6 +195,25 @@ point coordinates they represent). Drops all the points of in.las that have
 point.Z<1000 or point.Z>4000 and stores all surviving points to out.las 
 (use lasinfo.exe to see the range of point.Z).
 
+Available options for using the PROJ library for transformations between 
+Coordinate Reference Systems (CRSs). Specifying the source CRS is optional 
+for all commands. If no source CRS is specified, the tool will attempt to 
+extract this information from the header of the input file in.las.
+Files with CompoundCRS are not yet supported for transformations using PROJ in LAStools.
+The recommended methods for specifying CRSs are the use of EPSG codes or 
+WKT representations, as these adhere to well-defined standards:
+ 
+    las2las64 -i in.las -o out.las -proj_epsg 32633 4326
+    las2las64 -i in.las -o out.las -proj_wkt filename_source_wkt filename_target_wkt
+
+The methods using the json representation or the PROJ string are only recommended 
+for advanced and experienced users. When using the PROJ string, a single PROJ string 
+can also be used directly to describe the transformation or operation.
+
+    las2las64 -i in.las -o out.las -proj_json filename_source_json filename_target_json
+    las2las64 -i in.las -o out.las -proj_string "proj_string_source" "proj_string_target"
+
+Further examples
 
     las2las64 -h
     las2las64 -i *.las -utm 13N
@@ -212,7 +231,6 @@ point.Z<1000 or point.Z>4000 and stores all surviving points to out.las
     las2las64 -i in.las -drop_intensity_below 10 -olaz -stdout > out.laz
     las2las64 -i in.las -last_only -drop_gpstime_below 46.75 -otxt -oparse xyzt -stdout > out.txt
     las2las64 -i in.las -remove_all_vlrs -keep_class 2 3 4 -olas -stdout > out.las
-
 
 ## las2las specific arguments
 
@@ -772,6 +790,10 @@ point.Z<1000 or point.Z>4000 and stores all surviving points to out.las
 -nad83_harn                         : use datum NAD83_HARN  
 -nad83_pa11                         : set horizontal datum to NAD83 PA11  
 -osgb1936                           : use datum OSGB 1936  
+-proj_epsg [s] [t]           	    : (Recommended) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS [s] can be specified using EPSG code (deafult from the input file header). In addition, the target CRS [t] must be specified using EPSG code 
+-proj_wkt [s] [t]           	    : (Recommended) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS [s] can be specified by using a file with the WKR representation of the CRS (deafult from the input file header). In addition, the target CRS [t] must be specified using a file with the WKR representation of the CRS
+-proj_string [s] [t]           	    : (For experienced users) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS [s] can be specified using PRO string (deafult from the input file header). In addition, the target CRS [t] must be specified using PROJ string. Furthermore a single PROJ string [s] can also be specified, which directly describes a transformation or operation
+-proj_json [s] [t]           	    : (For experienced users) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS [s] can be specified by using a file with the PROJJSON representation of the CRS (deafult from the input file header). In addition, the target CRS [t] must be specified using a file with the PROJJSON representation of the CRS
 -sp27 SC_N                          : use the NAD27 South Carolina North state plane  
 -sp83 CO_S                          : use the NAD83 Colorado South state plane for georeferencing  
 -survey_feet                        : use survey feet  

--- a/bin/las2las_README.txt
+++ b/bin/las2las_README.txt
@@ -186,6 +186,24 @@ of in.las that have point.Z<1000 or point.Z>4000 and stores all
 surviving points to out.las (use lasinfo.exe to see the range of
 point.Z).
 
+Available options for using the PROJ library for transformations between 
+Coordinate Reference Systems (CRSs). Specifying the source CRS is optional 
+for all commands. If no source CRS is specified, the tool will attempt to 
+extract this information from the header of the input file in.las.
+Files with CompoundCRS are not yet supported for transformations using PROJ in LASTools.
+The recommended methods for specifying CRSs are the use of EPSG codes or 
+WKT representations, as these adhere to well-defined standards:
+ 
+>> las2las64 -i in.las -o out.las -proj_epsg 32633 4326
+>> las2las64 -i in.las -o out.las -proj_wkt filename_source_wkt filename_target_wkt
+
+The methods using the json representation or the PROJ string are only recommended 
+for advanced and experienced users. When using the PROJ string, a single PROJ string 
+can also be used directly to describe the transformation or operation.
+
+>> las2las64 -i in.las -o out.las -proj_json filename_source_json filename_target_json
+>> las2las64 -i in.las -o out.las -proj_string "proj_string_source" "proj_string_target"
+
 other commandline arguments are
 
 -auto_reoffset                 : puts a reasonable offset in the header and translates the points accordingly
@@ -278,7 +296,11 @@ other commandline arguments are
 -tm 1804461.942257 0.0 feet 0.8203047 -2.1089395 0.99996
 -lcc 609601.22 0.0 meter 33.75 -79 34.33333 36.16666      : specifies a lambertian conic confomal projection
 -lcc 1640416.666667 0.0 surveyfeet 47.000000 -120.833333 47.50 48.733333
--ellipsoid 23                                             : use ellipsoid WGS-84 (specify '-ellipsoid -1' for a list)
+-ellipsoid 23                    : use ellipsoid WGS-84 (specify '-ellipsoid -1' for a list)
+-proj_epsg 32633 4326     	 : (Recommended) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS can be specified using EPSG code (deafult from the input file header). In addition, the target CRS must be specified using EPSG code 
+-proj_wkt filename_source_wkt filename_target_wkt : (Recommended) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS can be specified by using a file with the WKR representation of the CRS (deafult from the input file header). In addition, the target CRS must be specified using a file with the WKR representation of the CRS
+-proj_string "proj_string_source" "proj_string_target" : (For experienced users) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS can be specified using PRO string (deafult from the input file header). In addition, the target CRS must be specified using PROJ string. Furthermore a single PROJ string can also be specified, which directly describes a transformation or operation
+-proj_json filename_source_json filename_target_json : (For experienced users) uses the PROJ lib to perform a CRS transformation. Optionally, the source CRS can be specified by using a file with the PROJJSON representation of the CRS (deafult from the input file header). In addition, the target CRS must be specified using a file with the PROJJSON representation of the CRS
 
 for more info:
 

--- a/bin/las2las_README.txt
+++ b/bin/las2las_README.txt
@@ -188,9 +188,15 @@ point.Z).
 
 Available options for using the PROJ library for transformations between 
 Coordinate Reference Systems (CRSs). Specifying the source CRS is optional 
-for all commands. If no source CRS is specified, the tool will attempt to 
-extract this information from the header of the input file in.las.
-Files with CompoundCRS are not yet supported for transformations using PROJ in LASTools.
+for all commands. If no source CRS is specified, the tool will attempt to extract this 
+information from the header of the input file in.las, which is recommended.
+There is a hierarchy for determining the source CRS for the PROJ transformation:
+1. the source CRS is passed as an argument.
+2. if not, the WKT is searched for in the header of the source file.
+3. if no WKT is available, it is generated from the GeoTIFF data.
+4. if this is not possible, the EPSG code from the GeoTIFF is used, which can lead to inaccuracies as GeoTIFF arguments could be ignored.
+
+Files with CompoundCRS are not yet supported for transformations using PROJ in LAStools.
 The recommended methods for specifying CRSs are the use of EPSG codes or 
 WKT representations, as these adhere to well-defined standards:
  

--- a/bin/lascopy_README.md
+++ b/bin/lascopy_README.md
@@ -76,13 +76,13 @@ within 0.5 units in source exists. Set all other z-values to 0.
 -copy_overlap_flag    : copy overlap flag to target (64bit only)  
 -copy_synthetic_flag  : copy synthetic flag to target (64bit only)  
 -copy_withheld_flag   : copy withheld flag to target (64bit only)  
--classification       : Deprecated: copy classification attribute (may be removed in futrue - replaced by copy_classification)  
--elevation            : Deprecated: copy elevation attribute (may be removed in futrue - replaced by copy_elevation)  
--intensity            : Deprecated: copy intensity attribute (may be removed in futrue - replaced by copy_intensity)  
--keypoint_flag        : Deprecated: copy keypoint flag to target (may be removed in futrue - replaced by copy_keypoint_flag)  
--overlap_flag         : Deprecated: copy overlap flag to target (may be removed in futrue - replaced by copy_overlap_flag)  
--synthetic_flag       : Deprecated: copy synthetic flag to target (may be removed in futrue - replaced by copy_synthetic_flag)  
--withheld_flag        : Deprecated: copy withheld flag to target (may be removed in futrue - replaced by copy_ithheld_flag)  
+-classification       : Deprecated: copy classification attribute (may be removed in future - replaced by copy_classification)  
+-elevation            : Deprecated: copy elevation attribute (may be removed in future - replaced by copy_elevation)  
+-intensity            : Deprecated: copy intensity attribute (may be removed in future - replaced by copy_intensity)  
+-keypoint_flag        : Deprecated: copy keypoint flag to target (may be removed in future - replaced by copy_keypoint_flag)  
+-overlap_flag         : Deprecated: copy overlap flag to target (may be removed in future - replaced by copy_overlap_flag)  
+-synthetic_flag       : Deprecated: copy synthetic flag to target (may be removed in future - replaced by copy_synthetic_flag)  
+-withheld_flag        : Deprecated: copy withheld flag to target (may be removed in future - replaced by copy_ithheld_flag)  
 -zero                 : set attribute of points to zero if not found in source  
 -unmatched            : copy attributes from source to target by point order  
 -ilay [n]             : apply [n] or all LASlayers found in corresponding *.lay file on read  

--- a/bin/lasinfo_README.md
+++ b/bin/lasinfo_README.md
@@ -226,19 +226,31 @@ without checking whether this will corrupt the file.
 CAREFUL! sets the start of waveform data packet record field of the LAS header
 to 0 without checking whether this will corrupt the file.
 
+Querying CRS representations and information, based on the input file.
+The [wkt] WKT representation, the [js] PROJJSON representation, the [str] PROJ string, 
+the [epsg] EPSG code, the [el] ellipsoid information, the [datum] datum information and 
+the [cs] coordinate system information can be queried.
+CAREFUL! If a CRS object was not created from a PROJ string, exporting it to a PROJ string will in 
+most cases lead to a loss of information. This can potentially lead to incorrect transformations. 
+The use of PROJ strings should only be used with advanced knowledge.
 
-lasinfo64 -i lidar.las  
-lasinfo64 -i lidar.las -compute_density -o lidar_info.txt  
-lasinfo64 -i *.las  
-lasinfo64 -i *.las -single -otxt  
-lasinfo64 -no_header -no_vlrs -i lidar.laz  
-lasinfo64 -nv -nc -stdout -i lidar.las  
-lasinfo64 -nv -nc -stdout -i *.laz -single | grep version  
-lasinfo64 -i *.laz -subseq 100000 100100 -histo user_data 8  
-lasinfo64 -i *.las -repair  
-lasinfo64 -i *.laz -repair_bb -set_file_creation 8 2007  
-lasinfo64 -i *.las -repair_counters -set_version 1.2  
-lasinfo64 -i *.laz -set_system_identifier "hello world!" -set_generating_software "this is a test (-:"
+    lasinfo64 -i lidar.las -proj_info wkt js str epsg el datum cs
+
+
+Further examples
+
+    lasinfo64 -i lidar.las  
+    lasinfo64 -i lidar.las -compute_density -o lidar_info.txt  
+    lasinfo64 -i *.las  
+    lasinfo64 -i *.las -single -otxt  
+    lasinfo64 -no_header -no_vlrs -i lidar.laz  
+    lasinfo64 -nv -nc -stdout -i lidar.las  
+    lasinfo64 -nv -nc -stdout -i *.laz -single | grep version  
+    lasinfo64 -i *.laz -subseq 100000 100100 -histo user_data 8  
+    lasinfo64 -i *.las -repair  
+    lasinfo64 -i *.laz -repair_bb -set_file_creation 8 2007  
+    lasinfo64 -i *.las -repair_counters -set_version 1.2  
+    lasinfo64 -i *.laz -set_system_identifier "hello world!" -set_generating_software "this is a test (-:"
 
 
 ## lasinfo specific arguments
@@ -268,6 +280,7 @@ lasinfo64 -i *.laz -set_system_identifier "hello world!" -set_generating_softwar
 -nw                                 : don't output WARNINGs  
 -otxt                               : output as textfile  
 -progress [n]                       : report progress every [n] points  
+-proj_info [wkt] [js] [str] [epsg] [el] [datum] [cs] : get CRS representations and information of the input file: [wkt] WKT, [js] PROJJSON, [str] PROJ string or [epsg] EPSG code representation and [el] ellipsoid, [datum] datum or [cs] coordinate system information.
 -rename [n]                         : renames input file 'fusa.laz' to '[n]_277750_6122250.laz'  
 -repair                             : repair both bounding box and counters  
 -repair_bb                          : repair bounding box  

--- a/bin/lasinfo_README.md
+++ b/bin/lasinfo_README.md
@@ -51,6 +51,25 @@ listed in the GUI are:
 -auto_date
 -set_global_encoding 1
 
+lasinfo provides detail information about this VLR records:
+    (user_id/record_id) 
+    LASF_Projection
+       34735 (GeoTIFF GeoKeyDirectoryTag)
+       34736 (GeoTIFF GeoDoubleParamsTag)
+       34737 (GeoTIFF GeoAsciiParamsTag)
+       2111 (OGC Math Transform WKT)
+       2112 (OGC Coordinate System WKT)
+    LASF_Spec      
+       0 (Classification Lookup)
+       2 (Histogram)
+       3 (Text Area Description)
+       4 (Extra Bytes)
+       100..354 (Waveform Packet Descriptor)
+    Raster LAZ
+       7113 Raster LAZ information
+    copc
+       1 copc information
+
 ## Examples
 
     lasinfo64 lidar.las
@@ -264,6 +283,8 @@ Further examples
 -delete_empty                       : delete LAS files with zero points  
 -gps_week                           : compute the GPS week (if data is Adjusted Standard GPS time)  
 -gw                                 : compute the GPS week (if data is Adjusted Standard GPS time)  
+-histo [m] [n]                      : histogram output about [m] with step width [n]  
+-histo_avg [m] [n] [o]              : histogram output about [m] with step width [n] and average [o]  
 -nc                                 : don't parse points (only check header and VLRs)  
 -nco                                : don't check whether points fall outside of LAS header bounding box  
 -nh                                 : don't output LAS header information  
@@ -342,7 +363,6 @@ Further examples
 -buffered [n]          : define read or write buffer of size [n]{default=262144}  
 -chunk_size [n]        : set chunk size [n] in number of bytes  
 -comma_not_point       : use comma instead of point as decimal separator  
--histo_avg [m] [n] [o] : histogram output about [m] with step width [n] and average [o]  
 -neighbors [n]         : set neighbors filename or wildcard [n]  
 -neighbors_lof [n]     : set neighbors list of files [fnf]  
 -stored                : use in memory reader  
@@ -911,6 +931,34 @@ Supported [sep] values:
   semicolon
   hyphen
   space
+
+### aggregate options
+This parameters can be used in "-histo" and "-histo_avg" argument as first parameter  
+    x                     : x coordinate  
+    y                     : x coordinate  
+    z                     : x coordinate  
+    X                     : X integer data value  
+    Y                     : X integer data value  
+    Z                     : X integer data value  
+    intensity  
+    classification  
+    extended_scan_angle  
+    scan_angle  
+    return_number  
+    number_of_returns  
+    user_data  
+    point_source  
+    gps_time  
+    scanner_channel  
+    R                    : RGB red value
+    G                    : RGB green value
+    B                    : RGB blue value
+    I                    : intensity
+    attribute0..9        : extra byte attribute value
+    wavepacket_index  
+    wavepacket_offset  
+    wavepacket_size  
+    wavepacket_location  
 
 ## License
 

--- a/bin/lasinfo_README.txt
+++ b/bin/lasinfo_README.txt
@@ -211,6 +211,16 @@ without checking whether this will corrupt the file.
 CAREFUL! sets the start of waveform data packet record field of the LAS header
 to 0 without checking whether this will corrupt the file.
 
+Querying CRS representations and information, based on the input file.
+The [wkt] WKT representation, the [js] PROJJSON representation, the [str] PROJ string, 
+the [epsg] EPSG code, the [el] ellipsoid information, the [datum] datum information and 
+the [cs] coordinate system information can be queried.
+CAREFUL! If a CRS object was not created from a PROJ string, exporting it to a PROJ string will in 
+most cases lead to a loss of information. This can potentially lead to incorrect transformations. 
+The use of PROJ strings should only be used with advanced knowledge.
+
+>> lasinfo64 -i lidar.las -proj_info wkt js str epsg el datum cs
+
 ****************************************************************
 
 overview of all tool-specific switches:
@@ -233,6 +243,7 @@ overview of all tool-specific switches:
 -cd or -compute_density              : compute rough approximation for covered area, density, and spacing
 -gw or -gps_week                     : compute the GPS week (if data is Asjusted Standard GPS time)
 -nco or -no_check_outside            : don't check whether points fall outside of LAS header bounding box
+-proj_info wkt js str epsg el datum cs : get CRS representations and information of the input file: WKT, PROJJSON, PROJ string or EPSG code representation and ellipsoid, datum or coordinate system information.
 -ro or -report_outside               : report attributes of each point that falls outside of LAS header bounding box
 -subseq 1000000 2000000              : only load subsequence from 1 millionth to 2 millionth point
 -start_at_point 1500000              : start loading from point at position 1500000 in the file

--- a/bin/lasmerge_README.md
+++ b/bin/lasmerge_README.md
@@ -33,7 +33,7 @@ Similarly a new offset can be specified
     -reoffset 600000 4000000 0
 
 
-# See also
+## See also
 
   lassplit - Merge or split lidar data files by properties
 

--- a/bin/lassplit_README.md
+++ b/bin/lassplit_README.md
@@ -40,7 +40,7 @@ offset only for the new point_source.
 If the id is negative it will be set to '1000000-id'.
 Point_source of points is limited/mapped to a unsigned 16 Bit integer.
  
-# See also
+## See also
 
 lasmerge - Merge or split lidar data files by number of points
 

--- a/bin/proj_README.md
+++ b/bin/proj_README.md
@@ -1,0 +1,146 @@
+# proj lib
+
+PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. 
+This includes cartographic projections as well as geodetic transformations. 
+It is utilized in the LAS tool (las2las) to transform LiDAR data between various coordinate reference systems and to 
+retrieve detailed represenations and information about CRS (lasinfo).
+
+**Key features include:**
+- Transformation of point coordinates between different CRS.
+- Conversion and representation of CRS in various formats (EPSG, WKT, PROJ string, PROJJSON).
+- Retrieval of metadata such as ellipsoids, axes, and datum information related to a CRS.
+
+The integration of the PROJ library provides a flexible and powerful means to perform geodetic transformations directly within the LAStools.
+
+The source code for the PROJ library is available at https://github.com/OSGeo/PROJ.
+
+PROJ is released under the X/MIT open source License.
+For more information about the license and usage of the PROJ library, 
+refer to the official PROJ repository or the official website https://proj.org.
+
+## Installing the PROJ Library
+
+To use the PROJ library in LAStools, it must be installed on your system (possibly via qigis or OSGeo4W).
+If the PROJ library is not already installed, here are several methods to install it:
+
+### Package Managers
+
+- **Conda**: Install PROJ with the following command:
+  ```
+  conda install -c conda-forge proj
+  ```
+  And for the PROJ data:
+  ```
+  conda install -c conda-forge proj-data
+  ```
+- **Docker**: Get the Docker image with:
+  ```
+  docker pull osgeo/proj
+  ```
+### QGIS/OSGeo4W Installation
+
+By installing QGIS, you automatically get the PROJ library installed and configured.
+- **Windows**:
+ 1. Download the QGIS installer from the [QGIS setup](https://www.qgis.org/download/).
+ 2. Run the installer and follow the installation steps.
+ 3. Once QGIS is installed, the PROJ library will be available.
+                
+ - Or use the [OSGeo4W setup](https://download.osgeo.org/osgeo4w/v2/) and select "proj" under   "Commandline_Utilities".
+  The OSGeo4W installer allows you to install QGIS along with the PROJ library.
+
+- **Linux**:
+  **Debian/Ubuntu**:
+  QGIS can also be installed on Linux distributions, which will include the PROJ library.
+ 1. Add the QGIS repository:
+    ```bash
+    sudo add-apt-repository ppa:ubuntugis/ppa
+    sudo apt update
+    ```
+ 2. Install QGIS:
+    ```
+    sudo apt install qgis qgis-plugin-grass
+    ```
+     The PROJ library is now installed with QGIS.
+     
+     **Fedora:**:
+      ```
+      sudo dnf install qgis qgis-grass
+      ```
+
+### Further installation options
+- **Linux**:
+  **Debian/Ubuntu**:
+  ```
+  sudo apt-get install proj-bin
+  ```
+  **Fedora**:
+  ```
+  sudo dnf install proj
+  ```
+  **Red Hat**:
+  ```
+  sudo yum install proj
+  ```
+
+- **Mac OS X**:
+  Using Homebrew:
+  ```
+  brew install proj
+  ```
+  Or MacPorts:
+  ```
+  sudo port install proj
+  ```
+
+### Required Files for PROJ in LASTools
+
+To ensure that the PROJ library functions correctly with LASTools, you need to have the following library files available:
+
+- `proj`
+- `libcrypto`
+- `libcurl`
+- `libssl`
+- `sqlite3`
+- `tiff`
+- `zlib`
+
+Additionally, ensure that the PROJ data files, including the `proj.db`, are installed for full functionality.
+
+### File and Data Locations
+
+- **`file` and `data` standart Directories**: If LAStools uses the PROJ library, the files and data of the library are automatically searched for in the standard directories of the installation via Conda or QGIS/OSGeo4W.  
+
+- **Custom Directory**: Alternatively, you can place the library files and PROJ data in custom     directories of your choice. To use these custom directories, set the environment variables as follows:
+  ```
+  set LASTOOLS_PROJ=...
+  ```
+  for the PROJ library directory, and
+  ```
+  set PROJ_LIB=...
+  ```
+  for the PROJ data directory.
+
+### Important Note
+
+Ensure that the version of the PROJ data matches the version of the PROJ library to avoid compatibility issues.
+For more information and detailed instructions about the installation, refer to the official PROJ installation page  https://proj.org/install.html
+
+## License
+
+This library is free to use.
+
+## Support
+
+To get more information about a LAStool just goto the
+[LAStools Google Group](http://groups.google.com/group/lastools/)
+and enter the tool name in the search function.
+You will get plenty of samples to this tool.
+
+To get further support see our
+[rapidlasso service page](https://rapidlasso.de/service/)
+
+Check for latest updates at
+https://rapidlasso.de/category/blog/releases/
+
+If you have any suggestions please let us (info@rapidlasso.de) know.
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,15 +28,15 @@ set(STANDALONE_TARGETS
 set(ALL_TARGETS ${GEOPROJECTION_TARGETS} ${STANDALONE_TARGETS})
 
 foreach(TARGET ${GEOPROJECTION_TARGETS})
-	add_executable(${TARGET} ${TARGET}.cpp geoprojectionconverter.cpp)
+	add_executable(${TARGET} ${TARGET}.cpp geoprojectionconverter.cpp proj_loader.cpp)
 endforeach(TARGET)
 
 foreach(TARGET ${STANDALONE_TARGETS})
-	add_executable(${TARGET} ${TARGET}.cpp)
+	add_executable(${TARGET} ${TARGET}.cpp proj_loader.cpp)
 endforeach(TARGET)
 
 foreach(TARGET ${ALL_TARGETS})
-	set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 14)
+	set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
 	target_link_libraries(${TARGET} LASlib)
 	set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin64)
 	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET}64)

--- a/src/geoprojectionconverter.cpp
+++ b/src/geoprojectionconverter.cpp
@@ -5600,10 +5600,8 @@ bool GeoProjectionConverter::set_epsg_code(short value, char* description, bool 
   bool longlat = false;
   bool ecef = false;
 
-  if (source)
-  {
-    source_header_epsg = value;
-  }
+  if (source) source_header_epsg = value;
+  if (is_proj_request) return true;
 
   if ((value >= 32601) && (value <= 32660)) // PCS_WGS84_UTM_zone_1N - PCS_WGS84_UTM_zone_60N
   {

--- a/src/geoprojectionconverter.cpp
+++ b/src/geoprojectionconverter.cpp
@@ -815,6 +815,336 @@ static const StatePlaneTM state_plane_tm_nad83_list[] =
 static const short EPSG_CH1903_LV03 = 21781;
 static const short EPSG_EOV_HD72 = 23700;
 
+ProjParameters::ProjParameters()
+    : arg_count(0),
+      max_param(7),
+      valid_proj_info_params{"wkt", "js", "str", "epsg", "el", "datum", "cs"},
+      header_wkt_representation(nullptr),
+      proj_crs_infos(nullptr),
+      proj_ctx(nullptr),
+      proj_source_crs(nullptr),
+      proj_target_crs(nullptr),
+      proj_transform_crs(nullptr),
+      proj_info_args(nullptr)
+{
+}
+
+ProjParameters::~ProjParameters()
+{
+  // Free the WKT representation if it was dynamically allocated
+  delete[] header_wkt_representation;
+  delete[] proj_crs_infos;
+
+  // Free the PROJ context
+  if (proj_ctx)  {
+    proj_context_destroy(proj_ctx);
+    proj_ctx = nullptr;  // Set to nullptr to avoid dangling pointers
+  }
+  // Free the source CRS
+  if (proj_source_crs)  {
+    proj_destroy(proj_source_crs);
+    proj_source_crs = nullptr;
+  }
+  // Free the target CRS
+  if (proj_target_crs)  {
+    proj_destroy(proj_target_crs);
+    proj_target_crs = nullptr;
+  }
+  // Free the transform CRS
+  if (proj_transform_crs)  {
+    proj_destroy(proj_transform_crs);
+    proj_transform_crs = nullptr;
+  }
+  //Release memory if proj_info_args
+  if (proj_info_args) {
+    for (int i = 0; i < arg_count; ++i) {
+      free(proj_info_args[i]);
+    }
+    free(proj_info_args);
+  }
+  unload_proj_library();
+}
+
+/// Method for setting ProjParameter members and their memory management
+void ProjParameters::set_proj_member(char*& member, const char* value)
+{
+  // Release previous memory to avoid memory leak
+  delete[] member;
+  if (value) {
+    member = new char[strlen(value) + 1];
+    strcpy_las(member, strlen(value) + 1, value);
+  } else {
+    member = nullptr;
+  }
+}
+
+/// Returns the target CRS WKT representation after a PROJ transformation for the header metadata
+const char* ProjParameters::get_target_header_wkt_representation()
+{
+  if (header_wkt_representation) {
+    return header_wkt_representation;
+  }
+  return nullptr;
+}
+
+/// Creates the WKT representation of the CRS for the file header
+void ProjParameters::set_header_wkt_representation(PJ* proj_crs)
+{
+  // Calling up and outputting the WKT display
+  if (proj_ctx && proj_crs) {
+    const char* wkt_representation = proj_as_wkt(proj_ctx, proj_crs, PJ_WKT2_2019, nullptr);
+
+    if (!wkt_representation) {
+      LASMessage(LAS_SERIOUS_WARNING, "The WKT representation could not be generated and could not be written to the output file header! It is therefore not possible to determine the CRS of the file.");
+    }
+    set_proj_member(header_wkt_representation, wkt_representation);
+  }
+}
+
+/// returns the WKT representation of the PROJ crs 
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_wkt_representation(bool source /*=true*/) const
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    // Retrieving and outputting the WKT representation
+    const char* wkt = proj_as_wkt(proj_ctx, source ? proj_source_crs : proj_target_crs, PJ_WKT2_2019, nullptr);
+    if (!wkt) {
+      laserror("The WKT representation of the PROJ CRS could not be generated.");
+    }
+    return wkt;
+  }
+  return nullptr;
+}
+
+/// returns the json representation of the PROJ crs 
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_json_representation(bool source /*=true*/) const
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    // Retrieving and outputting the JSON representation
+    const char* json = proj_as_projjson(proj_ctx, source ? proj_source_crs : proj_target_crs, nullptr);
+    if (!json) {
+      laserror("The json representation of the PROJ CRS could not be generated.");
+    }
+    return json;
+  }
+  return nullptr;
+}
+
+/// returns the PROj string representation of the PROJ crs 
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_projString_representation(bool source /*=true*/) const
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    // Retrieving and outputting the PROJ string representation
+    const char* projString = proj_as_proj_string(proj_ctx, source ? proj_source_crs : proj_target_crs, PJ_PROJ_5, nullptr);
+    if (!projString) {
+      laserror("The PROJ string representation of the PROJ CRS could not be generated.");
+    }
+    return projString;
+  }
+  return nullptr;
+}
+
+/// returns the epsg representation of the PROJ crs
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_epsg_representation(bool source /*=true*/) const
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    // Run through all identification codes
+    for (int i = 0;; ++i) {
+      const char* id_code = proj_get_id_code(source ? proj_source_crs : proj_target_crs, i);
+
+      if (!id_code) break;  
+
+      return id_code; 
+    }
+  }
+  return nullptr;
+}
+
+/// returns the ellipsoid information of the PROJ crs
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_ellipsoid_info(bool source /*=true*/)
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    PJ* ellipsoid = proj_get_ellipsoid(proj_ctx, source ? proj_source_crs : proj_target_crs);
+
+    if (ellipsoid) {
+      double semi_major_metre = 0.0;
+      double semi_minor_metre = 0.0;
+      int is_semi_minor_computed = 0;
+      double inv_flattening = 0.0;
+
+      // Retrieving the ellipsoid parameters
+      int result = proj_ellipsoid_get_parameters(proj_ctx, ellipsoid, &semi_major_metre, &semi_minor_metre, &is_semi_minor_computed, &inv_flattening);
+
+      if (result == 0) {
+        proj_destroy(ellipsoid);
+        laserror("Failed to retrieve ellipsoid parameters.");
+      }
+      proj_crs_infos = new char[200];
+      snprintf(
+          proj_crs_infos, 200,
+          "Semi-Major Axis: %.3f meters\n"
+          "Semi-Minor Axis: %.3f meters %s\n"
+          "Inverse Flattening: %.6f",
+          semi_major_metre, semi_minor_metre, is_semi_minor_computed ? " (computed)" : "", inv_flattening);
+
+      proj_destroy(ellipsoid); 
+      return proj_crs_infos;
+    }
+  }
+  return nullptr;
+}
+
+/// returns the datum information of the PROJ crs
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_datum_info(bool source /*=true*/)
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    PJ* datum_ensemble = proj_crs_get_datum_ensemble(proj_ctx, source ? proj_source_crs : proj_target_crs);
+
+    if (datum_ensemble) {
+      const char* datum_name = proj_get_name(source ? proj_source_crs : proj_target_crs);
+      int member_count = proj_datum_ensemble_get_member_count(proj_ctx, datum_ensemble);
+      double accuracy = proj_datum_ensemble_get_accuracy(proj_ctx, datum_ensemble);
+
+      // Formatted output of date information
+      proj_crs_infos = new char[1024];
+      int offset = 0;
+
+      // Formatted output of the basic information
+      offset += snprintf(
+          proj_crs_infos + offset, sizeof(proj_crs_infos) - offset,
+          "Name: %s\n"
+          "Accuracy: %.2f\n",
+          datum_name ? datum_name : "Unknown", accuracy);
+
+      // Get and format member information
+      for (int i = 0; i < member_count; ++i) {
+        PJ* member = proj_datum_ensemble_get_member(proj_ctx, datum_ensemble, i);
+        if (member){
+          const char* member_name = proj_get_name(member);         
+          if (member_name) {
+            offset += snprintf(proj_crs_infos + offset, sizeof(proj_crs_infos) - offset, "Member %d: %s%s", i + 1, member_name, (i < member_count - 1) ? "\n" : "");
+          }
+          proj_destroy(member);
+        }      
+      }
+      proj_destroy(datum_ensemble); 
+      return proj_crs_infos;
+    } else {
+      // If the date is not available as an ensemble, get it directly
+      PJ* datum = proj_crs_get_datum(proj_ctx, source ? proj_source_crs : proj_target_crs);
+      if (datum) {
+        const char* datum_name = proj_get_name(datum);
+        if (datum_name) {
+          proj_crs_infos = new char[256];
+          snprintf(proj_crs_infos, sizeof(proj_crs_infos), "Name: %s\n", datum_name);
+          return proj_crs_infos;
+        }
+      }
+      proj_destroy(datum);
+    }
+  }
+  return nullptr;
+}
+
+/// returns the coord system information of the PROJ crs
+/// IMPORTANT: the proj context and the PROJ crs object must have been created before calling the function
+const char* ProjParameters::get_coord_system_info(bool source /*=true*/)
+{
+  if (proj_ctx && ((proj_source_crs && source) || (proj_target_crs && !source))) {
+    PJ* coord_system = proj_crs_get_coordinate_system(proj_ctx, source ? proj_source_crs : proj_target_crs);
+
+    if (coord_system) {
+      PJ_COORDINATE_SYSTEM_TYPE cs_type = proj_cs_get_type(proj_ctx, coord_system);
+
+      const int buffer_size = 2048;
+      proj_crs_infos = new char[buffer_size];
+      proj_crs_infos[0] = '\0';
+
+      // Add the type of coordinate system
+      switch (cs_type) {
+        case PJ_CS_TYPE_CARTESIAN:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Cartesian Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_ELLIPSOIDAL:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Ellipsoidal Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_VERTICAL:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Vertical Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_SPHERICAL:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Spherical Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_ORDINAL:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Ordinal Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_PARAMETRIC:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Parametric Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_DATETIMETEMPORAL:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Date/Time Temporal Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_TEMPORALCOUNT:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Temporal Count Coordinate System\n");
+          break;
+        case PJ_CS_TYPE_TEMPORALMEASURE:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Temporal Measure Coordinate System\n");
+          break;
+        default:
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, "Unknown Coordinate System Type\n");
+          break;
+      }
+      // Retrieving the axis information
+      int axis_count = proj_cs_get_axis_count(proj_ctx, coord_system);
+      if (axis_count > 0) {
+        for (int i = 0; i < axis_count; ++i) {
+          const char* axis_name = nullptr;
+          const char* axis_abbreviation = nullptr;
+          const char* axis_direction = nullptr;
+          double unit_conv_factor = 0.0;
+          const char* unit_name = nullptr;
+          const char* unit_auth_name = nullptr;
+          const char* unit_code = nullptr;
+
+          proj_cs_get_axis_info(proj_ctx, coord_system, i, &axis_name, &axis_abbreviation, &axis_direction, &unit_conv_factor, &unit_name, &unit_auth_name, &unit_code);
+
+          // Attach the axis information
+          char axis_info[512]; 
+     
+          snprintf(
+              axis_info, sizeof(axis_info),
+              "Axis %d:\n  Abbreviation: %s\n  Direction: %s\n  Unit: %s (Conversion factor: %f)%s", i + 1,
+              axis_abbreviation ? axis_abbreviation : "Unknown", axis_direction ? axis_direction : "Unknown",
+              unit_name ? unit_name : "Unknown", unit_conv_factor, (i < axis_count - 1) ? "\n" : "");
+
+          strcat_las(proj_crs_infos, buffer_size - strlen(proj_crs_infos) - 1, axis_info);
+        }
+      }
+      proj_destroy(coord_system);
+
+      return proj_crs_infos;
+    } else {
+      laserror("The coordinate system of the PROJ CRS could not be generated.");
+    }
+  }
+  return nullptr;
+}
+
+/// Checks whether the PROJ info argument was present in the cmd
+bool ProjParameters::proj_info_arg_contains(const char* arg) const
+{
+  for (int i = 0; i < arg_count; i++) {
+    if (strcmp(proj_info_args[i], arg) == 0) {
+      return true; 
+    }
+  }
+  return false;
+}
+
 bool GeoProjectionConverter::set_projection_from_geo_keys(int num_geo_keys, const GeoProjectionGeoKeys* geo_keys, char* geo_ascii_params, double* geo_double_params, char* description, bool source)
 {
   bool user_defined_ellipsoid = false;
@@ -5270,6 +5600,11 @@ bool GeoProjectionConverter::set_epsg_code(short value, char* description, bool 
   bool longlat = false;
   bool ecef = false;
 
+  if (source)
+  {
+    source_header_epsg = value;
+  }
+
   if ((value >= 32601) && (value <= 32660)) // PCS_WGS84_UTM_zone_1N - PCS_WGS84_UTM_zone_60N
   {
     utm_northern = true; utm_zone = value-32600;
@@ -5623,8 +5958,8 @@ bool GeoProjectionConverter::set_epsg_code(short value, char* description, bool 
             return true;
           }
           else
-          {
-          LASMessage(LAS_WARNING, "transform %d of EPSG code %d not implemented.", transform, value);
+          {       
+            LASMessage(LAS_WARNING, "transform %d of EPSG code %d not implemented.", transform, value);
             return false;
           }
         }
@@ -7312,6 +7647,10 @@ GeoProjectionConverter::GeoProjectionConverter()
   target_elevation_precision = 0;
 
   elevation_offset_in_meter = 0.0f;
+
+  check_header_for_crs = false;
+  is_proj_request = false;
+  source_header_epsg = 0;
 }
 
 GeoProjectionConverter::~GeoProjectionConverter()
@@ -7638,6 +7977,258 @@ void GeoProjectionConverter::parse(int argc, char* argv[])
         }
       }
       *argv[i]='\0'; *argv[i+1]='\0'; i+=1;
+    }
+    //proj lib transformation
+    else if (strcmp(argv[i], "-proj_epsg") == 0) {
+      unsigned int source_code = 0;
+      unsigned int target_code = 0;
+
+      // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+      load_proj_library(nullptr);
+
+      if (argv[i + 1] != nullptr && argv[i + 1][0] != '\0' && argv[i + 1][0] != '-' && 
+          argv[i + 2] != nullptr && argv[i + 2][0] != '\0' && argv[i + 2][0] != '-')
+      {
+        if (sscanf_las(argv[i + 1], "%u", &source_code) != 1)
+        {
+          laserror("EPSG code from source '%s' not valid", argv[i + 1]);
+        }
+        if (sscanf_las(argv[i + 2], "%u", &target_code) != 1)
+        {
+          laserror("EPSG code for the target '%s' not valid", argv[i + 2]);
+        }
+        set_proj_param_for_transformation_with_epsg(source_code, target_code);
+        *argv[i] = '\0'; *argv[i + 1] = '\0'; *argv[i + 2] = '\0'; i += 2;
+      }
+      else if (argv[i + 1] != nullptr && argv[i + 1][0] != '\0' && argv[i + 1][0] != '-')
+      {
+        if (sscanf_las(argv[i + 1], "%u", &target_code) != 1)
+        {
+          laserror("EPSG code from source '%s' not valid", argv[i + 1]);
+        }
+        set_proj_crs_with_epsg(target_code, false);
+        check_header_for_crs = true;
+        *argv[i] = '\0'; *argv[i + 1] = '\0'; i += 1;
+      }
+      else {
+        laserror("'%s' needs at least 1 argument: target PROJ epsg code not specified", argv[i]);
+      }
+      is_proj_request = true;
+    }
+    else if (strcmp(argv[i], "-proj_string") == 0)
+    {
+      if (argv[i + 1] == nullptr || argv[i + 1][0] == '\0')
+      {
+        laserror("'%s' needs at least 1 argument: PROJ string not specified", argv[i]);
+      }
+      // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+      load_proj_library(nullptr);
+
+      size_t buffer_size = strlen(argv[i + 1]) + 1;
+      char* proj_source_string = (char*)malloc(buffer_size);
+
+      if (proj_source_string)
+      {
+        strcpy_las(proj_source_string, buffer_size, argv[i + 1]);
+
+        if (argv[i + 2] != nullptr && argv[i + 2][0] != '\0')
+        {
+          buffer_size = strlen(argv[i + 2]) + 1;
+          char* proj_target_string = (char*)malloc(buffer_size);
+          
+          if (proj_target_string)
+          {
+            strcpy_las(proj_target_string, buffer_size, argv[i + 2]);
+          
+            set_proj_param_for_transformation_with_string(proj_source_string, proj_target_string);
+            free((char*)proj_target_string);
+            *argv[i] = '\0'; *argv[i + 1] = '\0'; *argv[i + 2] = '\0'; i += 2;
+          }
+          else
+          {
+            free((char*)proj_source_string);
+            laserror("Failed to read the PROJ string target from the command line");
+          }
+        }
+        else
+        {      
+          set_proj_param_for_transformation_with_string(proj_source_string, nullptr);
+          *argv[i] = '\0'; *argv[i + 1] = '\0'; i += 1;
+        }
+        free((char*)proj_source_string);
+      }
+      else
+      {
+        laserror("Failed to read the source PROJ string from the command line");
+      }
+      is_proj_request = true;
+    }
+    else if (strcmp(argv[i], "-proj_json") == 0)
+    {
+      if (argv[i + 1] != nullptr && argv[i + 1][0] != '\0' && argv[i + 1][0] != '-')
+      {
+        // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+        load_proj_library(nullptr);
+
+        size_t buffer_size = strlen(argv[i + 1]) + 1;
+        char* proj_source_json = (char*)malloc(buffer_size);
+
+        if (proj_source_json)
+        {
+          strcpy_las(proj_source_json, buffer_size, argv[i + 1]);
+
+          if (argv[i + 2] != nullptr && argv[i + 2][0] != '\0' && argv[i + 2][0] != '-')
+          {            
+            buffer_size = strlen(argv[i + 2]) + 1;
+            char* proj_target_json = (char*)malloc(buffer_size);
+            
+            if (proj_target_json)
+            {
+              strcpy_las(proj_target_json, buffer_size, argv[i + 2]);
+            
+              set_proj_param_for_transformation_with_json(proj_source_json, proj_target_json);
+              free((char*)proj_target_json);
+            }
+            else
+            {
+              free((char*)proj_source_json);
+              laserror("Failed to read the PROJJSON target filename from the command line");
+            }
+            *argv[i] = '\0'; *argv[i + 1] = '\0'; *argv[i + 2] = '\0'; i += 2;
+          }
+          else 
+          {
+            //If only one json file is specified in the cmd, it is used as the target
+            set_proj_crs_with_json(proj_source_json, false);
+            check_header_for_crs = true;
+
+            *argv[i] = '\0'; *argv[i + 1] = '\0'; i += 1;
+          }
+          free((char*)proj_source_json);
+        }
+        else
+        {
+          laserror("Failed to read the PROJJSON source or target filename from the command line");
+        }
+      }
+      else 
+      {
+        laserror("'%s' needs at least 1 argument: target PROJJSON file not specified", argv[i]);
+      } 
+      is_proj_request = true;
+    }
+    else if (strcmp(argv[i], "-proj_wkt") == 0)
+    {
+      if (argv[i + 1] != nullptr && argv[i + 1][0] != '\0' && argv[i + 1][0] != '-')
+      {
+        // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+        load_proj_library(nullptr);
+
+        size_t buffer_size = strlen(argv[i + 1]) + 1;
+        char* proj_source_wkt = (char*)malloc(buffer_size);
+
+        if (proj_source_wkt)
+        {
+          strcpy_las(proj_source_wkt, buffer_size, argv[i + 1]);
+
+          if (argv[i + 2] != nullptr && argv[i + 2][0] != '\0' && argv[i + 2][0] != '-')
+          {
+            buffer_size = strlen(argv[i + 2]) + 1;
+            char* proj_target_wkt = (char*)malloc(buffer_size);
+            
+            if (proj_target_wkt)
+            {
+              strcpy_las(proj_target_wkt, buffer_size, argv[i + 2]);
+            
+              set_proj_param_for_transformation_with_wkt(proj_source_wkt, proj_target_wkt);
+              free((char*)proj_target_wkt);
+            }
+            else
+            {
+              free((char*)proj_source_wkt);
+              laserror("Failed to read the WKT target filename from the command line");
+            }
+            *argv[i] = '\0'; *argv[i + 1] = '\0'; *argv[i + 2] = '\0'; i += 2;
+          }
+          else {
+            // If only one json file is specified in the cmd, it is used as the target
+            set_proj_crs_with_wkt(proj_source_wkt, false);
+            check_header_for_crs = true;
+
+            *argv[i] = '\0'; *argv[i + 1] = '\0'; i += 1;
+          }
+          free((char*)proj_source_wkt);
+        }
+        else
+        {
+          laserror("Failed to read the WKT source or target filename from the command line");
+        }
+      } 
+      else 
+      {
+        laserror("'%s' needs at least 1 argument: target WKT file not specified", argv[i]);
+      }
+      is_proj_request = true;
+    }
+    //proj info 
+    else if (strcmp(argv[i], "-proj_info") == 0)
+    {
+      int j = i + 1;
+
+      if (argv[j] == nullptr || argv[j][0] == '\0' || argv[j][0] == '-')
+      {
+        laserror("'%s' needs minimum 1 arguments", argv[i]);
+      }    
+      // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+      load_proj_library(nullptr);
+
+      // Read parameters until a new argument (starting with '-') or the end is reached
+      while (argv[j] != nullptr && argv[j][0] != '-' && projParameters.arg_count < projParameters.max_param)
+      {
+        // Validation: Check whether the parameter is valid
+        bool valid = false;
+        for (int k = 0; k < projParameters.max_param; k++)
+        {
+          if (strcmp(argv[j], projParameters.valid_proj_info_params[k]) == 0)
+          {
+            valid = true;
+            break;
+          }
+        }
+        if (!valid)
+        {
+          laserror("Invalid parameter '%s' after '-proj_info' was specified", argv[j]);
+        }
+        projParameters.arg_count++;
+        j++;
+      }
+      // Reserve the memory for the number of parameters read
+      projParameters.proj_info_args = (char**)malloc(projParameters.arg_count * sizeof(char*));
+
+      if (projParameters.proj_info_args)
+      {
+        // Saving the parameters
+        for (int k = 0; k < projParameters.arg_count; k++)
+        {
+          size_t buffer_size = strlen(argv[i + 1 + k]) + 1;
+          projParameters.proj_info_args[k] = (char*)malloc(buffer_size);
+          if (projParameters.proj_info_args[k])
+          {
+            strcpy_las(projParameters.proj_info_args[k], buffer_size, argv[i + 1 + k]);
+          }
+        }
+      }
+      else
+      {
+        laserror("Failed to allocate memory for PROJ parameters");
+      }
+      // Set arguments to '\0'
+      for (int k = 0; k <= projParameters.arg_count; k++)
+      {
+        *argv[i + k] = '\0';
+      }
+      i += projParameters.arg_count;
+      is_proj_request = true;
     }
     else if (strcmp(argv[i],"-epsg") == 0 || strcmp(argv[i],"-target_epsg") == 0)
     {
@@ -8371,7 +8962,7 @@ bool GeoProjectionConverter::check_horizontal_datum_before_reprojection()
 
 bool GeoProjectionConverter::to_target(double* point) const
 {
-  if (target_projection)
+  if (target_projection || projParameters.proj_target_crs)
   {
     return to_target(point, point[0], point[1], point[2]);
   }
@@ -8467,6 +9058,8 @@ bool GeoProjectionConverter::to_target(const double* point,  double &x, double &
     }
     elevation = meter2elevation * (elevation2meter*point[2] + elevation_offset_in_meter);
     return true;
+  } else if (projParameters.proj_target_crs) {
+    return do_proj_crs_transformation(x, y, elevation);
   }
   return false;
 }
@@ -8478,14 +9071,21 @@ bool GeoProjectionConverter::has_target_precision() const
 
 double GeoProjectionConverter::get_target_precision() const
 {
-  if (target_precision)
-  {
+  if (target_precision) {
     return target_precision;
-  }
-  if (target_projection && (target_projection->type == GEO_PROJECTION_LONG_LAT || target_projection->type == GEO_PROJECTION_LAT_LONG))
-  {
+  } else if (target_projection && (target_projection->type == GEO_PROJECTION_LONG_LAT || target_projection->type == GEO_PROJECTION_LAT_LONG)) {
     return 1e-7;
-  }
+  } else if (projParameters.proj_target_crs && projParameters.proj_ctx) {
+    PJ* coord_system = proj_crs_get_coordinate_system(projParameters.proj_ctx, projParameters.proj_target_crs);
+
+    if (coord_system) {
+      PJ_COORDINATE_SYSTEM_TYPE cs_type = proj_cs_get_type(projParameters.proj_ctx, coord_system);
+
+      if (cs_type == PJ_CS_TYPE_ELLIPSOIDAL) {
+        return 1e-7;
+      }
+    }
+  } 
   return 0.01;
 }
 
@@ -8501,8 +9101,7 @@ bool GeoProjectionConverter::has_target_elevation_precision() const
 
 double GeoProjectionConverter::get_target_elevation_precision() const
 {
-  if (target_elevation_precision)
-  {
+  if (target_elevation_precision) {
     return target_elevation_precision;
   }
   return 0.01;
@@ -9228,3 +9827,405 @@ bool GeoProjectionConverter::set_dtm_projection_parameters(short horizontal_unit
 
   return true;
 }
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// create PROJ object using the epsg code (for source=true or target=false)
+/// Parse and validate the input epsg and set the ProjParameter crs
+void GeoProjectionConverter::set_proj_crs_with_epsg(unsigned int& epsg_code, bool source /*=true*/)
+{
+  int errno;
+
+  if (epsg_code == 0 || epsg_code > 999999) laserror("Invalid epsg code");
+
+  projParameters.proj_ctx = proj_context_create();
+
+  if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+
+  char crs_epsg[20];
+  snprintf(crs_epsg, sizeof(crs_epsg), "EPSG:%u", epsg_code);
+
+  PJ* proj_crs = proj_create(projParameters.proj_ctx, crs_epsg);
+
+  // Check whether the CRS is valid
+  if (!proj_crs) {
+    errno = proj_context_errno(projParameters.proj_ctx);
+
+    if (errno == 0) {
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS object using PROJ epsg code '%f'", crs_epsg);
+    } else {
+      const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS object using PROJ epsg code: %s", errstr);
+    }
+  }
+
+  if (source) {
+    projParameters.proj_source_crs = proj_crs;
+  } else {
+    projParameters.proj_target_crs = proj_crs;
+    projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// create PROJ object using the proj string (for source=true or target=false)
+/// Parse and validate the input proj string and set the ProjParameter crs
+void GeoProjectionConverter::set_proj_crs_with_string(const char* proj_string, bool source /*= true*/) 
+{
+  int errno;
+
+  if (proj_string == nullptr) laserror("PROJ string is not valid");
+
+  projParameters.proj_ctx = proj_context_create();
+
+  if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+
+  PJ* proj_crs = proj_create(projParameters.proj_ctx, proj_string);
+  
+  // Check whether the CRS is valid
+  if (!proj_crs) {
+    errno = proj_context_errno(projParameters.proj_ctx);
+  
+    if (errno == 0) {
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using PROJ string '%s'", proj_string);
+    } else {
+      const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using PROJ string: %s", errstr);
+    }
+  }
+
+  if (source) {
+    projParameters.proj_source_crs = proj_crs;
+  } else {
+    projParameters.proj_target_crs = proj_crs;
+    projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// create PROJ object using the json format (for source=true or target=false)
+/// Parse and validate the input json file and set the ProjParameter crs
+void GeoProjectionConverter::set_proj_crs_with_json(const char* json_filename, bool source /*= true*/)
+{
+  int errno;
+
+  if (json_filename == nullptr) laserror("Json filename is not valid");
+
+  projParameters.proj_ctx = proj_context_create();
+  
+  if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+  
+  // open target input file
+  FILE* Proj_file = LASfopen(json_filename, "r");
+  if (!Proj_file) {
+    laserror("The proj_json file '%s' could not be opened", json_filename);
+  }
+  fseek(Proj_file, 0, SEEK_END);
+  size_t fileSize = ftell(Proj_file);
+  if (fileSize == -1L) {
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Error reading file '%s'", json_filename);
+  }
+  fseek(Proj_file, 0, SEEK_SET); 
+  char* jsonContent = new char[fileSize + 1];
+
+  if (!jsonContent) {
+    fclose(Proj_file);
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Memory allocation failed for WKT content");
+  }
+  size_t readSize = fread(jsonContent, 1, fileSize, Proj_file);
+  jsonContent[readSize] = '\0';
+  fclose(Proj_file);
+  
+  if (readSize > fileSize) {
+    delete[] jsonContent;
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Error reading the PROJJSON file '%s'", json_filename);
+  }
+  PJ* proj_crs = proj_create(projParameters.proj_ctx, jsonContent);
+  delete[] jsonContent;
+  
+  // Check whether the CRS is valid
+  if (!proj_crs) {
+    errno = proj_context_errno(projParameters.proj_ctx);
+   
+    if (errno == 0) {
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS object using PROJJSON file '%f'", json_filename);
+    } else {
+      const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS object using PROJJSON file: %s", errstr);
+    }
+  }
+  
+  if (source) {
+    projParameters.proj_source_crs = proj_crs;
+  } else {
+    projParameters.proj_target_crs = proj_crs;
+    projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// create PROJ object using the wkt format (for source=true or target=false)
+/// Parse and validate the input wkt file and set the ProjParameter crs
+void GeoProjectionConverter::set_proj_crs_with_wkt(const char* wkt_filename, bool source /*= true*/)
+{
+  size_t fileSize = 0;
+  int errno;
+
+  if (!wkt_filename) laserror("Wkt filename is not valid");
+
+  projParameters.proj_ctx = proj_context_create();
+
+  if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+
+  // open source input file
+  FILE* Proj_file = LASfopen(wkt_filename, "r");
+  if (!Proj_file) {
+    laserror("The WKT file '%s' could not be opened", wkt_filename);
+  }
+
+  fseek(Proj_file, 0, SEEK_END);
+  fileSize = ftell(Proj_file);
+  if (fileSize == -1L) {
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Error reading file '%s'", wkt_filename);
+  }
+  fseek(Proj_file, 0, SEEK_SET);
+  char* wktContent = new char[fileSize + 1];
+
+  if (!wktContent) {
+    fclose(Proj_file);
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Memory allocation failed for WKT content");
+  }
+  size_t readSize = fread(wktContent, 1, fileSize, Proj_file);
+  wktContent[readSize] = '\0';
+  fclose(Proj_file);
+
+  if (readSize > fileSize) {
+    delete[] wktContent;
+    proj_context_destroy(projParameters.proj_ctx);
+    laserror("Error reading the WKT file '%s'", wkt_filename);
+  }
+  PJ* proj_crs = proj_create(projParameters.proj_ctx, wktContent);
+
+  // Check whether the CRS is valid
+  if (!proj_crs) {
+    errno = proj_context_errno(projParameters.proj_ctx);
+    delete[] wktContent;
+
+    if (errno == 0) {
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using WKT file '%f'", wkt_filename);
+    } else {
+      const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using WKT file: %s", errstr);
+    }
+  }   
+
+  if (source)  {
+    projParameters.proj_source_crs = proj_crs;
+  } else {
+    projParameters.proj_target_crs = proj_crs;
+    projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+  }
+  delete[] wktContent;
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// create PROJ object using the wkt content e.g. from the file header (for source=true or target=false)
+/// Parse and validate the input wkt content and set the ProjParameter crs
+void GeoProjectionConverter::set_proj_crs_with_file_header_wkt(const char* wktContent, bool source /*= true*/)
+{
+  int errno;
+
+  if (!wktContent) laserror("Wkt is not valid");
+
+  projParameters.proj_ctx = proj_context_create();
+
+  if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+
+  PJ* proj_crs = proj_create(projParameters.proj_ctx, wktContent);
+
+  // Check whether the CRS is valid
+  if (!proj_crs) {
+    errno = proj_context_errno(projParameters.proj_ctx);
+
+    if (errno == 0) {
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using WKT content '%f'", wktContent);
+    } else {
+      const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+      proj_context_destroy(projParameters.proj_ctx);
+      laserror("Failed to create the CRS objects using WKT content: %s", errstr);
+    }
+  }
+
+  if (source) {
+    projParameters.proj_source_crs = proj_crs;
+  } else {
+    projParameters.proj_target_crs = proj_crs;
+    projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// IMPORTANT: The source and target CRS must have been generated before to create a transformation object
+/// create PROJ object for the transformation
+void GeoProjectionConverter::set_proj_crs_transform()
+{
+  // Create the transformation PROJ object
+  if (projParameters.proj_source_crs && projParameters.proj_target_crs) {
+    // Check whether transformation between CRSs is valid
+    projParameters.proj_transform_crs = proj_create_crs_to_crs_from_pj(projParameters.proj_ctx, projParameters.proj_source_crs, projParameters.proj_target_crs, NULL, NULL);
+
+    if (!projParameters.proj_transform_crs) {
+      errno = proj_context_errno(projParameters.proj_ctx);
+
+      proj_destroy(projParameters.proj_source_crs);
+      proj_destroy(projParameters.proj_target_crs);
+
+      if (errno == 0) {
+        proj_context_destroy(projParameters.proj_ctx);
+        laserror("Failed to create PROJ object for the transformation, reason unknown");
+      } else {
+        const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+        proj_context_destroy(projParameters.proj_ctx);
+        laserror("Failed to create PROJ object for the transformation: %s", errstr);
+      }
+    }
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// PROJ transformation using the source and target epsg code
+/// Parse and validate the input values and set the ProjParameter
+void GeoProjectionConverter::set_proj_param_for_transformation_with_epsg(unsigned int& source_code, unsigned int& target_code)
+{
+  int errno;
+
+  if (source_code == 0 || source_code > 999999 || target_code == 0 || target_code > 999999) laserror("Invalid source or target epsg code");
+
+  //Create the proj crs object
+  set_proj_crs_with_epsg(source_code, true);
+  set_proj_crs_with_epsg(target_code, false);
+  
+  //Create the transformation PROJ object 
+  set_proj_crs_transform();
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// PROJ transformation using the PROJ string
+/// Parse and validate the input values and set the ProjParameter
+void GeoProjectionConverter::set_proj_param_for_transformation_with_string(const char* proj_source_string, const char* proj_target_string)
+{
+  int errno;
+
+  //If source and target PROJ string is given
+  if (proj_source_string && proj_target_string) {
+    set_proj_crs_with_string(proj_source_string, true);
+    set_proj_crs_with_string(proj_target_string, false);
+
+    // Create the transformation PROJ object
+    set_proj_crs_transform();
+  } else if (proj_source_string) {
+    // Check whether the individual PORJ string describes a transformation/operation/conversion or a single CRS
+    projParameters.proj_ctx = proj_context_create();
+
+    if (!projParameters.proj_ctx) laserror("Failed to create PROJ context");
+
+    PJ* proj_crs = proj_create(projParameters.proj_ctx, proj_source_string);
+
+    // Check whether the CRS is valid
+    if (!proj_crs) {
+      errno = proj_context_errno(projParameters.proj_ctx);
+
+      if (errno == 0) {
+        proj_context_destroy(projParameters.proj_ctx);
+        laserror("Failed to create the CRS objects using PROJ string '%s'", proj_source_string);
+      } else {
+        const char* errstr = proj_context_errno_string(projParameters.proj_ctx, errno);
+        proj_context_destroy(projParameters.proj_ctx);
+        laserror("Failed to create the CRS objects using PROJ string: %s", errstr);
+      }
+    }
+    PJ_TYPE type = proj_get_type(proj_crs);
+    //Here the PROJ string already describes a complete transformation/conversion/operation
+    if (type == PJ_TYPE_TRANSFORMATION || type == PJ_TYPE_CONVERSION || type == PJ_TYPE_CONCATENATED_OPERATION) {
+      projParameters.proj_transform_crs = proj_crs;
+      projParameters.proj_target_crs = proj_get_target_crs(projParameters.proj_ctx, projParameters.proj_transform_crs);
+
+      if (projParameters.proj_target_crs) {
+        // Calling up and outputting the WKT display
+        projParameters.set_header_wkt_representation(projParameters.proj_target_crs);
+      }
+    } else {
+      // If only one PROJ string was specified and describes a single CRS, it is set as the target.
+      set_proj_crs_with_string(proj_source_string, false);
+      check_header_for_crs = true;
+    }
+  } else {
+    laserror("At least one PROJ string must be specified");
+  }
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// PROJ transformation using the PROJJSON format 
+/// Parse and validate the input values and set the ProjParameter
+void GeoProjectionConverter::set_proj_param_for_transformation_with_json(const char* source_filename, const char* target_filename)
+{
+  int errno;
+
+  if (!source_filename || !target_filename) laserror("The source and target PROJJSON filenames must be specified");
+  //Create the proj crs object
+  set_proj_crs_with_json(source_filename, true);
+  set_proj_crs_with_json(target_filename, false);
+
+  // Create the transformation PROJ object 
+  set_proj_crs_transform(); 
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// PROJ transformation using the WKT format
+/// Parse and validate the input values and set the ProjParameter
+void GeoProjectionConverter::set_proj_param_for_transformation_with_wkt(const char* source_filename, const char* target_filename)
+{
+  int errno;
+
+  if (!source_filename || !target_filename) laserror("The source and target WKT filenames must be specified");
+  // Create the proj crs object
+  set_proj_crs_with_wkt(source_filename, true);
+  set_proj_crs_with_wkt(target_filename, false);
+
+  // Create the transformation PROJ object
+  set_proj_crs_transform();
+}
+
+/// IMPORTANT: The Proj lib must be installed and loaded to use this functionality.
+/// Executing the CRS transformation for the specified coordinates (x,y,elevation) using the PROJ library
+bool GeoProjectionConverter::do_proj_crs_transformation(double& x, double& y, double& elevation) const
+{
+  if (!projParameters.proj_transform_crs)
+    return false;
+
+  // Prepare Proj input coordinates
+  PJ_COORD coord = proj_coord(x, y, elevation, 0);
+  // Perform the Proj transformation
+  PJ_COORD result = proj_trans(projParameters.proj_transform_crs, PJ_FWD, coord);
+
+  // Assign transformed coordinates
+  x = result.xyzt.x;
+  y = result.xyzt.y;
+  elevation = result.xyzt.z;
+
+  return true;
+}
+

--- a/src/geoprojectionconverter.hpp
+++ b/src/geoprojectionconverter.hpp
@@ -51,6 +51,7 @@
 
   CHANGE HISTORY:
 
+     1 September 2024 -- integration of the PROJ Library for CRS transformations 
      1 November 2018 -- changes requested by Kirk Waters including GEO_GCS_NAD83_CORS96
      7 September 2018 -- introduced the LASCopyString macro to replace _strdup
     30 October 2017 -- '-vertical_evrf2007' for European Vertical Reference Frame 2007
@@ -68,6 +69,8 @@
 ===============================================================================
 */
 #pragma once
+
+#include "proj_loader.h"
 
 struct GeoProjectionGeoKeys
 {
@@ -273,6 +276,42 @@ public:
   double os_gf;
 };
 
+///This class is used for PROJ operations 
+/// IMPORTANT: The Proj lib must be installed and loaded to use these functionalities.
+class ProjParameters
+{
+ public:
+  int arg_count;
+  const int max_param;
+  char** proj_info_args;
+  const char* valid_proj_info_params[7];  // Anzahl der Parameter festlegen
+
+  PJ_CONTEXT* proj_ctx;
+  PJ* proj_source_crs;
+  PJ* proj_target_crs;
+  PJ* proj_transform_crs;
+  
+  ProjParameters();
+  ~ProjParameters();
+
+  void set_header_wkt_representation(PJ* proj_crs);
+  const char* get_target_header_wkt_representation();
+  const char* get_wkt_representation(bool source=true) const;  // cmd arg: 'wkt'
+  const char* get_json_representation(bool source = true) const;  // cmd arg: 'js'
+  const char* get_projString_representation(bool source = true) const;  // cmd arg: 'str'
+  const char* get_epsg_representation(bool source = true) const;        // cmd arg: 'epsg'
+  const char* get_ellipsoid_info(bool source = true);             // cmd arg: 'el'
+  const char* get_datum_info(bool source = true);                 // cmd arg: 'datum'
+  const char* get_coord_system_info(bool source = true);          // cmd arg: 'crs'
+  bool proj_info_arg_contains(const char* arg) const;
+  
+ private:
+  char* header_wkt_representation;
+  char* proj_crs_infos;
+
+  void set_proj_member(char*& member, const char* value);
+};
+
 class GeoProjectionConverter
 {
 public:
@@ -440,11 +479,24 @@ public:
   bool get_dtm_projection_parameters(short* horizontal_units, short* vertical_units, short* coordinate_system, short* coordinate_zone, short* horizontal_datum, short* vertical_datum, bool source=true);
   bool set_dtm_projection_parameters(short horizontal_units, short vertical_units, short coordinate_system, short coordinate_zone, short horizontal_datum, short vertical_datum, bool source=true);
 
+  // using PROJ lib
+  void set_proj_crs_transform();
+  void set_proj_crs_with_epsg(unsigned int& epsg_code, bool source = true);
+  void set_proj_crs_with_string(const char* proj_string, bool source = true);
+  void set_proj_crs_with_json(const char* json_filename, bool source = true);
+  void set_proj_crs_with_wkt(const char* wkt_filename, bool source = true);
+  void set_proj_crs_with_file_header_wkt(const char* wktContent, bool source = true);
+   
   // helps us to find the 'pcs.csv' file
   char* argv_zero;
 
-private:
+  // parameters for the PROJ operation
+  ProjParameters projParameters;
+  bool is_proj_request;
+  bool check_header_for_crs;
+  unsigned int source_header_epsg;
 
+private:
   // parameters for gtiff
   int num_geo_keys;
   GeoProjectionGeoKeys* geo_keys;
@@ -489,4 +541,11 @@ private:
   void compute_aeac_parameters(bool source);
   void compute_hom_parameters(bool source);
   void compute_os_parameters(bool source);
+
+  // using PROJ lib 
+  void set_proj_param_for_transformation_with_epsg(unsigned int& source_code, unsigned int& target_code);
+  void set_proj_param_for_transformation_with_string(const char* proj_sourge_string, const char* proj_target_string);
+  void set_proj_param_for_transformation_with_json(const char* source_filename, const char* target_filename);
+  void set_proj_param_for_transformation_with_wkt(const char* source_filename, const char* target_filename);
+  bool do_proj_crs_transformation(double& x, double& y, double& elevation) const;
 };

--- a/src/geoprojectionconverter.hpp
+++ b/src/geoprojectionconverter.hpp
@@ -493,6 +493,7 @@ public:
   // parameters for the PROJ operation
   ProjParameters projParameters;
   bool is_proj_request;
+  bool disable_messages;
   bool check_header_for_crs;
   unsigned int source_header_epsg;
 

--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -536,6 +536,7 @@ static void parse_save_load_vlr_args(int& i, int argc, char* argv[], bool& save_
 void get_wkt_from_proj(CHAR*& ogc_wkt_out, GeoProjectionConverter& geoprojectionconverter, LASreader* lasreader)
 {
   if (lasreader) {
+    //If there is a target wkt header, it is a CRS transformation
     const char* wkt_representation = geoprojectionconverter.projParameters.get_target_header_wkt_representation();
 
     //If the WKT representation has not been created yet

--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -542,10 +542,29 @@ void get_wkt_from_proj(CHAR*& ogc_wkt_out, GeoProjectionConverter& geoprojection
     //If the WKT representation has not been created yet
     if (geoprojectionconverter.source_header_epsg == 0 && wkt_representation == nullptr) {
       if (!geoprojectionconverter.has_projection(true)) {  // if no source projection was provided in the command line ...
-        if (lasreader->header.vlr_geo_ogc_wkt) {  // try to get it from the OGC WKT string
+        //1. try to get the WKT from file header
+        if (lasreader->header.vlr_geo_ogc_wkt) {
           geoprojectionconverter.set_proj_crs_with_file_header_wkt(lasreader->header.vlr_geo_ogc_wkt, false);
-        } else if (lasreader->header.vlr_geo_keys) {  // if no WKT exist in file header try keo_keyss.
-          geoprojectionconverter.set_projection_from_geo_keys(lasreader->header.vlr_geo_keys[0].number_of_keys, (GeoProjectionGeoKeys*)lasreader->header.vlr_geo_key_entries, lasreader->header.vlr_geo_ascii_params, lasreader->header.vlr_geo_double_params);
+        } else if (lasreader->header.vlr_geo_keys) {  
+          // 2. If no source CRS was specified and no WKT is in the header, then create WKT from GeoTiff
+          geoprojectionconverter.disable_messages = true;
+
+          geoprojectionconverter.set_projection_from_geo_keys(
+              lasreader->header.vlr_geo_keys[0].number_of_keys, (GeoProjectionGeoKeys*)lasreader->header.vlr_geo_key_entries,
+              lasreader->header.vlr_geo_ascii_params, lasreader->header.vlr_geo_double_params);
+
+          CHAR* ogc_wkt = nullptr;
+          I32 len = 0;
+          if (geoprojectionconverter.get_ogc_wkt_from_projection(len, &ogc_wkt)) {
+            geoprojectionconverter.set_proj_crs_with_file_header_wkt(ogc_wkt, true);
+          // 3. if no WKT can be generated from GeoTiff try to get die EPSG from GeoTiff
+          } else if (geoprojectionconverter.source_header_epsg) {
+            LASMessage(LAS_WARNING, "No valid WKT could be generated from the GeoTiff of the source file. The EPSG code from the GeoTiff is used for generating the WKT, "
+                "this can lead to loss of GeoTiff arguments, which can lead to inaccuracies or data loss in the WKT.");
+            geoprojectionconverter.set_proj_crs_with_epsg(geoprojectionconverter.source_header_epsg, true);
+          } else {
+            laserror("No WKT could be generated from the header information of the source file. Please specify the coordinate system (CRS) directly when calling the operation.");
+          }
           geoprojectionconverter.reset_projection();
         }
       }
@@ -799,22 +818,24 @@ int main(int argc, char* argv[])
       }
       else if (strncmp(argv[i], "-set_ogc_wkt", 12) == 0)
       {
-        // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
-        geoprojectionconverter.is_proj_request = load_proj_library(nullptr, false);
-
-        if (strcmp(argv[i], "-set_ogc_wkt") == 0)
-        {
-          set_ogc_wkt = true;
-          set_ogc_wkt_in_evlr = false;
-        }
-        else if (strcmp(argv[i], "-set_ogc_wkt_in_evlr") == 0)
-        {
-          set_ogc_wkt = true;
-          set_ogc_wkt_in_evlr = true;
-        }
-        else
-        {
-          lastool.parse_arg_invalid_n(i);
+        if (!geoprojectionconverter.is_proj_request) {
+          // When using the PROJ functionalities, the PROJ lib must be loaded dynamically
+          geoprojectionconverter.is_proj_request = load_proj_library(nullptr, false);
+          
+          if (strcmp(argv[i], "-set_ogc_wkt") == 0)
+          {
+            set_ogc_wkt = true;
+            set_ogc_wkt_in_evlr = false;
+          }
+          else if (strcmp(argv[i], "-set_ogc_wkt_in_evlr") == 0)
+          {
+            set_ogc_wkt = true;
+            set_ogc_wkt_in_evlr = true;
+          }
+          else
+          {
+            lastool.parse_arg_invalid_n(i);
+          }
         }
         if ((i + 1) < argc)
         {
@@ -1702,6 +1723,7 @@ int main(int argc, char* argv[])
       LASquantizer* reproject_quantizer = 0;
       LASquantizer* saved_quantizer = 0;
       bool set_projection_in_header = false;
+      bool set_wkt_global_encoding_bit = false;
 
       if (geoprojectionconverter.has_projection(false)) // reproject because a target projection was provided in the command line
       {
@@ -1752,29 +1774,43 @@ int main(int argc, char* argv[])
       // PROJ transformation
       if (geoprojectionconverter.is_proj_request && !set_ogc_wkt) 
       {
-        //If the source CRS is not specified as an argument (cmd line), try to generate it from the input file
+        LASMessage(LAS_VERY_VERBOSE, "the PROJ transformation is prepared within las2las");
+        //1. If the source CRS is not specified as an argument (cmd line), try to generate it from the input file
         if (geoprojectionconverter.check_header_for_crs) 
         {      
+          LASMessage(LAS_VERY_VERBOSE, "the header of the input file is checked for its CRS");
+          // 2. try to get it the source CRS from the OGC header WKT string
           if (lasreader->header.vlr_geo_ogc_wkt) 
-          {  // try to get it from the OGC WKT string
+          {
             geoprojectionconverter.set_proj_crs_with_file_header_wkt(lasreader->header.vlr_geo_ogc_wkt, true);
           } 
           else if (lasreader->header.vlr_geo_keys) 
-          {  // if no WKT exist in file header try keo_keys
+          {
+            geoprojectionconverter.disable_messages = true;
+
             geoprojectionconverter.set_projection_from_geo_keys(
                 lasreader->header.vlr_geo_keys[0].number_of_keys, (GeoProjectionGeoKeys*)lasreader->header.vlr_geo_key_entries,
                 lasreader->header.vlr_geo_ascii_params, lasreader->header.vlr_geo_double_params);
-            geoprojectionconverter.reset_projection();
 
-            if (geoprojectionconverter.source_header_epsg > 0) 
+            CHAR* ogc_wkt = nullptr;
+            I32 len = 0;
+            // 3. if no WKT exist in file header try to generate WKT from GeoTiff and lastool
+            if (geoprojectionconverter.get_ogc_wkt_from_projection(len, &ogc_wkt))
             {
-              // create the PROJ object
+              geoprojectionconverter.set_proj_crs_with_file_header_wkt(ogc_wkt, true);
+            }
+            // 4. if no WKT can be generated from GeoTiff try to get die EPSG from GeoTiff
+            else if (geoprojectionconverter.source_header_epsg)
+            {
+              LASMessage(LAS_WARNING, "No valid WKT could be generated from the GeoTiff of the source file. The EPSG code from the GeoTiff is used for the transformation, "
+                             "this can lead to loss of GeoTiff arguments, which can lead to inaccuracies or data loss during the transformation.");
               geoprojectionconverter.set_proj_crs_with_epsg(geoprojectionconverter.source_header_epsg, true);
-            } 
+            }
             else 
             {
               laserror("No valid CRS could be extracted from the header information of the source file. Please specify the coordinate system (CRS) directly when calling the transformation tool.");
             }
+            geoprojectionconverter.reset_projection();
           } 
           else 
           {
@@ -1797,8 +1833,10 @@ int main(int argc, char* argv[])
 
         set_projection_in_header = true;
         set_ogc_wkt = true;
+        set_wkt_global_encoding_bit = true;
         lasreader->header.clean_vlrs();
         lasreader->header.clean_evlrs();
+        LASMessage(LAS_VERY_VERBOSE, "the original vlr and evlr header information from the source file are not transferred to the target file");
       }
 
       if (set_projection_in_header)
@@ -1828,9 +1866,12 @@ int main(int argc, char* argv[])
         if (set_ogc_wkt || (lasreader->header.point_data_format >= 6)) // maybe also set the OCG WKT
         {
           CHAR* ogc_wkt = set_ogc_wkt_string;
-          // First try to create the WKT representation of the CRS via the PROJ lib
-          if (ogc_wkt == 0 && geoprojectionconverter.is_proj_request) 
+          // The WKT should be generated via the PROJ lib if: it is a PROJ transformation, a soure EPSG in the arguments is specified or a WKT is specified in the file header. 
+          // For older file versions that only contain GeoKeys in file header, the WKT should still be generated via LAStool.
+          if (ogc_wkt == 0 && geoprojectionconverter.is_proj_request) { 
+            LASMessage(LAS_VERBOSE, "the WKT for the file header is created via the PROJ library");
             get_wkt_from_proj(ogc_wkt, geoprojectionconverter, lasreader);
+          }
 
           I32 len = (ogc_wkt ? (I32)strlen(ogc_wkt) : 0);
 
@@ -1863,7 +1904,7 @@ int main(int argc, char* argv[])
               lasreader->header.set_geo_ogc_wkt(len, ogc_wkt);
             }
             if (!set_ogc_wkt_string) free(ogc_wkt);
-            if ((lasreader->header.version_minor >= 4) && (lasreader->header.point_data_format >= 6))
+            if (((lasreader->header.version_minor >= 4) && (lasreader->header.point_data_format >= 6)) || set_wkt_global_encoding_bit)
             {
               lasreader->header.set_global_encoding_bit(LAS_TOOLS_GLOBAL_ENCODING_BIT_OGC_WKT_CRS);
             }
@@ -1873,9 +1914,12 @@ int main(int argc, char* argv[])
       else if (set_ogc_wkt) // maybe only set the OCG WKT
       {
         CHAR* ogc_wkt = set_ogc_wkt_string;
-        // First try to create the WKT representation of the CRS via the PROJ lib
-        if (ogc_wkt == 0 && geoprojectionconverter.is_proj_request)
+        // The WKT should be generated via the PROJ lib if: it is a PROJ transformation, a soure EPSG in the arguments is specified or a WKT is specified in the file header. 
+        // For older file versions that only contain GeoKeys in file header, the WKT should still be generated via LAStool.
+        if (ogc_wkt == 0 && geoprojectionconverter.is_proj_request) {
+          LASMessage(LAS_VERBOSE, "the WKT for the file header is created via the PROJ library");
           get_wkt_from_proj(ogc_wkt, geoprojectionconverter, lasreader);
+        }
 
         I32 len = (ogc_wkt ? (I32)strlen(ogc_wkt) : 0);
         //If the WKT could not be created by the PROJ lib
@@ -1918,7 +1962,7 @@ int main(int argc, char* argv[])
 
           if (!set_ogc_wkt_string) free(ogc_wkt);
 
-          if ((lasreader->header.version_minor >= 4) && (lasreader->header.point_data_format >= 6))
+          if (((lasreader->header.version_minor >= 4) && (lasreader->header.point_data_format >= 6)) || set_wkt_global_encoding_bit)
           {
             lasreader->header.set_global_encoding_bit(LAS_TOOLS_GLOBAL_ENCODING_BIT_OGC_WKT_CRS);
           }

--- a/src/lasinfo.cpp
+++ b/src/lasinfo.cpp
@@ -4547,6 +4547,166 @@ class LasTool_lasinfo : public LasTool
         }
       }
 
+      // PROJ CRS Representations and information query
+      if (file_out && geoprojectionconverter.is_proj_request) 
+      {
+        // Try to generate the CRS PROJ object from the input file header information
+        if (lasreader->header.vlr_geo_ogc_wkt) 
+        {  // try to get it from the OGC WKT string
+          geoprojectionconverter.set_proj_crs_with_file_header_wkt(lasreader->header.vlr_geo_ogc_wkt, true);
+        } 
+        else if (lasreader->header.vlr_geo_keys) // if no WKT exist in file header try keo_keys
+        {  
+          geoprojectionconverter.set_projection_from_geo_keys(
+              lasreader->header.vlr_geo_keys[0].number_of_keys, (GeoProjectionGeoKeys*)lasreader->header.vlr_geo_key_entries,
+              lasreader->header.vlr_geo_ascii_params, lasreader->header.vlr_geo_double_params);
+          geoprojectionconverter.reset_projection();
+
+          if (geoprojectionconverter.source_header_epsg > 0) 
+          {
+            // create the PROJ object for the proj info query here
+            geoprojectionconverter.set_proj_crs_with_epsg(geoprojectionconverter.source_header_epsg, true);
+          } 
+          else 
+          {
+            laserror("No valid CRS could be extracted from the header information of the source file.");
+          }
+        } 
+        else 
+        {
+            laserror("No file header information could be found to identify the CRS.");
+        }
+        const char* info_content = nullptr;
+        const char* proj_crs_infos = nullptr;
+        
+        fprintf(file_out, "PROJ Coordinate Reference System (CRS) Representation and Information \n");
+        // Query the WKT representation of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("wkt")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_wkt_representation(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the wkt representation of the CRS could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "WKT representation of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }
+        // Query the PROJJSON representation of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("js")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_json_representation(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the json representation of the CRS could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "Json representation of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }
+        // Query the PROJ string representation of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("str")) {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_projString_representation(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the PROJ string representation of the CRS could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "PROJ string representation of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }
+        // Query the EPSG code of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("epsg")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_epsg_representation(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the epsg representation of the CRS could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "Epsg-Code representation of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }
+        // Query the ellipsoidal informations of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("el")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_ellipsoid_info(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the ellipsoid information could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "Ellipsoid of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }
+        // Query the datum informations of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("datum")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_datum_info(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the datum information could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "Datum of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        }      
+        // Query the coordinate system informations of the CRS
+        if (geoprojectionconverter.projParameters.proj_info_arg_contains("cs")) 
+        {
+          proj_crs_infos = geoprojectionconverter.projParameters.get_coord_system_info(true);
+          info_content = indent_text(proj_crs_infos, "  ");
+        
+          if (info_content == nullptr || *info_content == '\0') 
+          {
+            LASMessage(LAS_WARNING, "the content of the CRS information could not be generated");
+          } 
+          else 
+          {
+            fprintf(file_out, "Coordinate system of the CRS: \n");
+            fprintf(file_out, "%s \n", info_content);
+          }
+          delete[] info_content;
+          info_content = nullptr;
+        } 
+      }
+
       lasreader->close();
 
       FILE* file = 0;
@@ -5088,3 +5248,4 @@ int main(int argc, char* argv[])
   lastool.init(argc, argv, "lasinfo");
   return lastool.run();
 }
+

--- a/src/lasinfo.cpp
+++ b/src/lasinfo.cpp
@@ -182,7 +182,7 @@ static bool valid_resolution(F64 coordinate, F64 offset, F64 scale_factor)
 }
 
 #ifdef COMPILE_WITH_GUI
-extern int lasinfo_gui(int argc, char* argv[], LASreadOpener* lasreadopener);
+extern void lasinfo_gui(int argc, char* argv[], LASreadOpener* lasreadopener);
 #endif
 
 #ifdef COMPILE_WITH_MULTI_CORE
@@ -201,7 +201,7 @@ class LasTool_lasinfo : public LasTool
   F64* scale_header = 0;
 
  public:
-  int run()
+  void run()
   {
     int i;
     bool no_header = false;
@@ -278,7 +278,7 @@ class LasTool_lasinfo : public LasTool
     if (argc == 1)
     {
 #ifdef COMPILE_WITH_GUI
-      return lasinfo_gui(argc, argv, 0);
+      lasinfo_gui(argc, argv, 0);
 #else
       wait_on_exit = true;
       fprintf(stderr, "%s is better run in the command line\n", argv[0]);
@@ -919,7 +919,7 @@ class LasTool_lasinfo : public LasTool
 #ifdef COMPILE_WITH_GUI
     if (gui)
     {
-      return lasinfo_gui(argc, argv, &lasreadopener);
+      lasinfo_gui(argc, argv, &lasreadopener);
     }
 #endif
 
@@ -5246,6 +5246,6 @@ int main(int argc, char* argv[])
 {
   LasTool_lasinfo lastool;
   lastool.init(argc, argv, "lasinfo");
-  return lastool.run();
+  lastool.run();
 }
 

--- a/src/lassrclib.vcxproj
+++ b/src/lassrclib.vcxproj
@@ -9,9 +9,11 @@
   <ItemGroup>
     <ClCompile Include="..\LASzip\src\lasmessage.cpp" />
     <ClCompile Include="geoprojectionconverter.cpp" />
+    <ClCompile Include="proj_loader.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\LASzip\src\lasmessage.hpp" />
+    <ClInclude Include="proj_loader.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/src/proj.h
+++ b/src/proj.h
@@ -1,0 +1,1503 @@
+/******************************************************************************
+ * Project:  PROJ.4
+ * Purpose:  Revised, experimental API for PROJ.4, intended as the foundation
+ *           for added geodetic functionality.
+ *
+ *           The original proj API (defined previously in projects.h) has grown
+ *           organically over the years, but it has also grown somewhat messy.
+ *
+ *           The same has happened with the newer high level API (defined in
+ *           proj_api.h): To support various historical objectives, proj_api.h
+ *           contains a rather complex combination of conditional defines and
+ *           typedefs. Probably for good (historical) reasons, which are not
+ *           always evident from today's perspective.
+ *
+ *           This is an evolving attempt at creating a re-rationalized API
+ *           with primary design goals focused on sanitizing the namespaces.
+ *           Hence, all symbols exposed are being moved to the proj_ namespace,
+ *           while all data types are being moved to the PJ_ namespace.
+ *
+ *           Please note that this API is *orthogonal* to  the previous APIs:
+ *           Apart from some inclusion guards, projects.h and proj_api.h are not
+ *           touched - if you do not include proj.h, the projects and proj_api
+ *           APIs should work as they always have.
+ *
+ *           A few implementation details:
+ *
+ *           Apart from the namespacing efforts, I'm trying to eliminate three
+ *           proj_api elements, which I have found especially confusing.
+ *
+ *           FIRST and foremost, I try to avoid typedef'ing away pointer
+ *           semantics. I agree that it can be occasionally useful, but I
+ *           prefer having the pointer nature of function arguments being
+ *           explicitly visible.
+ *
+ *           Hence, projCtx has been replaced by PJ_CONTEXT *.
+ *           and    projPJ  has been replaced by PJ *
+ *
+ *           SECOND, I try to eliminate cases of information hiding implemented
+ *           by redefining data types to void pointers.
+ *
+ *           I prefer using a combination of forward declarations and typedefs.
+ *           Hence:
+ *               typedef void *projCtx;
+ *           Has been replaced by:
+ *               struct projCtx_t;
+ *               typedef struct projCtx_t PJ_CONTEXT;
+ *           This makes it possible for the calling program to know that the
+ *           PJ_CONTEXT data type exists, and handle pointers to that data type
+ *           without having any idea about its internals.
+ *
+ *           (obviously, in this example, struct projCtx_t should also be
+ *           renamed struct pj_ctx some day, but for backwards compatibility
+ *           it remains as-is for now).
+ *
+ *           THIRD, I try to eliminate implicit type punning. Hence this API
+ *           introduces the PJ_COORD union data type, for generic 4D coordinate
+ *           handling.
+ *
+ *           PJ_COORD makes it possible to make explicit the previously used
+ *           "implicit type punning", where a XY is turned into a LP by
+ *           re#defining both as UV, behind the back of the user.
+ *
+ *           The PJ_COORD union is used for storing 1D, 2D, 3D and 4D
+ *coordinates.
+ *
+ *           The bare essentials API presented here follows the PROJ.4
+ *           convention of sailing the coordinate to be reprojected, up on
+ *           the stack ("call by value"), and symmetrically returning the
+ *           result on the stack. Although the PJ_COORD object is twice as large
+ *           as the traditional XY and LP objects, timing results have shown the
+ *           overhead to be very reasonable.
+ *
+ *           Contexts and thread safety
+ *           --------------------------
+ *
+ *           After a year of experiments (and previous experience from the
+ *           trlib transformation library) it has become clear that the
+ *           context subsystem is unavoidable in a multi-threaded world.
+ *           Hence, instead of hiding it away, we move it into the limelight,
+ *           highly recommending (but not formally requiring) the bracketing
+ *           of any code block calling PROJ.4 functions with calls to
+ *           proj_context_create(...)/proj_context_destroy()
+ *
+ *           Legacy single threaded code need not do anything, but *may*
+ *           implement a bit of future compatibility by using the backward
+ *           compatible call proj_context_create(0), which will not create
+ *           a new context, but simply provide a pointer to the default one.
+ *
+ *           See proj_4D_api_test.c for examples of how to use the API.
+ *
+ * Author:   Thomas Knudsen, <thokn@sdfe.dk>
+ *           Benefitting from a large number of comments and suggestions
+ *           by (primarily) Kristian Evers and Even Rouault.
+ *
+ ******************************************************************************
+ * Copyright (c) 2016, 2017, Thomas Knudsen / SDFE
+ * Copyright (c) 2018, Even Rouault
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO COORD SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef PROJ_H
+#define PROJ_H
+
+#include <stddef.h> /* For size_t */
+
+#ifdef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#error "The proj_api.h header has been removed from PROJ with version 8.0.0"
+#endif
+
+#ifdef PROJ_RENAME_SYMBOLS
+#include "proj_symbol_rename.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \file proj.h
+ *
+ * C API new generation
+ */
+
+/*! @cond Doxygen_Suppress */
+
+#ifndef PROJ_DLL
+#if defined(_MSC_VER)
+#ifdef PROJ_MSVC_DLL_EXPORT
+#define PROJ_DLL __declspec(dllexport)
+#else
+#define PROJ_DLL __declspec(dllimport)
+#endif
+#elif defined(__GNUC__)
+#define PROJ_DLL __attribute__((visibility("default")))
+#else
+#define PROJ_DLL
+#endif
+#endif
+
+#ifdef PROJ_SUPPRESS_DEPRECATION_MESSAGE
+#define PROJ_DEPRECATED(decl, msg) decl
+#elif defined(__has_extension)
+#if __has_extension(attribute_deprecated_with_message)
+#define PROJ_DEPRECATED(decl, msg) decl __attribute__((deprecated(msg)))
+#elif defined(__GNUC__)
+#define PROJ_DEPRECATED(decl, msg) decl __attribute__((deprecated))
+#else
+#define PROJ_DEPRECATED(decl, msg) decl
+#endif
+#elif defined(__GNUC__)
+#define PROJ_DEPRECATED(decl, msg) decl __attribute__((deprecated))
+#elif defined(_MSVC_VER)
+#define PROJ_DEPRECATED(decl, msg) __declspec(deprecated(msg)) decl
+#else
+#define PROJ_DEPRECATED(decl, msg) decl
+#endif
+
+/* The version numbers should be updated with every release! **/
+#define PROJ_VERSION_MAJOR 9
+#define PROJ_VERSION_MINOR 3
+#define PROJ_VERSION_PATCH 0
+
+/* Note: the following 3 defines have been introduced in PROJ 8.0.1 */
+/* Macro to compute a PROJ version number from its components */
+#define PROJ_COMPUTE_VERSION(maj, min, patch)                                  \
+    ((maj)*10000 + (min)*100 + (patch))
+
+/* Current PROJ version from the above version numbers */
+#define PROJ_VERSION_NUMBER                                                    \
+    PROJ_COMPUTE_VERSION(PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR,               \
+                         PROJ_VERSION_PATCH)
+
+/* Macro that returns true if the current PROJ version is at least the version
+ * specified by (maj,min,patch) */
+#define PROJ_AT_LEAST_VERSION(maj, min, patch)                                 \
+    (PROJ_VERSION_NUMBER >= PROJ_COMPUTE_VERSION(maj, min, patch))
+
+extern char const PROJ_DLL pj_release[]; /* global release id string */
+
+/* first forward declare everything needed */
+
+/* Data type for generic geodetic 3D data plus epoch information */
+union PJ_COORD;
+typedef union PJ_COORD PJ_COORD;
+
+struct PJ_AREA;
+typedef struct PJ_AREA PJ_AREA;
+
+struct P5_FACTORS {          /* Common designation */
+    double meridional_scale; /* h */
+    double parallel_scale;   /* k */
+    double areal_scale;      /* s */
+
+    double angular_distortion;      /* omega */
+    double meridian_parallel_angle; /* theta-prime */
+    double meridian_convergence;    /* alpha */
+
+    double tissot_semimajor; /* a */
+    double tissot_semiminor; /* b */
+
+    double dx_dlam, dx_dphi;
+    double dy_dlam, dy_dphi;
+};
+typedef struct P5_FACTORS PJ_FACTORS;
+
+/* Data type for projection/transformation information */
+struct PJconsts;
+typedef struct PJconsts PJ; /* the PJ object herself */
+
+/* Data type for library level information */
+struct PJ_INFO;
+typedef struct PJ_INFO PJ_INFO;
+
+struct PJ_PROJ_INFO;
+typedef struct PJ_PROJ_INFO PJ_PROJ_INFO;
+
+struct PJ_GRID_INFO;
+typedef struct PJ_GRID_INFO PJ_GRID_INFO;
+
+struct PJ_INIT_INFO;
+typedef struct PJ_INIT_INFO PJ_INIT_INFO;
+
+/* Data types for list of operations, ellipsoids, datums and units used in
+ * PROJ.4 */
+struct PJ_LIST {
+    const char *id;           /* projection keyword */
+    PJ *(*proj)(PJ *);        /* projection entry point */
+    const char *const *descr; /* description text */
+};
+
+typedef struct PJ_LIST PJ_OPERATIONS;
+
+struct PJ_ELLPS {
+    const char *id;    /* ellipse keyword name */
+    const char *major; /* a= value */
+    const char *ell;   /* elliptical parameter */
+    const char *name;  /* comments */
+};
+typedef struct PJ_ELLPS PJ_ELLPS;
+
+struct PJ_UNITS {
+    const char *id;       /* units keyword */
+    const char *to_meter; /* multiply by value to get meters */
+    const char *name;     /* comments */
+    double factor;        /* to_meter factor in actual numbers */
+};
+typedef struct PJ_UNITS PJ_UNITS;
+
+struct PJ_PRIME_MERIDIANS {
+    const char *id;   /* prime meridian keyword */
+    const char *defn; /* offset from greenwich in DMS format. */
+};
+typedef struct PJ_PRIME_MERIDIANS PJ_PRIME_MERIDIANS;
+
+/* Geodetic, mostly spatiotemporal coordinate types */
+typedef struct {
+    double x, y, z, t;
+} PJ_XYZT;
+typedef struct {
+    double u, v, w, t;
+} PJ_UVWT;
+typedef struct {
+    double lam, phi, z, t;
+} PJ_LPZT;
+typedef struct {
+    double o, p, k;
+} PJ_OPK; /* Rotations: omega, phi, kappa */
+typedef struct {
+    double e, n, u;
+} PJ_ENU; /* East, North, Up */
+typedef struct {
+    double s, a1, a2;
+} PJ_GEOD; /* Geodesic length, fwd azi, rev azi */
+
+/* Classic proj.4 pair/triplet types - moved into the PJ_ name space */
+typedef struct {
+    double u, v;
+} PJ_UV;
+typedef struct {
+    double x, y;
+} PJ_XY;
+typedef struct {
+    double lam, phi;
+} PJ_LP;
+
+typedef struct {
+    double x, y, z;
+} PJ_XYZ;
+typedef struct {
+    double u, v, w;
+} PJ_UVW;
+typedef struct {
+    double lam, phi, z;
+} PJ_LPZ;
+
+/* Avoid preprocessor renaming and implicit type-punning: Use a union to make it
+ * explicit */
+union PJ_COORD {
+    double v[4]; /* First and foremost, it really is "just 4 numbers in a
+                    vector" */
+    PJ_XYZT xyzt;
+    PJ_UVWT uvwt;
+    PJ_LPZT lpzt;
+    PJ_GEOD geod;
+    PJ_OPK opk;
+    PJ_ENU enu;
+    PJ_XYZ xyz;
+    PJ_UVW uvw;
+    PJ_LPZ lpz;
+    PJ_XY xy;
+    PJ_UV uv;
+    PJ_LP lp;
+};
+
+struct PJ_INFO {
+    int major;              /* Major release number                 */
+    int minor;              /* Minor release number                 */
+    int patch;              /* Patch level                          */
+    const char *release;    /* Release info. Version + date         */
+    const char *version;    /* Full version number                  */
+    const char *searchpath; /* Paths where init and grid files are  */
+                            /* looked for. Paths are separated by   */
+                            /* semi-colons on Windows, and colons   */
+                            /* on non-Windows platforms.            */
+    const char *const *paths;
+    size_t path_count;
+};
+
+struct PJ_PROJ_INFO {
+    const char *id;          /* Name of the projection in question          */
+    const char *description; /* Description of the projection */
+    const char *definition;  /* Projection definition  */
+    int has_inverse; /* 1 if an inverse mapping exists, 0 otherwise         */
+    double
+        accuracy; /* Expected accuracy of the transformation. -1 if unknown.  */
+};
+
+struct PJ_GRID_INFO {
+    char gridname[32];     /* name of grid                         */
+    char filename[260];    /* full path to grid                    */
+    char format[8];        /* file format of grid                  */
+    PJ_LP lowerleft;       /* Coordinates of lower left corner     */
+    PJ_LP upperright;      /* Coordinates of upper right corner    */
+    int n_lon, n_lat;      /* Grid size                            */
+    double cs_lon, cs_lat; /* Cell size of grid                    */
+};
+
+struct PJ_INIT_INFO {
+    char name[32];       /* name of init file                        */
+    char filename[260];  /* full path to the init file.              */
+    char version[32];    /* version of the init file                 */
+    char origin[32];     /* origin of the file, e.g. EPSG            */
+    char lastupdate[16]; /* Date of last update in YYYY-MM-DD format */
+};
+
+typedef enum PJ_LOG_LEVEL {
+    PJ_LOG_NONE = 0,
+    PJ_LOG_ERROR = 1,
+    PJ_LOG_DEBUG = 2,
+    PJ_LOG_TRACE = 3,
+    PJ_LOG_TELL = 4,
+    PJ_LOG_DEBUG_MAJOR = 2, /* for proj_api.h compatibility */
+    PJ_LOG_DEBUG_MINOR = 3  /* for proj_api.h compatibility */
+} PJ_LOG_LEVEL;
+
+typedef void (*PJ_LOG_FUNCTION)(void *, int, const char *);
+
+/* The context type - properly namespaced synonym for pj_ctx */
+struct pj_ctx;
+typedef struct pj_ctx PJ_CONTEXT;
+
+/* A P I */
+
+/**
+ * The objects returned by the functions defined in this section have minimal
+ * interaction with the functions of the
+ * \ref iso19111_functions section, and vice versa. See its introduction
+ * paragraph for more details.
+ */
+
+/* Functionality for handling thread contexts */
+#ifdef __cplusplus
+#define PJ_DEFAULT_CTX nullptr
+#else
+#define PJ_DEFAULT_CTX 0
+#endif
+PJ_CONTEXT PROJ_DLL *proj_context_create(void);
+PJ_CONTEXT PROJ_DLL *proj_context_destroy(PJ_CONTEXT *ctx);
+PJ_CONTEXT PROJ_DLL *proj_context_clone(PJ_CONTEXT *ctx);
+
+/** Callback to resolve a filename to a full path */
+typedef const char *(*proj_file_finder)(PJ_CONTEXT *ctx, const char *,
+                                        void *user_data);
+/*! @endcond */
+
+void PROJ_DLL proj_context_set_file_finder(PJ_CONTEXT *ctx,
+                                           proj_file_finder finder,
+                                           void *user_data);
+void PROJ_DLL proj_context_set_search_paths(PJ_CONTEXT *ctx, int count_paths,
+                                            const char *const *paths);
+void PROJ_DLL proj_context_set_ca_bundle_path(PJ_CONTEXT *ctx,
+                                              const char *path);
+/*! @cond Doxygen_Suppress */
+void PROJ_DLL proj_context_use_proj4_init_rules(PJ_CONTEXT *ctx, int enable);
+int PROJ_DLL proj_context_get_use_proj4_init_rules(PJ_CONTEXT *ctx,
+                                                   int from_legacy_code_path);
+
+/*! @endcond */
+
+/** Opaque structure for PROJ for a file handle. Implementations might cast it
+ * to their structure/class of choice. */
+typedef struct PROJ_FILE_HANDLE PROJ_FILE_HANDLE;
+
+/** Open access / mode */
+typedef enum PROJ_OPEN_ACCESS {
+    /** Read-only access. Equivalent to "rb" */
+    PROJ_OPEN_ACCESS_READ_ONLY,
+
+    /** Read-update access. File should be created if not existing. Equivalent
+       to "r+b" */
+    PROJ_OPEN_ACCESS_READ_UPDATE,
+
+    /** Create access. File should be truncated to 0-byte if already existing.
+       Equivalent to "w+b" */
+    PROJ_OPEN_ACCESS_CREATE
+} PROJ_OPEN_ACCESS;
+
+/** File API callbacks */
+typedef struct PROJ_FILE_API {
+    /** Version of this structure. Should be set to 1 currently. */
+    int version;
+
+    /** Open file. Return NULL if error */
+    PROJ_FILE_HANDLE *(*open_cbk)(PJ_CONTEXT *ctx, const char *filename,
+                                  PROJ_OPEN_ACCESS access, void *user_data);
+
+    /** Read sizeBytes into buffer from current position and return number of
+     * bytes read */
+    size_t (*read_cbk)(PJ_CONTEXT *ctx, PROJ_FILE_HANDLE *, void *buffer,
+                       size_t sizeBytes, void *user_data);
+
+    /** Write sizeBytes into buffer from current position and return number of
+     * bytes written */
+    size_t (*write_cbk)(PJ_CONTEXT *ctx, PROJ_FILE_HANDLE *, const void *buffer,
+                        size_t sizeBytes, void *user_data);
+
+    /** Seek to offset using whence=SEEK_SET/SEEK_CUR/SEEK_END. Return TRUE in
+     * case of success */
+    int (*seek_cbk)(PJ_CONTEXT *ctx, PROJ_FILE_HANDLE *, long long offset,
+                    int whence, void *user_data);
+
+    /** Return current file position */
+    unsigned long long (*tell_cbk)(PJ_CONTEXT *ctx, PROJ_FILE_HANDLE *,
+                                   void *user_data);
+
+    /** Close file */
+    void (*close_cbk)(PJ_CONTEXT *ctx, PROJ_FILE_HANDLE *, void *user_data);
+
+    /** Return TRUE if a file exists */
+    int (*exists_cbk)(PJ_CONTEXT *ctx, const char *filename, void *user_data);
+
+    /** Return TRUE if directory exists or could be created  */
+    int (*mkdir_cbk)(PJ_CONTEXT *ctx, const char *filename, void *user_data);
+
+    /** Return TRUE if file could be removed  */
+    int (*unlink_cbk)(PJ_CONTEXT *ctx, const char *filename, void *user_data);
+
+    /** Return TRUE if file could be renamed  */
+    int (*rename_cbk)(PJ_CONTEXT *ctx, const char *oldPath, const char *newPath,
+                      void *user_data);
+} PROJ_FILE_API;
+
+int PROJ_DLL proj_context_set_fileapi(PJ_CONTEXT *ctx,
+                                      const PROJ_FILE_API *fileapi,
+                                      void *user_data);
+
+void PROJ_DLL proj_context_set_sqlite3_vfs_name(PJ_CONTEXT *ctx,
+                                                const char *name);
+
+/** Opaque structure for PROJ for a network handle. Implementations might cast
+ * it to their structure/class of choice. */
+typedef struct PROJ_NETWORK_HANDLE PROJ_NETWORK_HANDLE;
+
+/** Network access: open callback
+ *
+ * Should try to read the size_to_read first bytes at the specified offset of
+ * the file given by URL url,
+ * and write them to buffer. *out_size_read should be updated with the actual
+ * amount of bytes read (== size_to_read if the file is larger than
+ * size_to_read). During this read, the implementation should make sure to store
+ * the HTTP headers from the server response to be able to respond to
+ * proj_network_get_header_value_cbk_type callback.
+ *
+ * error_string_max_size should be the maximum size that can be written into
+ * the out_error_string buffer (including terminating nul character).
+ *
+ * @return a non-NULL opaque handle in case of success.
+ */
+typedef PROJ_NETWORK_HANDLE *(*proj_network_open_cbk_type)(
+    PJ_CONTEXT *ctx, const char *url, unsigned long long offset,
+    size_t size_to_read, void *buffer, size_t *out_size_read,
+    size_t error_string_max_size, char *out_error_string, void *user_data);
+
+/** Network access: close callback */
+typedef void (*proj_network_close_cbk_type)(PJ_CONTEXT *ctx,
+                                            PROJ_NETWORK_HANDLE *handle,
+                                            void *user_data);
+
+/** Network access: get HTTP headers */
+typedef const char *(*proj_network_get_header_value_cbk_type)(
+    PJ_CONTEXT *ctx, PROJ_NETWORK_HANDLE *handle, const char *header_name,
+    void *user_data);
+
+/** Network access: read range
+ *
+ * Read size_to_read bytes from handle, starting at offset, into
+ * buffer.
+ * During this read, the implementation should make sure to store the HTTP
+ * headers from the server response to be able to respond to
+ * proj_network_get_header_value_cbk_type callback.
+ *
+ * error_string_max_size should be the maximum size that can be written into
+ * the out_error_string buffer (including terminating nul character).
+ *
+ * @return the number of bytes actually read (0 in case of error)
+ */
+typedef size_t (*proj_network_read_range_type)(
+    PJ_CONTEXT *ctx, PROJ_NETWORK_HANDLE *handle, unsigned long long offset,
+    size_t size_to_read, void *buffer, size_t error_string_max_size,
+    char *out_error_string, void *user_data);
+
+int PROJ_DLL proj_context_set_network_callbacks(
+    PJ_CONTEXT *ctx, proj_network_open_cbk_type open_cbk,
+    proj_network_close_cbk_type close_cbk,
+    proj_network_get_header_value_cbk_type get_header_value_cbk,
+    proj_network_read_range_type read_range_cbk, void *user_data);
+
+int PROJ_DLL proj_context_set_enable_network(PJ_CONTEXT *ctx, int enabled);
+
+int PROJ_DLL proj_context_is_network_enabled(PJ_CONTEXT *ctx);
+
+void PROJ_DLL proj_context_set_url_endpoint(PJ_CONTEXT *ctx, const char *url);
+
+const char PROJ_DLL *proj_context_get_url_endpoint(PJ_CONTEXT *ctx);
+
+const char PROJ_DLL *proj_context_get_user_writable_directory(PJ_CONTEXT *ctx,
+                                                              int create);
+
+void PROJ_DLL proj_grid_cache_set_enable(PJ_CONTEXT *ctx, int enabled);
+
+void PROJ_DLL proj_grid_cache_set_filename(PJ_CONTEXT *ctx,
+                                           const char *fullname);
+
+void PROJ_DLL proj_grid_cache_set_max_size(PJ_CONTEXT *ctx, int max_size_MB);
+
+void PROJ_DLL proj_grid_cache_set_ttl(PJ_CONTEXT *ctx, int ttl_seconds);
+
+void PROJ_DLL proj_grid_cache_clear(PJ_CONTEXT *ctx);
+
+int PROJ_DLL proj_is_download_needed(PJ_CONTEXT *ctx,
+                                     const char *url_or_filename,
+                                     int ignore_ttl_setting);
+int PROJ_DLL proj_download_file(PJ_CONTEXT *ctx, const char *url_or_filename,
+                                int ignore_ttl_setting,
+                                int (*progress_cbk)(PJ_CONTEXT *, double pct,
+                                                    void *user_data),
+                                void *user_data);
+
+/*! @cond Doxygen_Suppress */
+
+/* Manage the transformation definition object PJ */
+PJ PROJ_DLL *proj_create(PJ_CONTEXT *ctx, const char *definition);
+PJ PROJ_DLL *proj_create_argv(PJ_CONTEXT *ctx, int argc, char **argv);
+PJ PROJ_DLL *proj_create_crs_to_crs(PJ_CONTEXT *ctx, const char *source_crs,
+                                    const char *target_crs, PJ_AREA *area);
+PJ PROJ_DLL *proj_create_crs_to_crs_from_pj(PJ_CONTEXT *ctx,
+                                            const PJ *source_crs,
+                                            const PJ *target_crs, PJ_AREA *area,
+                                            const char *const *options);
+/*! @endcond */
+PJ PROJ_DLL *proj_normalize_for_visualization(PJ_CONTEXT *ctx, const PJ *obj);
+/*! @cond Doxygen_Suppress */
+void PROJ_DLL proj_assign_context(PJ *pj, PJ_CONTEXT *ctx);
+PJ PROJ_DLL *proj_destroy(PJ *P);
+
+PJ_AREA PROJ_DLL *proj_area_create(void);
+void PROJ_DLL proj_area_set_bbox(PJ_AREA *area, double west_lon_degree,
+                                 double south_lat_degree,
+                                 double east_lon_degree,
+                                 double north_lat_degree);
+void PROJ_DLL proj_area_set_name(PJ_AREA *area, const char *name);
+void PROJ_DLL proj_area_destroy(PJ_AREA *area);
+
+/* Apply transformation to observation - in forward or inverse direction */
+enum PJ_DIRECTION {
+    PJ_FWD = 1,   /* Forward    */
+    PJ_IDENT = 0, /* Do nothing */
+    PJ_INV = -1   /* Inverse    */
+};
+typedef enum PJ_DIRECTION PJ_DIRECTION;
+
+int PROJ_DLL proj_angular_input(PJ *P, enum PJ_DIRECTION dir);
+int PROJ_DLL proj_angular_output(PJ *P, enum PJ_DIRECTION dir);
+
+int PROJ_DLL proj_degree_input(PJ *P, enum PJ_DIRECTION dir);
+int PROJ_DLL proj_degree_output(PJ *P, enum PJ_DIRECTION dir);
+
+PJ_COORD PROJ_DLL proj_trans(PJ *P, PJ_DIRECTION direction, PJ_COORD coord);
+PJ PROJ_DLL *proj_trans_get_last_used_operation(PJ *P);
+int PROJ_DLL proj_trans_array(PJ *P, PJ_DIRECTION direction, size_t n,
+                              PJ_COORD *coord);
+size_t PROJ_DLL proj_trans_generic(PJ *P, PJ_DIRECTION direction, double *x,
+                                   size_t sx, size_t nx, double *y, size_t sy,
+                                   size_t ny, double *z, size_t sz, size_t nz,
+                                   double *t, size_t st, size_t nt);
+/*! @endcond */
+int PROJ_DLL proj_trans_bounds(PJ_CONTEXT *context, PJ *P,
+                               PJ_DIRECTION direction, double xmin, double ymin,
+                               double xmax, double ymax, double *out_xmin,
+                               double *out_ymin, double *out_xmax,
+                               double *out_ymax, int densify_pts);
+/*! @cond Doxygen_Suppress */
+
+/* Initializers */
+PJ_COORD PROJ_DLL proj_coord(double x, double y, double z, double t);
+
+/* Measure internal consistency - in forward or inverse direction */
+double PROJ_DLL proj_roundtrip(PJ *P, PJ_DIRECTION direction, int n,
+                               PJ_COORD *coord);
+
+/* Geodesic distance between two points with angular 2D coordinates */
+double PROJ_DLL proj_lp_dist(const PJ *P, PJ_COORD a, PJ_COORD b);
+
+/* The geodesic distance AND the vertical offset */
+double PROJ_DLL proj_lpz_dist(const PJ *P, PJ_COORD a, PJ_COORD b);
+
+/* Euclidean distance between two points with linear 2D coordinates */
+double PROJ_DLL proj_xy_dist(PJ_COORD a, PJ_COORD b);
+
+/* Euclidean distance between two points with linear 3D coordinates */
+double PROJ_DLL proj_xyz_dist(PJ_COORD a, PJ_COORD b);
+
+/* Geodesic distance (in meter) + fwd and rev azimuth between two points on the
+ * ellipsoid */
+PJ_COORD PROJ_DLL proj_geod(const PJ *P, PJ_COORD a, PJ_COORD b);
+
+/* PROJ error codes */
+
+/** Error codes typically related to coordinate operation initialization
+ * Note: some of them can also be emitted during coordinate transformation,
+ * like PROJ_ERR_INVALID_OP_FILE_NOT_FOUND_OR_INVALID in case the resource
+ * loading is deferred until it is really needed.
+ */
+#define PROJ_ERR_INVALID_OP                                                    \
+    1024 /* other/unspecified error related to coordinate operation            \
+            initialization */
+#define PROJ_ERR_INVALID_OP_WRONG_SYNTAX                                       \
+    (PROJ_ERR_INVALID_OP +                                                     \
+     1) /* invalid pipeline structure, missing +proj argument, etc */
+#define PROJ_ERR_INVALID_OP_MISSING_ARG                                        \
+    (PROJ_ERR_INVALID_OP + 2) /* missing required operation parameter */
+#define PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE                                  \
+    (PROJ_ERR_INVALID_OP +                                                     \
+     3) /* one of the operation parameter has an illegal value */
+#define PROJ_ERR_INVALID_OP_MUTUALLY_EXCLUSIVE_ARGS                            \
+    (PROJ_ERR_INVALID_OP + 4) /* mutually exclusive arguments */
+#define PROJ_ERR_INVALID_OP_FILE_NOT_FOUND_OR_INVALID                          \
+    (PROJ_ERR_INVALID_OP + 5) /* file not found (particular case of            \
+                                 PROJ_ERR_INVALID_OP_ILLEGAL_ARG_VALUE) */
+
+/** Error codes related to transformation on a specific coordinate */
+#define PROJ_ERR_COORD_TRANSFM                                                 \
+    2048 /* other error related to coordinate transformation */
+#define PROJ_ERR_COORD_TRANSFM_INVALID_COORD                                   \
+    (PROJ_ERR_COORD_TRANSFM + 1) /* for e.g lat > 90deg */
+#define PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN                       \
+    (PROJ_ERR_COORD_TRANSFM +                                                  \
+     2) /* coordinate is outside of the projection domain. e.g approximate     \
+           mercator with |longitude - lon_0| > 90deg, or iterative convergence \
+           method failed */
+#define PROJ_ERR_COORD_TRANSFM_NO_OPERATION                                    \
+    (PROJ_ERR_COORD_TRANSFM +                                                  \
+     3) /* no operation found, e.g if no match the required accuracy, or if    \
+           ballpark transformations were asked to not be used and they would   \
+           be only such candidate */
+#define PROJ_ERR_COORD_TRANSFM_OUTSIDE_GRID                                    \
+    (PROJ_ERR_COORD_TRANSFM +                                                  \
+     4) /* point to transform falls outside grid or subgrid */
+#define PROJ_ERR_COORD_TRANSFM_GRID_AT_NODATA                                  \
+    (PROJ_ERR_COORD_TRANSFM +                                                  \
+     5) /* point to transform falls in a grid cell that evaluates to nodata */
+
+/** Other type of errors */
+#define PROJ_ERR_OTHER 4096
+#define PROJ_ERR_OTHER_API_MISUSE                                              \
+    (PROJ_ERR_OTHER + 1) /* error related to a misuse of PROJ API */
+#define PROJ_ERR_OTHER_NO_INVERSE_OP                                           \
+    (PROJ_ERR_OTHER + 2) /* no inverse method available */
+#define PROJ_ERR_OTHER_NETWORK_ERROR                                           \
+    (PROJ_ERR_OTHER + 3) /* failure when accessing a network resource */
+
+/* Set or read error level */
+int PROJ_DLL proj_context_errno(PJ_CONTEXT *ctx);
+int PROJ_DLL proj_errno(const PJ *P);
+int PROJ_DLL proj_errno_set(const PJ *P, int err);
+int PROJ_DLL proj_errno_reset(const PJ *P);
+int PROJ_DLL proj_errno_restore(const PJ *P, int err);
+const char PROJ_DLL *
+proj_errno_string(int err); /* deprecated. use proj_context_errno_string() */
+const char PROJ_DLL *proj_context_errno_string(PJ_CONTEXT *ctx, int err);
+
+PJ_LOG_LEVEL PROJ_DLL proj_log_level(PJ_CONTEXT *ctx, PJ_LOG_LEVEL log_level);
+void PROJ_DLL proj_log_func(PJ_CONTEXT *ctx, void *app_data,
+                            PJ_LOG_FUNCTION logf);
+
+/* Scaling and angular distortion factors */
+PJ_FACTORS PROJ_DLL proj_factors(PJ *P, PJ_COORD lp);
+
+/* Info functions - get information about various PROJ.4 entities */
+PJ_INFO PROJ_DLL proj_info(void);
+PJ_PROJ_INFO PROJ_DLL proj_pj_info(PJ *P);
+PJ_GRID_INFO PROJ_DLL proj_grid_info(const char *gridname);
+PJ_INIT_INFO PROJ_DLL proj_init_info(const char *initname);
+
+/* List functions: */
+/* Get lists of operations, ellipsoids, units and prime meridians. */
+const PJ_OPERATIONS PROJ_DLL *proj_list_operations(void);
+const PJ_ELLPS PROJ_DLL *proj_list_ellps(void);
+PROJ_DEPRECATED(const PJ_UNITS PROJ_DLL *proj_list_units(void),
+                "Deprecated by proj_get_units_from_database");
+PROJ_DEPRECATED(const PJ_UNITS PROJ_DLL *proj_list_angular_units(void),
+                "Deprecated by proj_get_units_from_database");
+const PJ_PRIME_MERIDIANS PROJ_DLL *proj_list_prime_meridians(void);
+
+/* These are trivial, and while occasionally useful in real code, primarily here
+ * to      */
+/* simplify demo code, and in acknowledgement of the proj-internal discrepancy
+ * between   */
+/* angular units expected by classical proj, and by Charles Karney's geodesics
+ * subsystem */
+double PROJ_DLL proj_torad(double angle_in_degrees);
+double PROJ_DLL proj_todeg(double angle_in_radians);
+
+double PROJ_DLL proj_dmstor(const char *is, char **rs);
+PROJ_DEPRECATED(char PROJ_DLL *proj_rtodms(char *s, double r, int pos, int neg),
+                "Deprecated by proj_rtodms2");
+char PROJ_DLL *proj_rtodms2(char *s, size_t sizeof_s, double r, int pos,
+                            int neg);
+
+void PROJ_DLL proj_cleanup(void);
+
+/*! @endcond */
+
+/* ------------------------------------------------------------------------- */
+/* Binding in C of C++ API */
+/* ------------------------------------------------------------------------- */
+
+/** @defgroup iso19111_types Data types for ISO19111 C API
+ *  Data types for ISO19111 C API
+ *  @{
+ */
+
+/** \brief Type representing a NULL terminated list of NULL-terminate strings.
+ */
+typedef char **PROJ_STRING_LIST;
+
+/** \brief Guessed WKT "dialect". */
+typedef enum {
+    /** \ref WKT2_2019 */
+    PJ_GUESSED_WKT2_2019,
+
+    /** Deprecated alias for PJ_GUESSED_WKT2_2019 */
+    PJ_GUESSED_WKT2_2018 = PJ_GUESSED_WKT2_2019,
+
+    /** \ref WKT2_2015 */
+    PJ_GUESSED_WKT2_2015,
+
+    /** \ref WKT1 */
+    PJ_GUESSED_WKT1_GDAL,
+
+    /** ESRI variant of WKT1 */
+    PJ_GUESSED_WKT1_ESRI,
+
+    /** Not WKT / unrecognized */
+    PJ_GUESSED_NOT_WKT
+} PJ_GUESSED_WKT_DIALECT;
+
+/** \brief Object category. */
+typedef enum {
+    PJ_CATEGORY_ELLIPSOID,
+    PJ_CATEGORY_PRIME_MERIDIAN,
+    PJ_CATEGORY_DATUM,
+    PJ_CATEGORY_CRS,
+    PJ_CATEGORY_COORDINATE_OPERATION,
+    PJ_CATEGORY_DATUM_ENSEMBLE
+} PJ_CATEGORY;
+
+/** \brief Object type. */
+typedef enum {
+    PJ_TYPE_UNKNOWN,
+
+    PJ_TYPE_ELLIPSOID,
+
+    PJ_TYPE_PRIME_MERIDIAN,
+
+    PJ_TYPE_GEODETIC_REFERENCE_FRAME,
+    PJ_TYPE_DYNAMIC_GEODETIC_REFERENCE_FRAME,
+    PJ_TYPE_VERTICAL_REFERENCE_FRAME,
+    PJ_TYPE_DYNAMIC_VERTICAL_REFERENCE_FRAME,
+    PJ_TYPE_DATUM_ENSEMBLE,
+
+    /** Abstract type, not returned by proj_get_type() */
+    PJ_TYPE_CRS,
+
+    PJ_TYPE_GEODETIC_CRS,
+    PJ_TYPE_GEOCENTRIC_CRS,
+
+    /** proj_get_type() will never return that type, but
+     * PJ_TYPE_GEOGRAPHIC_2D_CRS or PJ_TYPE_GEOGRAPHIC_3D_CRS. */
+    PJ_TYPE_GEOGRAPHIC_CRS,
+
+    PJ_TYPE_GEOGRAPHIC_2D_CRS,
+    PJ_TYPE_GEOGRAPHIC_3D_CRS,
+    PJ_TYPE_VERTICAL_CRS,
+    PJ_TYPE_PROJECTED_CRS,
+    PJ_TYPE_COMPOUND_CRS,
+    PJ_TYPE_TEMPORAL_CRS,
+    PJ_TYPE_ENGINEERING_CRS,
+    PJ_TYPE_BOUND_CRS,
+    PJ_TYPE_OTHER_CRS,
+
+    PJ_TYPE_CONVERSION,
+    PJ_TYPE_TRANSFORMATION,
+    PJ_TYPE_CONCATENATED_OPERATION,
+    PJ_TYPE_OTHER_COORDINATE_OPERATION,
+
+    PJ_TYPE_TEMPORAL_DATUM,
+    PJ_TYPE_ENGINEERING_DATUM,
+    PJ_TYPE_PARAMETRIC_DATUM,
+
+    PJ_TYPE_DERIVED_PROJECTED_CRS,
+
+    PJ_TYPE_COORDINATE_METADATA,
+} PJ_TYPE;
+
+/** Comparison criterion. */
+typedef enum {
+    /** All properties are identical. */
+    PJ_COMP_STRICT,
+
+    /** The objects are equivalent for the purpose of coordinate
+     * operations. They can differ by the name of their objects,
+     * identifiers, other metadata.
+     * Parameters may be expressed in different units, provided that the
+     * value is (with some tolerance) the same once expressed in a
+     * common unit.
+     */
+    PJ_COMP_EQUIVALENT,
+
+    /** Same as EQUIVALENT, relaxed with an exception that the axis order
+     * of the base CRS of a DerivedCRS/ProjectedCRS or the axis order of
+     * a GeographicCRS is ignored. Only to be used
+     * with DerivedCRS/ProjectedCRS/GeographicCRS */
+    PJ_COMP_EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS,
+} PJ_COMPARISON_CRITERION;
+
+/** \brief WKT version. */
+typedef enum {
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2 */
+    PJ_WKT2_2015,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_SIMPLIFIED */
+    PJ_WKT2_2015_SIMPLIFIED,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2019 */
+    PJ_WKT2_2019,
+    /** Deprecated alias for PJ_WKT2_2019 */
+    PJ_WKT2_2018 = PJ_WKT2_2019,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT2_2019_SIMPLIFIED */
+    PJ_WKT2_2019_SIMPLIFIED,
+    /** Deprecated alias for PJ_WKT2_2019 */
+    PJ_WKT2_2018_SIMPLIFIED = PJ_WKT2_2019_SIMPLIFIED,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT1_GDAL */
+    PJ_WKT1_GDAL,
+    /** cf osgeo::proj::io::WKTFormatter::Convention::WKT1_ESRI */
+    PJ_WKT1_ESRI
+} PJ_WKT_TYPE;
+
+/** Specify how source and target CRS extent should be used to restrict
+ * candidate operations (only taken into account if no explicit area of
+ * interest is specified. */
+typedef enum {
+    /** Ignore CRS extent */
+    PJ_CRS_EXTENT_NONE,
+
+    /** Test coordinate operation extent against both CRS extent. */
+    PJ_CRS_EXTENT_BOTH,
+
+    /** Test coordinate operation extent against the intersection of both
+        CRS extent. */
+    PJ_CRS_EXTENT_INTERSECTION,
+
+    /** Test coordinate operation against the smallest of both CRS extent. */
+    PJ_CRS_EXTENT_SMALLEST
+} PROJ_CRS_EXTENT_USE;
+
+/** Describe how grid availability is used. */
+typedef enum {
+    /** Grid availability is only used for sorting results. Operations
+     * where some grids are missing will be sorted last. */
+    PROJ_GRID_AVAILABILITY_USED_FOR_SORTING,
+
+    /** Completely discard an operation if a required grid is missing. */
+    PROJ_GRID_AVAILABILITY_DISCARD_OPERATION_IF_MISSING_GRID,
+
+    /** Ignore grid availability at all. Results will be presented as if
+     * all grids were available. */
+    PROJ_GRID_AVAILABILITY_IGNORED,
+
+    /** Results will be presented as if grids known to PROJ (that is
+     * registered in the grid_alternatives table of its database) were
+     * available. Used typically when networking is enabled.
+     */
+    PROJ_GRID_AVAILABILITY_KNOWN_AVAILABLE,
+} PROJ_GRID_AVAILABILITY_USE;
+
+/** \brief PROJ string version. */
+typedef enum {
+    /** cf osgeo::proj::io::PROJStringFormatter::Convention::PROJ_5 */
+    PJ_PROJ_5,
+    /** cf osgeo::proj::io::PROJStringFormatter::Convention::PROJ_4 */
+    PJ_PROJ_4
+} PJ_PROJ_STRING_TYPE;
+
+/** Spatial criterion to restrict candidate operations. */
+typedef enum {
+    /** The area of validity of transforms should strictly contain the
+     * are of interest. */
+    PROJ_SPATIAL_CRITERION_STRICT_CONTAINMENT,
+
+    /** The area of validity of transforms should at least intersect the
+     * area of interest. */
+    PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION
+} PROJ_SPATIAL_CRITERION;
+
+/** Describe if and how intermediate CRS should be used */
+typedef enum {
+    /** Always search for intermediate CRS. */
+    PROJ_INTERMEDIATE_CRS_USE_ALWAYS,
+
+    /** Only attempt looking for intermediate CRS if there is no direct
+     * transformation available. */
+    PROJ_INTERMEDIATE_CRS_USE_IF_NO_DIRECT_TRANSFORMATION,
+
+    /* Do not attempt looking for intermediate CRS. */
+    PROJ_INTERMEDIATE_CRS_USE_NEVER,
+} PROJ_INTERMEDIATE_CRS_USE;
+
+/** Type of coordinate system. */
+typedef enum {
+    PJ_CS_TYPE_UNKNOWN,
+
+    PJ_CS_TYPE_CARTESIAN,
+    PJ_CS_TYPE_ELLIPSOIDAL,
+    PJ_CS_TYPE_VERTICAL,
+    PJ_CS_TYPE_SPHERICAL,
+    PJ_CS_TYPE_ORDINAL,
+    PJ_CS_TYPE_PARAMETRIC,
+    PJ_CS_TYPE_DATETIMETEMPORAL,
+    PJ_CS_TYPE_TEMPORALCOUNT,
+    PJ_CS_TYPE_TEMPORALMEASURE
+} PJ_COORDINATE_SYSTEM_TYPE;
+
+/** \brief Structure given overall description of a CRS.
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ */
+typedef struct {
+    /** Authority name. */
+    char *auth_name;
+    /** Object code. */
+    char *code;
+    /** Object name. */
+    char *name;
+    /** Object type. */
+    PJ_TYPE type;
+    /** Whether the object is deprecated */
+    int deprecated;
+    /** Whereas the west_lon_degree, south_lat_degree, east_lon_degree and
+     * north_lat_degree fields are valid. */
+    int bbox_valid;
+    /** Western-most longitude of the area of use, in degrees. */
+    double west_lon_degree;
+    /** Southern-most latitude of the area of use, in degrees. */
+    double south_lat_degree;
+    /** Eastern-most longitude of the area of use, in degrees. */
+    double east_lon_degree;
+    /** Northern-most latitude of the area of use, in degrees. */
+    double north_lat_degree;
+    /** Name of the area of use. */
+    char *area_name;
+    /** Name of the projection method for a projected CRS. Might be NULL even
+     *for projected CRS in some cases. */
+    char *projection_method_name;
+
+    /** Name of the celestial body of the CRS (e.g. "Earth").
+     * @since 8.1
+     */
+    char *celestial_body_name;
+} PROJ_CRS_INFO;
+
+/** \brief Structure describing optional parameters for proj_get_crs_list();
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ */
+typedef struct {
+    /** Array of allowed object types. Should be NULL if all types are allowed*/
+    const PJ_TYPE *types;
+    /** Size of types. Should be 0 if all types are allowed*/
+    size_t typesCount;
+
+    /** If TRUE and bbox_valid == TRUE, then only CRS whose area of use
+     * entirely contains the specified bounding box will be returned.
+     * If FALSE and bbox_valid == TRUE, then only CRS whose area of use
+     * intersects the specified bounding box will be returned.
+     */
+    int crs_area_of_use_contains_bbox;
+    /** To set to TRUE so that west_lon_degree, south_lat_degree,
+     * east_lon_degree and north_lat_degree fields are taken into account. */
+    int bbox_valid;
+    /** Western-most longitude of the area of use, in degrees. */
+    double west_lon_degree;
+    /** Southern-most latitude of the area of use, in degrees. */
+    double south_lat_degree;
+    /** Eastern-most longitude of the area of use, in degrees. */
+    double east_lon_degree;
+    /** Northern-most latitude of the area of use, in degrees. */
+    double north_lat_degree;
+
+    /** Whether deprecated objects are allowed. Default to FALSE. */
+    int allow_deprecated;
+
+    /** Celestial body of the CRS (e.g. "Earth"). The default value, NULL,
+     *  means no restriction
+     * @since 8.1
+     */
+    const char *celestial_body_name;
+} PROJ_CRS_LIST_PARAMETERS;
+
+/** \brief Structure given description of a unit.
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ * @since 7.1
+ */
+typedef struct {
+    /** Authority name. */
+    char *auth_name;
+
+    /** Object code. */
+    char *code;
+
+    /** Object name. For example "metre", "US survey foot", etc. */
+    char *name;
+
+    /** Category of the unit: one of "linear", "linear_per_time", "angular",
+     * "angular_per_time", "scale", "scale_per_time" or "time" */
+    char *category;
+
+    /** Conversion factor to apply to transform from that unit to the
+     * corresponding SI unit (metre for "linear", radian for "angular", etc.).
+     * It might be 0 in some cases to indicate no known conversion factor. */
+    double conv_factor;
+
+    /** PROJ short name, like "m", "ft", "us-ft", etc... Might be NULL */
+    char *proj_short_name;
+
+    /** Whether the object is deprecated */
+    int deprecated;
+} PROJ_UNIT_INFO;
+
+/** \brief Structure given description of a celestial body.
+ *
+ * This structure may grow over time, and should not be directly allocated by
+ * client code.
+ * @since 8.1
+ */
+typedef struct {
+    /** Authority name. */
+    char *auth_name;
+
+    /** Object name. For example "Earth" */
+    char *name;
+
+} PROJ_CELESTIAL_BODY_INFO;
+
+/**@}*/
+
+/**
+ * \defgroup iso19111_functions Binding in C of basic methods from the C++ API
+ *  Functions for ISO19111 C API
+ *
+ * The PJ* objects returned by proj_create_from_wkt(),
+ * proj_create_from_database() and other functions in that section
+ * will have generally minimal interaction with the functions declared in the
+ * upper section of this header file (calling those functions on those objects
+ * will either return an error or default/nonsensical values). The exception is
+ * for ISO19111 objects of type CoordinateOperation that can be exported as a
+ * valid PROJ pipeline. In this case, the PJ objects will work for example with
+ * proj_trans_generic().
+ * Conversely, objects returned by proj_create() and proj_create_argv(), which
+ * are not of type CRS, will return an error when used with functions of this
+ * section.
+ * @{
+ */
+
+/*! @cond Doxygen_Suppress */
+typedef struct PJ_OBJ_LIST PJ_OBJ_LIST;
+/*! @endcond */
+
+void PROJ_DLL proj_string_list_destroy(PROJ_STRING_LIST list);
+
+void PROJ_DLL proj_context_set_autoclose_database(PJ_CONTEXT *ctx,
+                                                  int autoclose);
+
+int PROJ_DLL proj_context_set_database_path(PJ_CONTEXT *ctx, const char *dbPath,
+                                            const char *const *auxDbPaths,
+                                            const char *const *options);
+
+const char PROJ_DLL *proj_context_get_database_path(PJ_CONTEXT *ctx);
+
+const char PROJ_DLL *proj_context_get_database_metadata(PJ_CONTEXT *ctx,
+                                                        const char *key);
+
+PROJ_STRING_LIST PROJ_DLL proj_context_get_database_structure(
+    PJ_CONTEXT *ctx, const char *const *options);
+
+PJ_GUESSED_WKT_DIALECT PROJ_DLL proj_context_guess_wkt_dialect(PJ_CONTEXT *ctx,
+                                                               const char *wkt);
+
+PJ PROJ_DLL *proj_create_from_wkt(PJ_CONTEXT *ctx, const char *wkt,
+                                  const char *const *options,
+                                  PROJ_STRING_LIST *out_warnings,
+                                  PROJ_STRING_LIST *out_grammar_errors);
+
+PJ PROJ_DLL *proj_create_from_database(PJ_CONTEXT *ctx, const char *auth_name,
+                                       const char *code, PJ_CATEGORY category,
+                                       int usePROJAlternativeGridNames,
+                                       const char *const *options);
+
+int PROJ_DLL proj_uom_get_info_from_database(
+    PJ_CONTEXT *ctx, const char *auth_name, const char *code,
+    const char **out_name, double *out_conv_factor, const char **out_category);
+
+int PROJ_DLL proj_grid_get_info_from_database(
+    PJ_CONTEXT *ctx, const char *grid_name, const char **out_full_name,
+    const char **out_package_name, const char **out_url,
+    int *out_direct_download, int *out_open_license, int *out_available);
+
+PJ PROJ_DLL *proj_clone(PJ_CONTEXT *ctx, const PJ *obj);
+
+PJ_OBJ_LIST PROJ_DLL *
+proj_create_from_name(PJ_CONTEXT *ctx, const char *auth_name,
+                      const char *searchedName, const PJ_TYPE *types,
+                      size_t typesCount, int approximateMatch,
+                      size_t limitResultCount, const char *const *options);
+
+PJ_TYPE PROJ_DLL proj_get_type(const PJ *obj);
+
+int PROJ_DLL proj_is_deprecated(const PJ *obj);
+
+PJ_OBJ_LIST PROJ_DLL *proj_get_non_deprecated(PJ_CONTEXT *ctx, const PJ *obj);
+
+int PROJ_DLL proj_is_equivalent_to(const PJ *obj, const PJ *other,
+                                   PJ_COMPARISON_CRITERION criterion);
+
+int PROJ_DLL proj_is_equivalent_to_with_ctx(PJ_CONTEXT *ctx, const PJ *obj,
+                                            const PJ *other,
+                                            PJ_COMPARISON_CRITERION criterion);
+
+int PROJ_DLL proj_is_crs(const PJ *obj);
+
+const char PROJ_DLL *proj_get_name(const PJ *obj);
+
+const char PROJ_DLL *proj_get_id_auth_name(const PJ *obj, int index);
+
+const char PROJ_DLL *proj_get_id_code(const PJ *obj, int index);
+
+const char PROJ_DLL *proj_get_remarks(const PJ *obj);
+
+int PROJ_DLL proj_get_domain_count(const PJ *obj);
+
+const char PROJ_DLL *proj_get_scope(const PJ *obj);
+
+const char PROJ_DLL *proj_get_scope_ex(const PJ *obj, int domainIdx);
+
+int PROJ_DLL proj_get_area_of_use(PJ_CONTEXT *ctx, const PJ *obj,
+                                  double *out_west_lon_degree,
+                                  double *out_south_lat_degree,
+                                  double *out_east_lon_degree,
+                                  double *out_north_lat_degree,
+                                  const char **out_area_name);
+
+int PROJ_DLL proj_get_area_of_use_ex(PJ_CONTEXT *ctx, const PJ *obj,
+                                     int domainIdx, double *out_west_lon_degree,
+                                     double *out_south_lat_degree,
+                                     double *out_east_lon_degree,
+                                     double *out_north_lat_degree,
+                                     const char **out_area_name);
+
+const char PROJ_DLL *proj_as_wkt(PJ_CONTEXT *ctx, const PJ *obj,
+                                 PJ_WKT_TYPE type, const char *const *options);
+
+const char PROJ_DLL *proj_as_proj_string(PJ_CONTEXT *ctx, const PJ *obj,
+                                         PJ_PROJ_STRING_TYPE type,
+                                         const char *const *options);
+
+const char PROJ_DLL *proj_as_projjson(PJ_CONTEXT *ctx, const PJ *obj,
+                                      const char *const *options);
+
+PJ PROJ_DLL *proj_get_source_crs(PJ_CONTEXT *ctx, const PJ *obj);
+
+PJ PROJ_DLL *proj_get_target_crs(PJ_CONTEXT *ctx, const PJ *obj);
+
+PJ_OBJ_LIST PROJ_DLL *proj_identify(PJ_CONTEXT *ctx, const PJ *obj,
+                                    const char *auth_name,
+                                    const char *const *options,
+                                    int **out_confidence);
+
+PROJ_STRING_LIST PROJ_DLL proj_get_geoid_models_from_database(
+    PJ_CONTEXT *ctx, const char *auth_name, const char *code,
+    const char *const *options);
+
+void PROJ_DLL proj_int_list_destroy(int *list);
+
+/* ------------------------------------------------------------------------- */
+
+PROJ_STRING_LIST PROJ_DLL proj_get_authorities_from_database(PJ_CONTEXT *ctx);
+
+PROJ_STRING_LIST PROJ_DLL proj_get_codes_from_database(PJ_CONTEXT *ctx,
+                                                       const char *auth_name,
+                                                       PJ_TYPE type,
+                                                       int allow_deprecated);
+
+PROJ_CELESTIAL_BODY_INFO PROJ_DLL **proj_get_celestial_body_list_from_database(
+    PJ_CONTEXT *ctx, const char *auth_name, int *out_result_count);
+
+void PROJ_DLL proj_celestial_body_list_destroy(PROJ_CELESTIAL_BODY_INFO **list);
+
+PROJ_CRS_LIST_PARAMETERS PROJ_DLL *proj_get_crs_list_parameters_create(void);
+
+void PROJ_DLL
+proj_get_crs_list_parameters_destroy(PROJ_CRS_LIST_PARAMETERS *params);
+
+PROJ_CRS_INFO PROJ_DLL **
+proj_get_crs_info_list_from_database(PJ_CONTEXT *ctx, const char *auth_name,
+                                     const PROJ_CRS_LIST_PARAMETERS *params,
+                                     int *out_result_count);
+
+void PROJ_DLL proj_crs_info_list_destroy(PROJ_CRS_INFO **list);
+
+PROJ_UNIT_INFO PROJ_DLL **proj_get_units_from_database(PJ_CONTEXT *ctx,
+                                                       const char *auth_name,
+                                                       const char *category,
+                                                       int allow_deprecated,
+                                                       int *out_result_count);
+
+void PROJ_DLL proj_unit_list_destroy(PROJ_UNIT_INFO **list);
+
+/* ------------------------------------------------------------------------- */
+/*! @cond Doxygen_Suppress */
+typedef struct PJ_INSERT_SESSION PJ_INSERT_SESSION;
+/*! @endcond */
+
+PJ_INSERT_SESSION PROJ_DLL *proj_insert_object_session_create(PJ_CONTEXT *ctx);
+
+void PROJ_DLL proj_insert_object_session_destroy(PJ_CONTEXT *ctx,
+                                                 PJ_INSERT_SESSION *session);
+
+PROJ_STRING_LIST PROJ_DLL proj_get_insert_statements(
+    PJ_CONTEXT *ctx, PJ_INSERT_SESSION *session, const PJ *object,
+    const char *authority, const char *code, int numeric_codes,
+    const char *const *allowed_authorities, const char *const *options);
+
+char PROJ_DLL *proj_suggests_code_for(PJ_CONTEXT *ctx, const PJ *object,
+                                      const char *authority, int numeric_code,
+                                      const char *const *options);
+
+void PROJ_DLL proj_string_destroy(char *str);
+
+/* ------------------------------------------------------------------------- */
+/*! @cond Doxygen_Suppress */
+typedef struct PJ_OPERATION_FACTORY_CONTEXT PJ_OPERATION_FACTORY_CONTEXT;
+/*! @endcond */
+
+PJ_OPERATION_FACTORY_CONTEXT PROJ_DLL *
+proj_create_operation_factory_context(PJ_CONTEXT *ctx, const char *authority);
+
+void PROJ_DLL
+proj_operation_factory_context_destroy(PJ_OPERATION_FACTORY_CONTEXT *ctx);
+
+void PROJ_DLL proj_operation_factory_context_set_desired_accuracy(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    double accuracy);
+
+void PROJ_DLL proj_operation_factory_context_set_area_of_interest(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    double west_lon_degree, double south_lat_degree, double east_lon_degree,
+    double north_lat_degree);
+
+void PROJ_DLL proj_operation_factory_context_set_area_of_interest_name(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    const char *area_name);
+
+void PROJ_DLL proj_operation_factory_context_set_crs_extent_use(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    PROJ_CRS_EXTENT_USE use);
+
+void PROJ_DLL proj_operation_factory_context_set_spatial_criterion(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    PROJ_SPATIAL_CRITERION criterion);
+
+void PROJ_DLL proj_operation_factory_context_set_grid_availability_use(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    PROJ_GRID_AVAILABILITY_USE use);
+
+void PROJ_DLL
+proj_operation_factory_context_set_use_proj_alternative_grid_names(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    int usePROJNames);
+
+void PROJ_DLL proj_operation_factory_context_set_allow_use_intermediate_crs(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    PROJ_INTERMEDIATE_CRS_USE use);
+
+void PROJ_DLL proj_operation_factory_context_set_allowed_intermediate_crs(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx,
+    const char *const *list_of_auth_name_codes);
+
+void PROJ_DLL proj_operation_factory_context_set_discard_superseded(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx, int discard);
+
+void PROJ_DLL proj_operation_factory_context_set_allow_ballpark_transformations(
+    PJ_CONTEXT *ctx, PJ_OPERATION_FACTORY_CONTEXT *factory_ctx, int allow);
+
+/* ------------------------------------------------------------------------- */
+
+PJ_OBJ_LIST PROJ_DLL *
+proj_create_operations(PJ_CONTEXT *ctx, const PJ *source_crs,
+                       const PJ *target_crs,
+                       const PJ_OPERATION_FACTORY_CONTEXT *operationContext);
+
+int PROJ_DLL proj_list_get_count(const PJ_OBJ_LIST *result);
+
+PJ PROJ_DLL *proj_list_get(PJ_CONTEXT *ctx, const PJ_OBJ_LIST *result,
+                           int index);
+
+void PROJ_DLL proj_list_destroy(PJ_OBJ_LIST *result);
+
+int PROJ_DLL proj_get_suggested_operation(PJ_CONTEXT *ctx,
+                                          PJ_OBJ_LIST *operations,
+                                          PJ_DIRECTION direction,
+                                          PJ_COORD coord);
+
+/* ------------------------------------------------------------------------- */
+
+int PROJ_DLL proj_crs_is_derived(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ PROJ_DLL *proj_crs_get_geodetic_crs(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ PROJ_DLL *proj_crs_get_horizontal_datum(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ PROJ_DLL *proj_crs_get_sub_crs(PJ_CONTEXT *ctx, const PJ *crs, int index);
+
+PJ PROJ_DLL *proj_crs_get_datum(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ PROJ_DLL *proj_crs_get_datum_ensemble(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ PROJ_DLL *proj_crs_get_datum_forced(PJ_CONTEXT *ctx, const PJ *crs);
+
+int PROJ_DLL proj_datum_ensemble_get_member_count(PJ_CONTEXT *ctx,
+                                                  const PJ *datum_ensemble);
+
+double PROJ_DLL proj_datum_ensemble_get_accuracy(PJ_CONTEXT *ctx,
+                                                 const PJ *datum_ensemble);
+
+PJ PROJ_DLL *proj_datum_ensemble_get_member(PJ_CONTEXT *ctx,
+                                            const PJ *datum_ensemble,
+                                            int member_index);
+
+double PROJ_DLL proj_dynamic_datum_get_frame_reference_epoch(PJ_CONTEXT *ctx,
+                                                             const PJ *datum);
+
+PJ PROJ_DLL *proj_crs_get_coordinate_system(PJ_CONTEXT *ctx, const PJ *crs);
+
+PJ_COORDINATE_SYSTEM_TYPE PROJ_DLL proj_cs_get_type(PJ_CONTEXT *ctx,
+                                                    const PJ *cs);
+
+int PROJ_DLL proj_cs_get_axis_count(PJ_CONTEXT *ctx, const PJ *cs);
+
+int PROJ_DLL proj_cs_get_axis_info(
+    PJ_CONTEXT *ctx, const PJ *cs, int index, const char **out_name,
+    const char **out_abbrev, const char **out_direction,
+    double *out_unit_conv_factor, const char **out_unit_name,
+    const char **out_unit_auth_name, const char **out_unit_code);
+
+PJ PROJ_DLL *proj_get_ellipsoid(PJ_CONTEXT *ctx, const PJ *obj);
+
+int PROJ_DLL proj_ellipsoid_get_parameters(PJ_CONTEXT *ctx, const PJ *ellipsoid,
+                                           double *out_semi_major_metre,
+                                           double *out_semi_minor_metre,
+                                           int *out_is_semi_minor_computed,
+                                           double *out_inv_flattening);
+
+const char PROJ_DLL *proj_get_celestial_body_name(PJ_CONTEXT *ctx,
+                                                  const PJ *obj);
+
+PJ PROJ_DLL *proj_get_prime_meridian(PJ_CONTEXT *ctx, const PJ *obj);
+
+int PROJ_DLL proj_prime_meridian_get_parameters(PJ_CONTEXT *ctx,
+                                                const PJ *prime_meridian,
+                                                double *out_longitude,
+                                                double *out_unit_conv_factor,
+                                                const char **out_unit_name);
+
+PJ PROJ_DLL *proj_crs_get_coordoperation(PJ_CONTEXT *ctx, const PJ *crs);
+
+int PROJ_DLL proj_coordoperation_get_method_info(
+    PJ_CONTEXT *ctx, const PJ *coordoperation, const char **out_method_name,
+    const char **out_method_auth_name, const char **out_method_code);
+
+int PROJ_DLL proj_coordoperation_is_instantiable(PJ_CONTEXT *ctx,
+                                                 const PJ *coordoperation);
+
+int PROJ_DLL proj_coordoperation_has_ballpark_transformation(
+    PJ_CONTEXT *ctx, const PJ *coordoperation);
+
+int PROJ_DLL proj_coordoperation_get_param_count(PJ_CONTEXT *ctx,
+                                                 const PJ *coordoperation);
+
+int PROJ_DLL proj_coordoperation_get_param_index(PJ_CONTEXT *ctx,
+                                                 const PJ *coordoperation,
+                                                 const char *name);
+
+int PROJ_DLL proj_coordoperation_get_param(
+    PJ_CONTEXT *ctx, const PJ *coordoperation, int index, const char **out_name,
+    const char **out_auth_name, const char **out_code, double *out_value,
+    const char **out_value_string, double *out_unit_conv_factor,
+    const char **out_unit_name, const char **out_unit_auth_name,
+    const char **out_unit_code, const char **out_unit_category);
+
+int PROJ_DLL proj_coordoperation_get_grid_used_count(PJ_CONTEXT *ctx,
+                                                     const PJ *coordoperation);
+
+int PROJ_DLL proj_coordoperation_get_grid_used(
+    PJ_CONTEXT *ctx, const PJ *coordoperation, int index,
+    const char **out_short_name, const char **out_full_name,
+    const char **out_package_name, const char **out_url,
+    int *out_direct_download, int *out_open_license, int *out_available);
+
+double PROJ_DLL proj_coordoperation_get_accuracy(PJ_CONTEXT *ctx,
+                                                 const PJ *obj);
+
+int PROJ_DLL proj_coordoperation_get_towgs84_values(
+    PJ_CONTEXT *ctx, const PJ *coordoperation, double *out_values,
+    int value_count, int emit_error_if_incompatible);
+
+PJ PROJ_DLL *proj_coordoperation_create_inverse(PJ_CONTEXT *ctx, const PJ *obj);
+
+int PROJ_DLL proj_concatoperation_get_step_count(PJ_CONTEXT *ctx,
+                                                 const PJ *concatoperation);
+
+PJ PROJ_DLL *proj_concatoperation_get_step(PJ_CONTEXT *ctx,
+                                           const PJ *concatoperation,
+                                           int i_step);
+
+double PROJ_DLL proj_coordinate_metadata_get_epoch(PJ_CONTEXT *ctx,
+                                                   const PJ *obj);
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ndef PROJ_H */

--- a/src/proj_loader.cpp
+++ b/src/proj_loader.cpp
@@ -38,20 +38,12 @@
 #include <algorithm>
 #include <cstring>
 
-//namespace fs = std::filesystem;
-
 #ifdef min
 #undef min
 #endif
 
-#ifdef _WIN32
-#define PATH_SEPARATOR '\\'
-#else
-#define PATH_SEPARATOR '/'
-#endif
-
 // Global handle for the dynamically loaded library
-static void* proj_lib_handle = nullptr;
+PROJ_LIB_HANDLE proj_lib_handle = nullptr;
 
 // Initialise function pointer variables
 proj_as_wkt_t proj_as_wkt_ptr = nullptr;
@@ -212,27 +204,31 @@ static char* findLatestQGISInstallationPath() {
   size_t numPaths = 0;
   const char** defaultPaths = getDefaultProgramPaths(numPaths);
   char* latestVersionPath = nullptr;
-  const char* latestVersionName = nullptr;
+  char* latestVersionName = nullptr;
 
   // Checking the standard paths
   for (size_t i = 0; i < numPaths; ++i) {
-    for (const auto& entry : std::filesystem::directory_iterator(defaultPaths[i])) {
-      std::string directoryName = entry.path().filename().string();
-      // Check whether the name begins with ‘QGIS ’
-      if (directoryName.find("QGIS ") == 0) {
-        const char* dirName = directoryName.c_str();
-        if (!latestVersionName || compareVersions(dirName, latestVersionName)) {
-          latestVersionName = dirName;
-          std::filesystem::path path(entry.path());
-          path /= "bin";  // Append "bin" to the path
-          delete[] latestVersionPath;
-          latestVersionPath = new char[path.string().size() + 1];
-          strcpy_las(latestVersionPath, path.string().size() + 1, path.string().c_str());
-          return latestVersionPath;
+    for (const auto& programEntry : std::filesystem::directory_iterator(defaultPaths[i])) {
+      if (programEntry.is_directory()) {
+        std::string directoryName = programEntry.path().filename().string();
+        // Check whether the name begins with ‘QGIS ’
+        if (directoryName.find("QGIS ") == 0) {
+          const char* dirName = directoryName.c_str();
+          if (!latestVersionName || compareVersions(dirName, latestVersionName)) {
+            free(latestVersionName);
+            delete[] latestVersionPath;
+            latestVersionName = strdup(dirName);
+            std::filesystem::path path(programEntry.path());
+            path /= "bin";  // Append "bin" to the path
+            latestVersionPath = new char[path.string().size() + 1];
+            strcpy_las(latestVersionPath, path.string().size() + 1, path.string().c_str());
+          }
         }
       }
     }
   }
+  free(latestVersionName);
+  return latestVersionPath;
 #else
   // First check the QGIS_PREFIX_PATH, then the system-wide library directories
   if (qgisPathEnv) {
@@ -326,20 +322,22 @@ static char* findLatestProjLibraryPath(const char* binPath) {
   const char* fileExtension = ".dll";
 
   char* latestVersionPath = nullptr;
-  const char* latestVersionName = nullptr;
+  char* latestVersionName = nullptr;
 
   for (const auto& entry : std::filesystem::directory_iterator(binPath)) {
     std::string fileName = entry.path().filename().string();
     if (fileName.find(projLibraryPattern) != std::string::npos && fileName.find(fileExtension) != std::string::npos) {
       if (!latestVersionName || compareVersions(fileName.c_str(), latestVersionName)) {
-        latestVersionName = fileName.c_str();
+        free(latestVersionName);
         delete[] latestVersionPath;
+        latestVersionName = strdup(fileName.c_str());
         latestVersionPath = new char[entry.path().string().size() + 1];
         strcpy_las(latestVersionPath, entry.path().string().size() + 1, entry.path().string().c_str());
-        return latestVersionPath;
       }
     }
   }
+  free(latestVersionName);
+  return latestVersionPath;
 #else
   // libproj.so always refers to the corresponding version
   const char* projLibraryName = "libproj.so";
@@ -348,7 +346,7 @@ static char* findLatestProjLibraryPath(const char* binPath) {
     std::string fileName = entry.path().filename().string();
     if (fileName == projLibraryName) {
       char* resultPath = new char[entry.path().string().size() + 1];
-      std::strcpy(resultPath, entry.path().string().c_str());
+      strcpy_las(resultPath, entry.path().string().size() + 1, entry.path().string().c_str());
       return resultPath;
     }
   }

--- a/src/proj_loader.cpp
+++ b/src/proj_loader.cpp
@@ -1,0 +1,503 @@
+/*
+===============================================================================
+
+  FILE:  proj_loader.cpp
+
+  CONTENTS:
+
+    see corresponding header file
+
+  PROGRAMMERS:
+
+    info@rapidlasso.de  -  https://rapidlasso.de
+
+  COPYRIGHT:
+
+    (c) 2007-2024, rapidlasso GmbH - fast tools to catch reality
+
+    This is free software; you can redistribute and/or modify it under the
+    terms of the Apache Public License 2.0 published by the Apache Software
+    Foundation. See the COPYING file for more information.
+
+    This software is distributed WITHOUT ANY WARRANTY and without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  CHANGE HISTORY:
+
+    see corresponding header file
+
+===============================================================================
+*/
+#include "lasmessage.hpp"
+#include "proj_loader.h"
+
+#include <vector>
+#include <filesystem>
+#include <regex>
+#include <sstream>
+#include <algorithm>
+#include <cstring>
+
+//namespace fs = std::filesystem;
+
+#ifdef min
+#undef min
+#endif
+
+#ifdef _WIN32
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
+// Global handle for the dynamically loaded library
+static void* proj_lib_handle = nullptr;
+
+// Initialise function pointer variables
+proj_as_wkt_t proj_as_wkt_ptr = nullptr;
+proj_as_proj_string_t proj_as_proj_string_ptr = nullptr;
+proj_as_projjson_t proj_as_projjson_ptr = nullptr;
+proj_get_source_crs_t proj_get_source_crs_ptr = nullptr;
+proj_get_target_crs_t proj_get_target_crs_ptr = nullptr;
+proj_destroy_t proj_destroy_ptr = nullptr;
+proj_context_create_t proj_context_create_ptr = nullptr;
+proj_context_destroy_t proj_context_destroy_ptr = nullptr;
+proj_get_id_code_t proj_get_id_code_ptr = nullptr;
+proj_get_ellipsoid_t proj_get_ellipsoid_ptr = nullptr;
+proj_ellipsoid_get_parameters_t proj_ellipsoid_get_parameters_ptr = nullptr;
+proj_crs_get_datum_ensemble_t proj_crs_get_datum_ensemble_ptr = nullptr;
+proj_get_name_t proj_get_name_ptr = nullptr;
+proj_datum_ensemble_get_member_count_t proj_datum_ensemble_get_member_count_ptr = nullptr;
+proj_datum_ensemble_get_accuracy_t proj_datum_ensemble_get_accuracy_ptr = nullptr;
+proj_datum_ensemble_get_member_t proj_datum_ensemble_get_member_ptr = nullptr;
+proj_crs_get_datum_t proj_crs_get_datum_ptr = nullptr;
+proj_crs_get_coordinate_system_t proj_crs_get_coordinate_system_ptr = nullptr;
+proj_cs_get_type_t proj_cs_get_type_ptr = nullptr;
+proj_cs_get_axis_count_t proj_cs_get_axis_count_ptr = nullptr;
+proj_cs_get_axis_info_t proj_cs_get_axis_info_ptr = nullptr;
+proj_create_t proj_create_ptr = nullptr;
+proj_create_argv_t proj_create_argv_ptr = nullptr;
+proj_create_crs_to_crs_t proj_create_crs_to_crs_ptr = nullptr;
+proj_create_crs_to_crs_from_pj_t proj_create_crs_to_crs_from_pj_ptr = nullptr;
+proj_create_from_wkt_t proj_create_from_wkt_ptr = nullptr;
+proj_context_errno_t proj_context_errno_ptr = nullptr;
+proj_context_errno_string_t proj_context_errno_string_ptr = nullptr;
+proj_coord_t proj_coord_ptr = nullptr;
+proj_trans_t proj_trans_ptr = nullptr;
+proj_get_type_t proj_get_type_ptr = nullptr;
+
+/// Function to get the home directory of the current user
+const char* getHomeDirectory() {
+#ifdef _WIN32
+  return getenv("USERPROFILE");
+#else
+  return getenv("HOME"); 
+#endif
+}
+
+/// Function for determining the standard programme paths
+const char** getDefaultProgramPaths(size_t& numPaths) {
+#ifdef _WIN32
+  // Windows: Use environment variables or API for Program Files directories
+  static const char* defaultPaths[] = {
+      getenv("ProgramFiles"),
+      getenv("ProgramFiles(x86)"),
+      nullptr};
+  // Count valid paths
+  numPaths = 0;
+  while (defaultPaths[numPaths] != nullptr) {
+    ++numPaths;
+  }
+  return defaultPaths;
+#elif __APPLE__
+  // macOS: Standard directories
+  static const char* defaultPaths[] = {"/Applications/", "/usr/local/", nullptr};
+  numPaths = sizeof(defaultPaths) / sizeof(defaultPaths[0]) - 1;
+  return defaultPaths;
+#else
+  // Linux/Unix: Standard directories
+  static const char* defaultPaths[] = {"/usr/local/", "/opt/", "/usr/share/", nullptr};
+  numPaths = sizeof(defaultPaths) / sizeof(defaultPaths[0]) - 1;
+  return defaultPaths;
+#endif
+}
+
+/// Function for parsing the version number from the directory name
+static std::vector<int> parseVersion(const char* versionStr) {
+  std::vector<int> versionNumbers;
+  std::regex versionRegex("(\\d+)");
+  std::string versionString(versionStr);
+  std::sregex_iterator it(versionString.begin(), versionString.end(), versionRegex);
+  std::sregex_iterator end;
+
+  while (it != end) {
+    versionNumbers.push_back(std::stoi(it->str()));
+    ++it;
+  }
+
+  return versionNumbers;
+}
+
+#ifdef __unix__
+static char* findUnixLibProjPath() {
+  // Check system-wide directories
+  const std::string systemLibPaths[] = {
+      "/usr/lib/", "/usr/bin/",
+      "/usr/local/bin/"
+      "/usr/lib/x86_64-linux-gnu/",
+      "/lib/x86_64-linux-gnu/"};
+
+  for (const auto& systemLibPath : systemLibPaths) {
+    std::filesystem::path binPath = systemLibPath;
+
+    if (std::filesystem::is_directory(binPath) && std::filesystem::exists(binPath / "libproj.so")) {
+      char* resultPath = new char[binPath.string().size() + 1];
+      strcpy_las(resultPath, binPath.string().size() + 1, binPath.string().c_str());
+      return resultPath;
+    }
+  }
+
+  // Optional: Use the user's home directory if necessary
+  const char* homeDir = getHomeDirectory();
+  if (homeDir) {
+    std::filesystem::path userLibPath(homeDir);
+    userLibPath /= ".local";  // the .local/lib directory for user installations
+    userLibPath /= "lib";
+
+    if (std::filesystem::is_directory(userLibPath) && std::filesystem::exists(userLibPath / "libproj.so")) {
+      char* resultPath = new char[userLibPath.string().size() + 1];
+      strcpy_las(resultPath, userLibPath.string().size() + 1, userLibPath.string().c_str());
+      return resultPath;
+    }
+  }
+
+ return nullptr;
+}
+#endif
+
+/// Comparison function for version numbers
+static bool compareVersions(const char* v1, const char* v2) {
+  std::vector<int> version1 = parseVersion(v1);
+  std::vector<int> version2 = parseVersion(v2);
+
+  size_t len = std::min(version1.size(), version2.size());
+  for (size_t i = 0; i < len; ++i) {
+    if (version1[i] > version2[i]) return true;
+    if (version1[i] < version2[i]) return false;
+  }
+
+  return version1.size() > version2.size();
+}
+
+/// Finds the latest QGIS installation path by first checking the `QGIS_PREFIX_PATH` environment variable.
+/// If the environment variable is not set, it searches through default installation directories and selects the latest version based on directory names.
+/// appends "bin" to the path, where the proj lib is located
+static char* findLatestQGISInstallationPath() {
+  // 1. Check the environment variable QGIS_PREFIX_PATH
+  const char* qgisPathEnv = getenv("QGIS_PREFIX_PATH");
+  std::filesystem::path binPath;
+
+#ifdef _WIN32
+  if (qgisPathEnv) {
+    if (std::filesystem::exists(qgisPathEnv)) {
+      std::filesystem::path path(qgisPathEnv);
+      path /= "bin";  // Append "bin" to the path
+      char* resultPath = new char[path.string().size() + 1];
+      strcpy_las(resultPath, path.string().size() + 1, path.string().c_str());
+      return resultPath;
+    }
+  }
+
+// 2. If the environment variable is not set, check default paths
+  size_t numPaths = 0;
+  const char** defaultPaths = getDefaultProgramPaths(numPaths);
+  char* latestVersionPath = nullptr;
+  const char* latestVersionName = nullptr;
+
+  // Checking the standard paths
+  for (size_t i = 0; i < numPaths; ++i) {
+    for (const auto& entry : std::filesystem::directory_iterator(defaultPaths[i])) {
+      std::string directoryName = entry.path().filename().string();
+      // Check whether the name begins with ‘QGIS ’
+      if (directoryName.find("QGIS ") == 0) {
+        const char* dirName = directoryName.c_str();
+        if (!latestVersionName || compareVersions(dirName, latestVersionName)) {
+          latestVersionName = dirName;
+          std::filesystem::path path(entry.path());
+          path /= "bin";  // Append "bin" to the path
+          delete[] latestVersionPath;
+          latestVersionPath = new char[path.string().size() + 1];
+          strcpy_las(latestVersionPath, path.string().size() + 1, path.string().c_str());
+          return latestVersionPath;
+        }
+      }
+    }
+  }
+#else
+  // First check the QGIS_PREFIX_PATH, then the system-wide library directories
+  if (qgisPathEnv) {
+    std::filesystem::path path(qgisPathEnv);
+    binPath = path / "lib";
+
+    if (std::filesystem::is_directory(binPath) && std::filesystem::exists(binPath / "libproj.so")) {
+      char* resultPath = new char[binPath.string().size() + 1];
+      strcpy_las(resultPath, binPath.string().size() + 1, binPath.string().c_str());
+      return resultPath;
+    }
+  }
+
+  // Check system-wide standard directories
+  return findUnixLibProjPath();
+#endif
+
+  return nullptr;
+}
+
+/// Finds the latest QGIS installation path in Conda environments
+static char* findLatestCondaInstallationPath() {
+  // 1. Check the environment variable CONDA_PREFIX
+  const char* condaPathEnv = getenv("CONDA_PREFIX");
+  std::filesystem::path binPath;
+
+#ifdef _WIN32
+  if (condaPathEnv) {
+    if (std::filesystem::exists(condaPathEnv)) {
+      std::filesystem::path path(condaPathEnv);
+      path /= "Library";  // Append "Library" to the path
+      path /= "bin";  // Append "bin" to the path
+      char* resultPath = new char[path.string().size() + 1];
+      strcpy_las(resultPath, path.string().size() + 1, path.string().c_str());
+      return resultPath;
+    }
+  }
+
+  // 2. If the environment variable is not set, check standart path
+  const char* homeDir = getHomeDirectory();
+  if (!homeDir) return nullptr;
+
+  std::filesystem::path homePath(homeDir);
+  char* latestVersionPath = nullptr;
+
+  // Iterate through directories in the home directory
+  for (const auto& entry : std::filesystem::directory_iterator(homePath)) {
+    std::string directoryName = entry.path().filename().string();
+    if (directoryName.find("miniconda") == 0 || directoryName.find("anaconda") == 0) {
+      binPath = entry.path() / "Library" / "bin";
+
+      if (std::filesystem::exists(binPath) && std::filesystem::is_directory(binPath)) {
+        delete[] latestVersionPath;
+        latestVersionPath = new char[binPath.string().size() + 1];
+        strcpy_las(latestVersionPath, binPath.string().size() + 1, binPath.string().c_str());
+        return latestVersionPath;
+      }
+    }
+  }
+#else
+  // First check the CONDA_PREFIX, then the system-wide library directories
+  if (condaPathEnv) {
+    std::filesystem::path path(condaPathEnv);
+    binPath = path / "lib";
+
+    if (std::filesystem::is_directory(binPath)  && std::filesystem::exists(binPath / "libproj.so")) {
+      char* resultPath = new char[binPath.string().size() + 1];
+      strcpy_las(resultPath, binPath.string().size() + 1, binPath.string().c_str());
+      return resultPath;
+    }
+  }
+
+  // Check system-wide standard directories
+  return findUnixLibProjPath();
+#endif
+
+  return nullptr;
+}
+
+/// Finds the latest proj library path within the QGIS installation path
+static char* findLatestProjLibraryPath(const char* binPath) {
+  if (!binPath) return nullptr;
+
+  // Check if the binPath exists and is a directory
+  if (!std::filesystem::exists(binPath) || !std::filesystem::is_directory(binPath)) {
+    return nullptr;
+  }
+
+#ifdef _WIN32
+  const char* projLibraryPattern = "proj_";
+  const char* fileExtension = ".dll";
+
+  char* latestVersionPath = nullptr;
+  const char* latestVersionName = nullptr;
+
+  for (const auto& entry : std::filesystem::directory_iterator(binPath)) {
+    std::string fileName = entry.path().filename().string();
+    if (fileName.find(projLibraryPattern) != std::string::npos && fileName.find(fileExtension) != std::string::npos) {
+      if (!latestVersionName || compareVersions(fileName.c_str(), latestVersionName)) {
+        latestVersionName = fileName.c_str();
+        delete[] latestVersionPath;
+        latestVersionPath = new char[entry.path().string().size() + 1];
+        strcpy_las(latestVersionPath, entry.path().string().size() + 1, entry.path().string().c_str());
+        return latestVersionPath;
+      }
+    }
+  }
+#else
+  // libproj.so always refers to the corresponding version
+  const char* projLibraryName = "libproj.so";
+
+  for (const auto& entry : std::filesystem::directory_iterator(binPath)) {
+    std::string fileName = entry.path().filename().string();
+    if (fileName == projLibraryName) {
+      char* resultPath = new char[entry.path().string().size() + 1];
+      std::strcpy(resultPath, entry.path().string().c_str());
+      return resultPath;
+    }
+  }
+#endif
+
+  return nullptr;
+}
+
+/// Dynamically loads the PROJ library
+/// 1. load library via environment variabl 'LASTOOLSPROJ'
+/// 2. fallback: load library from standard paths (executable directory)
+/// 3. set the PROJ data directory using an environment variable 'PROJ_LIB'
+bool load_proj_library(const char* path, bool isNecessary/*=true*/) {
+  proj_lib_handle = nullptr;
+
+  // 1. Load library via environment variable
+  const char* proj_path = getenv("LASTOOLS_PROJ");
+  if (proj_path) {
+    char* projLibPath = findLatestProjLibraryPath(proj_path);
+    if (projLibPath) {
+      proj_lib_handle = LOAD_LIBRARY(projLibPath);
+      delete[] projLibPath;  // Free memory after usage
+    }
+  }
+
+  //2. fallback : load library from QGIS environments (default directorys)
+  if (!proj_lib_handle) {
+    char* qgisPath = findLatestQGISInstallationPath();
+    if (qgisPath) {
+      char* proj_lib_path = findLatestProjLibraryPath(qgisPath);
+      delete[] qgisPath;
+
+      if (proj_lib_path) {  
+        // Try to load the library
+        proj_lib_handle = LOAD_LIBRARY(proj_lib_path);
+        delete[](proj_lib_path);
+      }
+    }
+  }
+
+  // 3. fallback : load library from Conda environments (default directorys)
+  if (!proj_lib_handle) {
+    char* condaPath = findLatestCondaInstallationPath();
+    if (condaPath) {
+      char* proj_lib_path = findLatestProjLibraryPath(condaPath);
+      delete[] condaPath;
+
+      if (proj_lib_path) {
+        // Try to load the library
+        proj_lib_handle = LOAD_LIBRARY(proj_lib_path);
+        delete[] proj_lib_path;
+      }
+    }
+  }
+
+  // Check if the PROJ lib could be loaded
+  if (!proj_lib_handle) {
+    if (isNecessary) {
+      laserror("PROJ Installation not found. For more information see proj_README.md.");
+    } else {
+      // LASMessage(LAS_WARNING, "PROJ Installation not found, the functionalities of LASTools are used instead. For more information see proj_README.md.");
+      return false;
+    }
+  }
+
+  // 4. resolve function pointer
+  proj_as_wkt_ptr = (proj_as_wkt_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_as_wkt");
+  proj_as_proj_string_ptr = (proj_as_proj_string_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_as_proj_string");
+  proj_as_projjson_ptr = (proj_as_projjson_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_as_projjson");
+  proj_get_source_crs_ptr = (proj_get_source_crs_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_source_crs");
+  proj_get_target_crs_ptr = (proj_get_target_crs_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_target_crs");
+  proj_destroy_ptr = (proj_destroy_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_destroy");
+  proj_context_create_ptr = (proj_context_create_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_context_create");
+  proj_context_destroy_ptr = (proj_context_destroy_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_context_destroy");
+  proj_get_id_code_ptr = (proj_get_id_code_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_id_code");
+  proj_get_ellipsoid_ptr = (proj_get_ellipsoid_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_ellipsoid");
+  proj_ellipsoid_get_parameters_ptr = (proj_ellipsoid_get_parameters_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_ellipsoid_get_parameters");
+  proj_crs_get_datum_ensemble_ptr = (proj_crs_get_datum_ensemble_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_crs_get_datum_ensemble");
+  proj_get_name_ptr = (proj_get_name_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_name");
+  proj_datum_ensemble_get_member_count_ptr = (proj_datum_ensemble_get_member_count_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_datum_ensemble_get_member_count");
+  proj_datum_ensemble_get_accuracy_ptr = (proj_datum_ensemble_get_accuracy_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_datum_ensemble_get_accuracy");
+  proj_datum_ensemble_get_member_ptr = (proj_datum_ensemble_get_member_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_datum_ensemble_get_member");
+  proj_crs_get_datum_ptr = (proj_crs_get_datum_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_crs_get_datum");
+  proj_crs_get_coordinate_system_ptr = (proj_crs_get_coordinate_system_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_crs_get_coordinate_system");
+  proj_cs_get_type_ptr = (proj_cs_get_type_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_cs_get_type");
+  proj_cs_get_axis_count_ptr = (proj_cs_get_axis_count_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_cs_get_axis_count");
+  proj_cs_get_axis_info_ptr = (proj_cs_get_axis_info_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_cs_get_axis_info");
+  proj_create_ptr = (proj_create_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_create");
+  proj_create_argv_ptr = (proj_create_argv_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_create_argv");
+  proj_create_crs_to_crs_ptr = (proj_create_crs_to_crs_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_create_crs_to_crs");
+  proj_create_crs_to_crs_from_pj_ptr = (proj_create_crs_to_crs_from_pj_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_create_crs_to_crs_from_pj");
+  proj_create_from_wkt_ptr = (proj_create_from_wkt_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_create_from_wkt");
+  proj_context_errno_ptr = (proj_context_errno_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_context_errno");
+  proj_context_errno_string_ptr = (proj_context_errno_string_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_context_errno_string");
+  proj_coord_ptr = (proj_coord_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_coord");
+  proj_trans_ptr = (proj_trans_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_trans");
+  proj_get_type_ptr = (proj_get_type_t)GET_PROC_ADDRESS(proj_lib_handle, "proj_get_type");
+
+  if (!proj_as_wkt_ptr || !proj_as_proj_string_ptr || !proj_as_projjson_ptr || !proj_get_source_crs_ptr || !proj_get_target_crs_ptr ||
+      !proj_destroy_ptr || !proj_context_create_ptr || !proj_context_destroy_ptr || !proj_get_id_code_ptr || !proj_get_ellipsoid_ptr ||
+      !proj_ellipsoid_get_parameters_ptr || !proj_crs_get_datum_ensemble_ptr || !proj_get_name_ptr || !proj_datum_ensemble_get_member_count_ptr ||
+      !proj_datum_ensemble_get_accuracy_ptr || !proj_datum_ensemble_get_member_ptr || !proj_crs_get_datum_ptr ||
+      !proj_crs_get_coordinate_system_ptr || !proj_cs_get_type_ptr || !proj_cs_get_axis_count_ptr || !proj_cs_get_axis_info_ptr || !proj_create_ptr ||
+      !proj_create_argv_ptr || !proj_create_crs_to_crs_ptr || !proj_create_crs_to_crs_from_pj_ptr || !proj_create_from_wkt_ptr ||
+      !proj_context_errno_ptr || !proj_context_errno_string_ptr || !proj_coord_ptr || !proj_trans_ptr || !proj_get_type_ptr)
+  {
+    unload_proj_library();
+    laserror("Failed to load necessary PROJ functions.");
+  }
+  return true;
+}
+
+/// unloads the PROJ library and sets all associated function pointers to nullptr.
+void unload_proj_library() {
+  if (proj_lib_handle) {  // Check whether lib_handle is valid
+    FREE_LIBRARY(proj_lib_handle);  // Unload library
+    proj_lib_handle = nullptr;      // Set handle to nullptr
+  }
+
+  // Set function pointer to nullptr
+  proj_as_wkt_ptr = nullptr;
+  proj_as_proj_string_ptr = nullptr;
+  proj_as_projjson_ptr = nullptr;
+  proj_get_source_crs_ptr = nullptr;
+  proj_get_target_crs_ptr = nullptr;
+  proj_destroy_ptr = nullptr;
+  proj_context_create_ptr = nullptr;
+  proj_context_destroy_ptr = nullptr;
+  proj_get_id_code_ptr = nullptr;
+  proj_get_ellipsoid_ptr = nullptr;
+  proj_ellipsoid_get_parameters_ptr = nullptr;
+  proj_crs_get_datum_ensemble_ptr = nullptr;
+  proj_get_name_ptr = nullptr;
+  proj_datum_ensemble_get_member_count_ptr = nullptr;
+  proj_datum_ensemble_get_accuracy_ptr = nullptr;
+  proj_datum_ensemble_get_member_ptr = nullptr;
+  proj_crs_get_datum_ptr = nullptr;
+  proj_crs_get_coordinate_system_ptr = nullptr;
+  proj_cs_get_type_ptr = nullptr;
+  proj_cs_get_axis_count_ptr = nullptr;
+  proj_cs_get_axis_info_ptr = nullptr;
+  proj_create_ptr = nullptr;
+  proj_create_argv_ptr = nullptr;
+  proj_create_crs_to_crs_ptr = nullptr;
+  proj_create_crs_to_crs_from_pj_ptr = nullptr;
+  proj_create_from_wkt_ptr = nullptr;
+  proj_context_errno_ptr = nullptr;
+  proj_context_errno_string_ptr = nullptr;
+  proj_coord_ptr = nullptr;
+  proj_trans_ptr = nullptr;
+  proj_get_type_ptr = nullptr;
+}

--- a/src/proj_loader.cpp
+++ b/src/proj_loader.cpp
@@ -217,7 +217,7 @@ static char* findLatestQGISInstallationPath() {
           if (!latestVersionName || compareVersions(dirName, latestVersionName)) {
             free(latestVersionName);
             delete[] latestVersionPath;
-            latestVersionName = strdup(dirName);
+            latestVersionName = strdup_las(dirName);
             std::filesystem::path path(programEntry.path());
             path /= "bin";  // Append "bin" to the path
             latestVersionPath = new char[path.string().size() + 1];
@@ -330,7 +330,7 @@ static char* findLatestProjLibraryPath(const char* binPath) {
       if (!latestVersionName || compareVersions(fileName.c_str(), latestVersionName)) {
         free(latestVersionName);
         delete[] latestVersionPath;
-        latestVersionName = strdup(fileName.c_str());
+        latestVersionName = strdup_las(fileName.c_str());
         latestVersionPath = new char[entry.path().string().size() + 1];
         strcpy_las(latestVersionPath, entry.path().string().size() + 1, entry.path().string().c_str());
       }

--- a/src/proj_loader.h
+++ b/src/proj_loader.h
@@ -37,14 +37,16 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#define LOAD_LIBRARY(name) LoadLibrary(name)
+#define LOAD_LIBRARY(name) LoadLibraryEx(name, NULL, LOAD_WITH_ALTERED_SEARCH_PATH)
 #define GET_PROC_ADDRESS(lib, name) GetProcAddress((HMODULE)lib, name)
 #define FREE_LIBRARY(lib) FreeLibrary((HMODULE)lib)
+#define PROJ_LIB_HANDLE HMODULE
 #else
 #include <dlfcn.h>
 #define LOAD_LIBRARY(name) dlopen(name, RTLD_LAZY)
 #define GET_PROC_ADDRESS(lib, name) dlsym(lib, name)
 #define FREE_LIBRARY(lib) dlclose(lib)
+#define PROJ_LIB_HANDLE void*
 #endif
 
 // Function pointer type definitions

--- a/src/proj_loader.h
+++ b/src/proj_loader.h
@@ -1,0 +1,201 @@
+/*
+===============================================================================
+
+  FILE:  proj_loader.h
+
+  CONTENTS:
+    This header file provides declarations and macros for dynamically loading
+    and interfacing with the PROJ library. It includes function pointer type
+    definitions for various PROJ functions, macros for simplified function
+    calls, and functions for loading and unloading the PROJ library dynamically.
+    It also defines platform-specific macros for handling dynamic libraries on
+    different systems. 
+    
+  PROGRAMMERS:
+
+    info@rapidlasso.de  -  https://rapidlasso.de
+
+  COPYRIGHT:
+
+    (c) 2007-2024, rapidlasso GmbH - fast tools to catch reality
+
+    This is free software; you can redistribute and/or modify it under the
+    terms of the Apache Public License 2.0 published by the Apache Software
+    Foundation. See the COPYING file for more information.
+
+    This software is distributed WITHOUT ANY WARRANTY and without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  CHANGE HISTORY:
+
+===============================================================================
+*/
+#ifndef PROJ_LOADER_H
+#define PROJ_LOADER_H
+
+#include <proj.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#define LOAD_LIBRARY(name) LoadLibrary(name)
+#define GET_PROC_ADDRESS(lib, name) GetProcAddress((HMODULE)lib, name)
+#define FREE_LIBRARY(lib) FreeLibrary((HMODULE)lib)
+#else
+#include <dlfcn.h>
+#define LOAD_LIBRARY(name) dlopen(name, RTLD_LAZY)
+#define GET_PROC_ADDRESS(lib, name) dlsym(lib, name)
+#define FREE_LIBRARY(lib) dlclose(lib)
+#endif
+
+// Function pointer type definitions
+typedef const char* (*proj_as_wkt_t)(PJ_CONTEXT*, const PJ*, PJ_WKT_TYPE, const char* const*);
+typedef const char* (*proj_as_proj_string_t)(PJ_CONTEXT*, const PJ*, PJ_PROJ_STRING_TYPE, const char* const*);
+typedef const char* (*proj_as_projjson_t)(PJ_CONTEXT*, const PJ*, const char* const*);
+typedef PJ* (*proj_get_source_crs_t)(PJ_CONTEXT*, const PJ*);
+typedef PJ* (*proj_get_target_crs_t)(PJ_CONTEXT*, const PJ*);
+typedef void (*proj_destroy_t)(PJ*);
+typedef PJ_CONTEXT* (*proj_context_create_t)(void);
+typedef void (*proj_context_destroy_t)(PJ_CONTEXT*);
+typedef const char* (*proj_get_id_code_t)(const PJ*, int);
+typedef PJ* (*proj_get_ellipsoid_t)(PJ_CONTEXT*, const PJ*);
+typedef int (*proj_ellipsoid_get_parameters_t)(PJ_CONTEXT*, const PJ*, double*, double*, int*, double*);
+typedef PJ* (*proj_crs_get_datum_ensemble_t)(PJ_CONTEXT*, const PJ*);
+typedef const char* (*proj_get_name_t)(const PJ*);
+typedef int (*proj_datum_ensemble_get_member_count_t)(PJ_CONTEXT*, const PJ*);
+typedef double (*proj_datum_ensemble_get_accuracy_t)(PJ_CONTEXT*, const PJ*);
+typedef PJ* (*proj_datum_ensemble_get_member_t)(PJ_CONTEXT*, const PJ*, int);
+typedef PJ* (*proj_crs_get_datum_t)(PJ_CONTEXT*, const PJ*);
+typedef PJ* (*proj_crs_get_coordinate_system_t)(PJ_CONTEXT*, const PJ*);
+typedef PJ_COORDINATE_SYSTEM_TYPE (*proj_cs_get_type_t)(PJ_CONTEXT*, const PJ*);
+typedef int (*proj_cs_get_axis_count_t)(PJ_CONTEXT*, const PJ*);
+typedef int (*proj_cs_get_axis_info_t)(PJ_CONTEXT*, const PJ*, int, const char**, const char**, const char**, double*, const char**, const char**, const char**);
+typedef PJ* (*proj_create_t)(PJ_CONTEXT*, const char*);
+typedef PJ* (*proj_create_argv_t)(PJ_CONTEXT*, int, char**);
+typedef PJ* (*proj_create_crs_to_crs_t)(PJ_CONTEXT*, const char*, const char*, PJ_AREA*);
+typedef PJ* (*proj_create_crs_to_crs_from_pj_t)(PJ_CONTEXT*, const PJ*, const PJ*, PJ_AREA*, const char* const*);
+typedef PJ* (*proj_create_from_wkt_t)(PJ_CONTEXT*, const char*, const char* const*, PROJ_STRING_LIST*, PROJ_STRING_LIST*);
+typedef int (*proj_context_errno_t)(PJ_CONTEXT*);
+typedef const char* (*proj_context_errno_string_t)(PJ_CONTEXT*, int);
+typedef PJ_COORD (*proj_coord_t)(double, double, double, double);
+typedef PJ_COORD (*proj_trans_t)(PJ*, PJ_DIRECTION, PJ_COORD);
+typedef PJ_TYPE (*proj_get_type_t)(const PJ*);
+
+// External variables for function pointers
+extern proj_as_wkt_t proj_as_wkt_ptr;
+extern proj_as_proj_string_t proj_as_proj_string_ptr;
+extern proj_as_projjson_t proj_as_projjson_ptr;
+extern proj_get_source_crs_t proj_get_source_crs_ptr;
+extern proj_get_target_crs_t proj_get_target_crs_ptr;
+extern proj_destroy_t proj_destroy_ptr;
+extern proj_context_create_t proj_context_create_ptr;
+extern proj_context_destroy_t proj_context_destroy_ptr;
+extern proj_get_id_code_t proj_get_id_code_ptr;
+extern proj_get_ellipsoid_t proj_get_ellipsoid_ptr;
+extern proj_ellipsoid_get_parameters_t proj_ellipsoid_get_parameters_ptr;
+extern proj_crs_get_datum_ensemble_t proj_crs_get_datum_ensemble_ptr;
+extern proj_get_name_t proj_get_name_ptr;
+extern proj_datum_ensemble_get_member_count_t proj_datum_ensemble_get_member_count_ptr;
+extern proj_datum_ensemble_get_accuracy_t proj_datum_ensemble_get_accuracy_ptr;
+extern proj_datum_ensemble_get_member_t proj_datum_ensemble_get_member_ptr;
+extern proj_crs_get_datum_t proj_crs_get_datum_ptr;
+extern proj_crs_get_coordinate_system_t proj_crs_get_coordinate_system_ptr;
+extern proj_cs_get_type_t proj_cs_get_type_ptr;
+extern proj_cs_get_axis_count_t proj_cs_get_axis_count_ptr;
+extern proj_cs_get_axis_info_t proj_cs_get_axis_info_ptr;
+extern proj_create_t proj_create_ptr;
+extern proj_create_argv_t proj_create_argv_ptr;
+extern proj_create_crs_to_crs_t proj_create_crs_to_crs_ptr;
+extern proj_create_crs_to_crs_from_pj_t proj_create_crs_to_crs_from_pj_ptr;
+extern proj_create_from_wkt_t proj_create_from_wkt_ptr;
+extern proj_context_errno_t proj_context_errno_ptr;
+extern proj_context_errno_string_t proj_context_errno_string_ptr;
+extern proj_coord_t proj_coord_ptr;
+extern proj_trans_t proj_trans_ptr;
+extern proj_get_type_t proj_get_type_ptr;
+
+// Function for dynamic loading of the PROJ library
+bool load_proj_library(const char* path, bool isNecessary = true);
+// Function for unloading the PROJ library
+void unload_proj_library();
+
+// Macros for function calls
+#define proj_as_wkt(ctx, obj, type, options) (proj_as_wkt_ptr ? proj_as_wkt_ptr(ctx, obj, type, options) : nullptr)
+
+#define proj_as_proj_string(ctx, obj, type, options) (proj_as_proj_string_ptr ? proj_as_proj_string_ptr(ctx, obj, type, options) : nullptr)
+
+#define proj_as_projjson(ctx, obj, options) (proj_as_projjson_ptr ? proj_as_projjson_ptr(ctx, obj, options) : nullptr)
+
+#define proj_get_source_crs(ctx, obj) (proj_get_source_crs_ptr ? proj_get_source_crs_ptr(ctx, obj) : nullptr)
+
+#define proj_get_target_crs(ctx, obj) (proj_get_target_crs_ptr ? proj_get_target_crs_ptr(ctx, obj) : nullptr)
+
+#define proj_destroy(P)                                                                                                                              \
+  if (proj_destroy_ptr) proj_destroy_ptr(P)
+
+#define proj_context_create() (proj_context_create_ptr ? proj_context_create_ptr() : nullptr)
+
+#define proj_context_destroy(ctx)                                                                                                                    \
+  if (proj_context_destroy_ptr) proj_context_destroy_ptr(ctx)
+
+#define proj_get_id_code(obj, index) (proj_get_id_code_ptr ? proj_get_id_code_ptr(obj, index) : nullptr)
+
+#define proj_get_ellipsoid(ctx, obj) (proj_get_ellipsoid_ptr ? proj_get_ellipsoid_ptr(ctx, obj) : nullptr)
+
+#define proj_ellipsoid_get_parameters(ctx, ellipsoid, out_semi_major_metre, out_semi_minor_metre, out_is_semi_minor_computed, out_inv_flattening)    \
+  (proj_ellipsoid_get_parameters_ptr                                                                                                                 \
+       ? proj_ellipsoid_get_parameters_ptr(                                                                                                          \
+             ctx, ellipsoid, out_semi_major_metre, out_semi_minor_metre, out_is_semi_minor_computed, out_inv_flattening)                             \
+       : 0)
+
+#define proj_crs_get_datum_ensemble(ctx, crs) (proj_crs_get_datum_ensemble_ptr ? proj_crs_get_datum_ensemble_ptr(ctx, crs) : nullptr)
+
+#define proj_get_name(obj) (proj_get_name_ptr ? proj_get_name_ptr(obj) : nullptr)
+
+#define proj_datum_ensemble_get_member_count(ctx, datum_ensemble)                                                                                    \
+  (proj_datum_ensemble_get_member_count_ptr ? proj_datum_ensemble_get_member_count_ptr(ctx, datum_ensemble) : 0)
+
+#define proj_datum_ensemble_get_accuracy(ctx, datum_ensemble)                                                                                        \
+  (proj_datum_ensemble_get_accuracy_ptr ? proj_datum_ensemble_get_accuracy_ptr(ctx, datum_ensemble) : 0)
+
+#define proj_datum_ensemble_get_member(ctx, datum_ensemble, member_index)                                                                            \
+  (proj_datum_ensemble_get_member_ptr ? proj_datum_ensemble_get_member_ptr(ctx, datum_ensemble, member_index) : nullptr)
+
+#define proj_crs_get_datum(ctx, crs) (proj_crs_get_datum_ptr ? proj_crs_get_datum_ptr(ctx, crs) : nullptr)
+
+#define proj_crs_get_coordinate_system(ctx, crs) (proj_crs_get_coordinate_system_ptr ? proj_crs_get_coordinate_system_ptr(ctx, crs) : nullptr)
+
+#define proj_cs_get_type(ctx, cs) (proj_cs_get_type_ptr ? proj_cs_get_type_ptr(ctx, cs) : PJ_CS_TYPE_UNKNOWN)
+
+#define proj_cs_get_axis_count(ctx, cs) (proj_cs_get_axis_count_ptr ? proj_cs_get_axis_count_ptr(ctx, cs) : 0)
+
+#define proj_cs_get_axis_info(                                                                                                                       \
+    ctx, cs, index, out_name, out_abbrev, out_direction, out_unit_conv_factor, out_unit_name, out_unit_auth_name, out_unit_code)                     \
+  (proj_cs_get_axis_info_ptr                                                                                                                         \
+       ? proj_cs_get_axis_info_ptr(                                                                                                                  \
+             ctx, cs, index, out_name, out_abbrev, out_direction, out_unit_conv_factor, out_unit_name, out_unit_auth_name, out_unit_code)            \
+       : 0)
+
+#define proj_create(ctx, definition) (proj_create_ptr ? proj_create_ptr(ctx, definition) : nullptr)
+
+#define proj_create_argv(ctx, argc, argv) (proj_create_argv_ptr ? proj_create_argv_ptr(ctx, argc, argv) : nullptr)
+
+#define proj_create_crs_to_crs(ctx, source_crs, target_crs, area_of_use)                                                                             \
+  (proj_create_crs_to_crs_ptr ? proj_create_crs_to_crs_ptr(ctx, source_crs, target_crs, area_of_use) : nullptr)
+
+#define proj_create_crs_to_crs_from_pj(ctx, source_crs, target_crs, area_of_use, options)                                                            \
+  (proj_create_crs_to_crs_from_pj_ptr ? proj_create_crs_to_crs_from_pj_ptr(ctx, source_crs, target_crs, area_of_use, options) : nullptr)
+
+#define proj_create_from_wkt(ctx, wkt, options, proj_string_list, proj_string_list_out)                                                              \
+  (proj_create_from_wkt_ptr ? proj_create_from_wkt_ptr(ctx, wkt, options, proj_string_list, proj_string_list_out) : nullptr)
+
+#define proj_context_errno(ctx) (proj_context_errno_ptr ? proj_context_errno_ptr(ctx) : 0)
+
+#define proj_context_errno_string(ctx, err) (proj_context_errno_string_ptr ? proj_context_errno_string_ptr(ctx, err) : nullptr)
+
+#define proj_coord(x, y, z, t) (proj_coord_ptr ? proj_coord_ptr(x, y, z, t) : PJ_COORD{})
+
+#define proj_trans(P, direction, coord) (proj_trans_ptr ? proj_trans_ptr(P, direction, coord) : PJ_COORD{})
+
+#define proj_get_type(P) (proj_get_type_ptr ? proj_get_type_ptr(P) : PJ_TYPE{})
+
+#endif  // PROJ_LOADER_H

--- a/src/proj_symbol_rename.h
+++ b/src/proj_symbol_rename.h
@@ -1,0 +1,420 @@
+/* This is a generated file by create_proj_symbol_rename.sh. *DO NOT EDIT
+ * MANUALLY !* */
+#ifndef PROJ_SYMBOL_RENAME_H
+#define PROJ_SYMBOL_RENAME_H
+#define geod_direct internal_geod_direct
+#define geod_directline internal_geod_directline
+#define geod_gendirect internal_geod_gendirect
+#define geod_gendirectline internal_geod_gendirectline
+#define geod_geninverse internal_geod_geninverse
+#define geod_genposition internal_geod_genposition
+#define geod_gensetdistance internal_geod_gensetdistance
+#define geod_init internal_geod_init
+#define geod_inverse internal_geod_inverse
+#define geod_inverseline internal_geod_inverseline
+#define geod_lineinit internal_geod_lineinit
+#define geod_polygon_addedge internal_geod_polygon_addedge
+#define geod_polygon_addpoint internal_geod_polygon_addpoint
+#define geod_polygonarea internal_geod_polygonarea
+#define geod_polygon_clear internal_geod_polygon_clear
+#define geod_polygon_compute internal_geod_polygon_compute
+#define geod_polygon_init internal_geod_polygon_init
+#define geod_polygon_testedge internal_geod_polygon_testedge
+#define geod_polygon_testpoint internal_geod_polygon_testpoint
+#define geod_position internal_geod_position
+#define geod_setdistance internal_geod_setdistance
+#define proj_alter_id internal_proj_alter_id
+#define proj_alter_name internal_proj_alter_name
+#define proj_angular_input internal_proj_angular_input
+#define proj_angular_output internal_proj_angular_output
+#define proj_area_create internal_proj_area_create
+#define proj_area_destroy internal_proj_area_destroy
+#define proj_area_set_bbox internal_proj_area_set_bbox
+#define proj_area_set_name internal_proj_area_set_name
+#define proj_as_projjson internal_proj_as_projjson
+#define proj_as_proj_string internal_proj_as_proj_string
+#define proj_assign_context internal_proj_assign_context
+#define proj_as_wkt internal_proj_as_wkt
+#define proj_celestial_body_list_destroy                                       \
+    internal_proj_celestial_body_list_destroy
+#define proj_cleanup internal_proj_cleanup
+#define proj_clone internal_proj_clone
+#define proj_concatoperation_get_step internal_proj_concatoperation_get_step
+#define proj_concatoperation_get_step_count                                    \
+    internal_proj_concatoperation_get_step_count
+#define proj_context_clone internal_proj_context_clone
+#define proj_context_create internal_proj_context_create
+#define proj_context_destroy internal_proj_context_destroy
+#define proj_context_errno internal_proj_context_errno
+#define proj_context_errno_string internal_proj_context_errno_string
+#define proj_context_get_database_metadata                                     \
+    internal_proj_context_get_database_metadata
+#define proj_context_get_database_path internal_proj_context_get_database_path
+#define proj_context_get_database_structure                                    \
+    internal_proj_context_get_database_structure
+#define proj_context_get_url_endpoint internal_proj_context_get_url_endpoint
+#define proj_context_get_use_proj4_init_rules                                  \
+    internal_proj_context_get_use_proj4_init_rules
+#define proj_context_get_user_writable_directory                               \
+    internal_proj_context_get_user_writable_directory
+#define proj_context_guess_wkt_dialect internal_proj_context_guess_wkt_dialect
+#define proj_context_is_network_enabled internal_proj_context_is_network_enabled
+#define proj_context_set_autoclose_database                                    \
+    internal_proj_context_set_autoclose_database
+#define proj_context_set_ca_bundle_path internal_proj_context_set_ca_bundle_path
+#define proj_context_set_database_path internal_proj_context_set_database_path
+#define proj_context_set_enable_network internal_proj_context_set_enable_network
+#define proj_context_set_fileapi internal_proj_context_set_fileapi
+#define proj_context_set_file_finder internal_proj_context_set_file_finder
+#define proj_context_set_network_callbacks                                     \
+    internal_proj_context_set_network_callbacks
+#define proj_context_set_search_paths internal_proj_context_set_search_paths
+#define proj_context_set_sqlite3_vfs_name                                      \
+    internal_proj_context_set_sqlite3_vfs_name
+#define proj_context_set_url_endpoint internal_proj_context_set_url_endpoint
+#define proj_context_use_proj4_init_rules                                      \
+    internal_proj_context_use_proj4_init_rules
+#define proj_convert_conversion_to_other_method                                \
+    internal_proj_convert_conversion_to_other_method
+#define proj_coord internal_proj_coord
+#define proj_coordinate_metadata_get_epoch                                     \
+    internal_proj_coordinate_metadata_get_epoch
+#define proj_coordoperation_create_inverse                                     \
+    internal_proj_coordoperation_create_inverse
+#define proj_coordoperation_get_accuracy                                       \
+    internal_proj_coordoperation_get_accuracy
+#define proj_coordoperation_get_grid_used                                      \
+    internal_proj_coordoperation_get_grid_used
+#define proj_coordoperation_get_grid_used_count                                \
+    internal_proj_coordoperation_get_grid_used_count
+#define proj_coordoperation_get_method_info                                    \
+    internal_proj_coordoperation_get_method_info
+#define proj_coordoperation_get_param internal_proj_coordoperation_get_param
+#define proj_coordoperation_get_param_count                                    \
+    internal_proj_coordoperation_get_param_count
+#define proj_coordoperation_get_param_index                                    \
+    internal_proj_coordoperation_get_param_index
+#define proj_coordoperation_get_towgs84_values                                 \
+    internal_proj_coordoperation_get_towgs84_values
+#define proj_coordoperation_has_ballpark_transformation                        \
+    internal_proj_coordoperation_has_ballpark_transformation
+#define proj_coordoperation_is_instantiable                                    \
+    internal_proj_coordoperation_is_instantiable
+#define proj_create internal_proj_create
+#define proj_create_argv internal_proj_create_argv
+#define proj_create_cartesian_2D_cs internal_proj_create_cartesian_2D_cs
+#define proj_create_compound_crs internal_proj_create_compound_crs
+#define proj_create_conversion internal_proj_create_conversion
+#define proj_create_conversion_albers_equal_area                               \
+    internal_proj_create_conversion_albers_equal_area
+#define proj_create_conversion_american_polyconic                              \
+    internal_proj_create_conversion_american_polyconic
+#define proj_create_conversion_azimuthal_equidistant                           \
+    internal_proj_create_conversion_azimuthal_equidistant
+#define proj_create_conversion_bonne internal_proj_create_conversion_bonne
+#define proj_create_conversion_cassini_soldner                                 \
+    internal_proj_create_conversion_cassini_soldner
+#define proj_create_conversion_eckert_i internal_proj_create_conversion_eckert_i
+#define proj_create_conversion_eckert_ii                                       \
+    internal_proj_create_conversion_eckert_ii
+#define proj_create_conversion_eckert_iii                                      \
+    internal_proj_create_conversion_eckert_iii
+#define proj_create_conversion_eckert_iv                                       \
+    internal_proj_create_conversion_eckert_iv
+#define proj_create_conversion_eckert_v internal_proj_create_conversion_eckert_v
+#define proj_create_conversion_eckert_vi                                       \
+    internal_proj_create_conversion_eckert_vi
+#define proj_create_conversion_equal_earth                                     \
+    internal_proj_create_conversion_equal_earth
+#define proj_create_conversion_equidistant_conic                               \
+    internal_proj_create_conversion_equidistant_conic
+#define proj_create_conversion_equidistant_cylindrical                         \
+    internal_proj_create_conversion_equidistant_cylindrical
+#define proj_create_conversion_equidistant_cylindrical_spherical               \
+    internal_proj_create_conversion_equidistant_cylindrical_spherical
+#define proj_create_conversion_gall internal_proj_create_conversion_gall
+#define proj_create_conversion_gauss_schreiber_transverse_mercator             \
+    internal_proj_create_conversion_gauss_schreiber_transverse_mercator
+#define proj_create_conversion_geostationary_satellite_sweep_x                 \
+    internal_proj_create_conversion_geostationary_satellite_sweep_x
+#define proj_create_conversion_geostationary_satellite_sweep_y                 \
+    internal_proj_create_conversion_geostationary_satellite_sweep_y
+#define proj_create_conversion_gnomonic internal_proj_create_conversion_gnomonic
+#define proj_create_conversion_goode_homolosine                                \
+    internal_proj_create_conversion_goode_homolosine
+#define proj_create_conversion_guam_projection                                 \
+    internal_proj_create_conversion_guam_projection
+#define proj_create_conversion_hotine_oblique_mercator_two_point_natural_origin \
+    internal_proj_create_conversion_hotine_oblique_mercator_two_point_natural_origin
+#define proj_create_conversion_hotine_oblique_mercator_variant_a               \
+    internal_proj_create_conversion_hotine_oblique_mercator_variant_a
+#define proj_create_conversion_hotine_oblique_mercator_variant_b               \
+    internal_proj_create_conversion_hotine_oblique_mercator_variant_b
+#define proj_create_conversion_international_map_world_polyconic               \
+    internal_proj_create_conversion_international_map_world_polyconic
+#define proj_create_conversion_interrupted_goode_homolosine                    \
+    internal_proj_create_conversion_interrupted_goode_homolosine
+#define proj_create_conversion_krovak internal_proj_create_conversion_krovak
+#define proj_create_conversion_krovak_north_oriented                           \
+    internal_proj_create_conversion_krovak_north_oriented
+#define proj_create_conversion_laborde_oblique_mercator                        \
+    internal_proj_create_conversion_laborde_oblique_mercator
+#define proj_create_conversion_lambert_azimuthal_equal_area                    \
+    internal_proj_create_conversion_lambert_azimuthal_equal_area
+#define proj_create_conversion_lambert_conic_conformal_1sp                     \
+    internal_proj_create_conversion_lambert_conic_conformal_1sp
+#define proj_create_conversion_lambert_conic_conformal_2sp                     \
+    internal_proj_create_conversion_lambert_conic_conformal_2sp
+#define proj_create_conversion_lambert_conic_conformal_2sp_belgium             \
+    internal_proj_create_conversion_lambert_conic_conformal_2sp_belgium
+#define proj_create_conversion_lambert_conic_conformal_2sp_michigan            \
+    internal_proj_create_conversion_lambert_conic_conformal_2sp_michigan
+#define proj_create_conversion_lambert_cylindrical_equal_area                  \
+    internal_proj_create_conversion_lambert_cylindrical_equal_area
+#define proj_create_conversion_lambert_cylindrical_equal_area_spherical        \
+    internal_proj_create_conversion_lambert_cylindrical_equal_area_spherical
+#define proj_create_conversion_mercator_variant_a                              \
+    internal_proj_create_conversion_mercator_variant_a
+#define proj_create_conversion_mercator_variant_b                              \
+    internal_proj_create_conversion_mercator_variant_b
+#define proj_create_conversion_miller_cylindrical                              \
+    internal_proj_create_conversion_miller_cylindrical
+#define proj_create_conversion_mollweide                                       \
+    internal_proj_create_conversion_mollweide
+#define proj_create_conversion_new_zealand_mapping_grid                        \
+    internal_proj_create_conversion_new_zealand_mapping_grid
+#define proj_create_conversion_oblique_stereographic                           \
+    internal_proj_create_conversion_oblique_stereographic
+#define proj_create_conversion_orthographic                                    \
+    internal_proj_create_conversion_orthographic
+#define proj_create_conversion_polar_stereographic_variant_a                   \
+    internal_proj_create_conversion_polar_stereographic_variant_a
+#define proj_create_conversion_polar_stereographic_variant_b                   \
+    internal_proj_create_conversion_polar_stereographic_variant_b
+#define proj_create_conversion_pole_rotation_grib_convention                   \
+    internal_proj_create_conversion_pole_rotation_grib_convention
+#define proj_create_conversion_pole_rotation_netcdf_cf_convention              \
+    internal_proj_create_conversion_pole_rotation_netcdf_cf_convention
+#define proj_create_conversion_popular_visualisation_pseudo_mercator           \
+    internal_proj_create_conversion_popular_visualisation_pseudo_mercator
+#define proj_create_conversion_quadrilateralized_spherical_cube                \
+    internal_proj_create_conversion_quadrilateralized_spherical_cube
+#define proj_create_conversion_robinson internal_proj_create_conversion_robinson
+#define proj_create_conversion_sinusoidal                                      \
+    internal_proj_create_conversion_sinusoidal
+#define proj_create_conversion_spherical_cross_track_height                    \
+    internal_proj_create_conversion_spherical_cross_track_height
+#define proj_create_conversion_stereographic                                   \
+    internal_proj_create_conversion_stereographic
+#define proj_create_conversion_transverse_mercator                             \
+    internal_proj_create_conversion_transverse_mercator
+#define proj_create_conversion_transverse_mercator_south_oriented              \
+    internal_proj_create_conversion_transverse_mercator_south_oriented
+#define proj_create_conversion_tunisia_mapping_grid                            \
+    internal_proj_create_conversion_tunisia_mapping_grid
+#define proj_create_conversion_tunisia_mining_grid                             \
+    internal_proj_create_conversion_tunisia_mining_grid
+#define proj_create_conversion_two_point_equidistant                           \
+    internal_proj_create_conversion_two_point_equidistant
+#define proj_create_conversion_utm internal_proj_create_conversion_utm
+#define proj_create_conversion_van_der_grinten                                 \
+    internal_proj_create_conversion_van_der_grinten
+#define proj_create_conversion_vertical_perspective                            \
+    internal_proj_create_conversion_vertical_perspective
+#define proj_create_conversion_wagner_i internal_proj_create_conversion_wagner_i
+#define proj_create_conversion_wagner_ii                                       \
+    internal_proj_create_conversion_wagner_ii
+#define proj_create_conversion_wagner_iii                                      \
+    internal_proj_create_conversion_wagner_iii
+#define proj_create_conversion_wagner_iv                                       \
+    internal_proj_create_conversion_wagner_iv
+#define proj_create_conversion_wagner_v internal_proj_create_conversion_wagner_v
+#define proj_create_conversion_wagner_vi                                       \
+    internal_proj_create_conversion_wagner_vi
+#define proj_create_conversion_wagner_vii                                      \
+    internal_proj_create_conversion_wagner_vii
+#define proj_create_crs_to_crs internal_proj_create_crs_to_crs
+#define proj_create_crs_to_crs_from_pj internal_proj_create_crs_to_crs_from_pj
+#define proj_create_cs internal_proj_create_cs
+#define proj_create_derived_geographic_crs                                     \
+    internal_proj_create_derived_geographic_crs
+#define proj_create_ellipsoidal_2D_cs internal_proj_create_ellipsoidal_2D_cs
+#define proj_create_ellipsoidal_3D_cs internal_proj_create_ellipsoidal_3D_cs
+#define proj_create_engineering_crs internal_proj_create_engineering_crs
+#define proj_create_from_database internal_proj_create_from_database
+#define proj_create_from_name internal_proj_create_from_name
+#define proj_create_from_wkt internal_proj_create_from_wkt
+#define proj_create_geocentric_crs internal_proj_create_geocentric_crs
+#define proj_create_geocentric_crs_from_datum                                  \
+    internal_proj_create_geocentric_crs_from_datum
+#define proj_create_geographic_crs internal_proj_create_geographic_crs
+#define proj_create_geographic_crs_from_datum                                  \
+    internal_proj_create_geographic_crs_from_datum
+#define proj_create_operation_factory_context                                  \
+    internal_proj_create_operation_factory_context
+#define proj_create_operations internal_proj_create_operations
+#define proj_create_projected_crs internal_proj_create_projected_crs
+#define proj_create_transformation internal_proj_create_transformation
+#define proj_create_vertical_crs internal_proj_create_vertical_crs
+#define proj_create_vertical_crs_ex internal_proj_create_vertical_crs_ex
+#define proj_crs_alter_cs_angular_unit internal_proj_crs_alter_cs_angular_unit
+#define proj_crs_alter_cs_linear_unit internal_proj_crs_alter_cs_linear_unit
+#define proj_crs_alter_geodetic_crs internal_proj_crs_alter_geodetic_crs
+#define proj_crs_alter_parameters_linear_unit                                  \
+    internal_proj_crs_alter_parameters_linear_unit
+#define proj_crs_create_bound_crs internal_proj_crs_create_bound_crs
+#define proj_crs_create_bound_crs_to_WGS84                                     \
+    internal_proj_crs_create_bound_crs_to_WGS84
+#define proj_crs_create_bound_vertical_crs                                     \
+    internal_proj_crs_create_bound_vertical_crs
+#define proj_crs_create_projected_3D_crs_from_2D                               \
+    internal_proj_crs_create_projected_3D_crs_from_2D
+#define proj_crs_demote_to_2D internal_proj_crs_demote_to_2D
+#define proj_crs_get_coordinate_system internal_proj_crs_get_coordinate_system
+#define proj_crs_get_coordoperation internal_proj_crs_get_coordoperation
+#define proj_crs_get_datum internal_proj_crs_get_datum
+#define proj_crs_get_datum_ensemble internal_proj_crs_get_datum_ensemble
+#define proj_crs_get_datum_forced internal_proj_crs_get_datum_forced
+#define proj_crs_get_geodetic_crs internal_proj_crs_get_geodetic_crs
+#define proj_crs_get_horizontal_datum internal_proj_crs_get_horizontal_datum
+#define proj_crs_get_sub_crs internal_proj_crs_get_sub_crs
+#define proj_crs_info_list_destroy internal_proj_crs_info_list_destroy
+#define proj_crs_is_derived internal_proj_crs_is_derived
+#define proj_crs_promote_to_3D internal_proj_crs_promote_to_3D
+#define proj_cs_get_axis_count internal_proj_cs_get_axis_count
+#define proj_cs_get_axis_info internal_proj_cs_get_axis_info
+#define proj_cs_get_type internal_proj_cs_get_type
+#define proj_datum_ensemble_get_accuracy                                       \
+    internal_proj_datum_ensemble_get_accuracy
+#define proj_datum_ensemble_get_member internal_proj_datum_ensemble_get_member
+#define proj_datum_ensemble_get_member_count                                   \
+    internal_proj_datum_ensemble_get_member_count
+#define proj_degree_input internal_proj_degree_input
+#define proj_degree_output internal_proj_degree_output
+#define proj_destroy internal_proj_destroy
+#define proj_dmstor internal_proj_dmstor
+#define proj_download_file internal_proj_download_file
+#define proj_dynamic_datum_get_frame_reference_epoch                           \
+    internal_proj_dynamic_datum_get_frame_reference_epoch
+#define proj_ellipsoid_get_parameters internal_proj_ellipsoid_get_parameters
+#define proj_errno internal_proj_errno
+#define proj_errno_reset internal_proj_errno_reset
+#define proj_errno_restore internal_proj_errno_restore
+#define proj_errno_set internal_proj_errno_set
+#define proj_errno_string internal_proj_errno_string
+#define proj_factors internal_proj_factors
+#define proj_geod internal_proj_geod
+#define proj_get_area_of_use internal_proj_get_area_of_use
+#define proj_get_authorities_from_database                                     \
+    internal_proj_get_authorities_from_database
+#define proj_get_celestial_body_list_from_database                             \
+    internal_proj_get_celestial_body_list_from_database
+#define proj_get_celestial_body_name internal_proj_get_celestial_body_name
+#define proj_get_codes_from_database internal_proj_get_codes_from_database
+#define proj_get_crs_info_list_from_database                                   \
+    internal_proj_get_crs_info_list_from_database
+#define proj_get_crs_list_parameters_create                                    \
+    internal_proj_get_crs_list_parameters_create
+#define proj_get_crs_list_parameters_destroy                                   \
+    internal_proj_get_crs_list_parameters_destroy
+#define proj_get_ellipsoid internal_proj_get_ellipsoid
+#define proj_get_geoid_models_from_database                                    \
+    internal_proj_get_geoid_models_from_database
+#define proj_get_id_auth_name internal_proj_get_id_auth_name
+#define proj_get_id_code internal_proj_get_id_code
+#define proj_get_insert_statements internal_proj_get_insert_statements
+#define proj_get_name internal_proj_get_name
+#define proj_get_non_deprecated internal_proj_get_non_deprecated
+#define proj_get_prime_meridian internal_proj_get_prime_meridian
+#define proj_get_remarks internal_proj_get_remarks
+#define proj_get_scope internal_proj_get_scope
+#define proj_get_source_crs internal_proj_get_source_crs
+#define proj_get_suggested_operation internal_proj_get_suggested_operation
+#define proj_get_target_crs internal_proj_get_target_crs
+#define proj_get_type internal_proj_get_type
+#define proj_get_units_from_database internal_proj_get_units_from_database
+#define proj_grid_cache_clear internal_proj_grid_cache_clear
+#define proj_grid_cache_set_enable internal_proj_grid_cache_set_enable
+#define proj_grid_cache_set_filename internal_proj_grid_cache_set_filename
+#define proj_grid_cache_set_max_size internal_proj_grid_cache_set_max_size
+#define proj_grid_cache_set_ttl internal_proj_grid_cache_set_ttl
+#define proj_grid_get_info_from_database                                       \
+    internal_proj_grid_get_info_from_database
+#define proj_grid_info internal_proj_grid_info
+#define proj_identify internal_proj_identify
+#define proj_info internal_proj_info
+#define proj_init_info internal_proj_init_info
+#define proj_insert_object_session_create                                      \
+    internal_proj_insert_object_session_create
+#define proj_insert_object_session_destroy                                     \
+    internal_proj_insert_object_session_destroy
+#define proj_int_list_destroy internal_proj_int_list_destroy
+#define proj_is_crs internal_proj_is_crs
+#define proj_is_deprecated internal_proj_is_deprecated
+#define proj_is_derived_crs internal_proj_is_derived_crs
+#define proj_is_download_needed internal_proj_is_download_needed
+#define proj_is_equivalent_to internal_proj_is_equivalent_to
+#define proj_is_equivalent_to_with_ctx internal_proj_is_equivalent_to_with_ctx
+#define proj_list_angular_units internal_proj_list_angular_units
+#define proj_list_destroy internal_proj_list_destroy
+#define proj_list_ellps internal_proj_list_ellps
+#define proj_list_get internal_proj_list_get
+#define proj_list_get_count internal_proj_list_get_count
+#define proj_list_operations internal_proj_list_operations
+#define proj_list_prime_meridians internal_proj_list_prime_meridians
+#define proj_list_units internal_proj_list_units
+#define proj_log_func internal_proj_log_func
+#define proj_log_level internal_proj_log_level
+#define proj_lp_dist internal_proj_lp_dist
+#define proj_lpz_dist internal_proj_lpz_dist
+#define proj_normalize_for_visualization                                       \
+    internal_proj_normalize_for_visualization
+#define proj_operation_factory_context_destroy                                 \
+    internal_proj_operation_factory_context_destroy
+#define proj_operation_factory_context_set_allow_ballpark_transformations      \
+    internal_proj_operation_factory_context_set_allow_ballpark_transformations
+#define proj_operation_factory_context_set_allowed_intermediate_crs            \
+    internal_proj_operation_factory_context_set_allowed_intermediate_crs
+#define proj_operation_factory_context_set_allow_use_intermediate_crs          \
+    internal_proj_operation_factory_context_set_allow_use_intermediate_crs
+#define proj_operation_factory_context_set_area_of_interest                    \
+    internal_proj_operation_factory_context_set_area_of_interest
+#define proj_operation_factory_context_set_area_of_interest_name               \
+    internal_proj_operation_factory_context_set_area_of_interest_name
+#define proj_operation_factory_context_set_crs_extent_use                      \
+    internal_proj_operation_factory_context_set_crs_extent_use
+#define proj_operation_factory_context_set_desired_accuracy                    \
+    internal_proj_operation_factory_context_set_desired_accuracy
+#define proj_operation_factory_context_set_discard_superseded                  \
+    internal_proj_operation_factory_context_set_discard_superseded
+#define proj_operation_factory_context_set_grid_availability_use               \
+    internal_proj_operation_factory_context_set_grid_availability_use
+#define proj_operation_factory_context_set_spatial_criterion                   \
+    internal_proj_operation_factory_context_set_spatial_criterion
+#define proj_operation_factory_context_set_use_proj_alternative_grid_names     \
+    internal_proj_operation_factory_context_set_use_proj_alternative_grid_names
+#define proj_pj_info internal_proj_pj_info
+#define proj_prime_meridian_get_parameters                                     \
+    internal_proj_prime_meridian_get_parameters
+#define proj_query_geodetic_crs_from_datum                                     \
+    internal_proj_query_geodetic_crs_from_datum
+#define proj_roundtrip internal_proj_roundtrip
+#define proj_rtodms internal_proj_rtodms
+#define proj_rtodms2 internal_proj_rtodms2
+#define proj_string_destroy internal_proj_string_destroy
+#define proj_string_list_destroy internal_proj_string_list_destroy
+#define proj_suggests_code_for internal_proj_suggests_code_for
+#define proj_todeg internal_proj_todeg
+#define proj_torad internal_proj_torad
+#define proj_trans internal_proj_trans
+#define proj_trans_array internal_proj_trans_array
+#define proj_trans_bounds internal_proj_trans_bounds
+#define proj_trans_generic internal_proj_trans_generic
+#define proj_trans_get_last_used_operation                                     \
+    internal_proj_trans_get_last_used_operation
+#define proj_unit_list_destroy internal_proj_unit_list_destroy
+#define proj_uom_get_info_from_database internal_proj_uom_get_info_from_database
+#define proj_xy_dist internal_proj_xy_dist
+#define proj_xyz_dist internal_proj_xyz_dist
+#define pj_release internal_pj_release
+#endif /* PROJ_SYMBOL_RENAME_H */


### PR DESCRIPTION
Added the PROJ library to LAStools for performing transformations between Coordinate Reference Systems (CRS) using las2las with various formates: EPSG code
Well-Known Text (WKT)
PROJJSON representation
PROJ string

Enhanced lasinfo to query and display CRS representation and related information such as: WKT (Well-Known Text) - "wkt"
PROJJSON representation - "js"
PROJ string representation - "str"
EPSG code - "epsg"
Ellipsoid information - "el"
Datum information - "datum"
Coordinate System information - "cs"

Added support for the -set_ogc_wkt option, utilizing the PROJ library for WKT representation if installed.

Updated documentation to reflect new CRS transformation capabilities and metadata querying features.