### PR TITLE
Fix build issue with GCC 14.2

### DIFF
--- a/src/las2las.cpp
+++ b/src/las2las.cpp
@@ -62,6 +62,7 @@
 ===============================================================================
 */
 
+#include <cstdint>
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Include standard header `cstdint` to provide symbol `UINT16_MAX`