### PR TITLE
Update proj_loader.cpp

### DIFF
--- a/src/proj_loader.cpp
+++ b/src/proj_loader.cpp
@@ -131,7 +131,7 @@ static std::vector<int> parseVersion(const char* versionStr) {
   return versionNumbers;
 }
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 static char* findUnixLibProjPath() {
   // Check system-wide directories
   const std::string systemLibPaths[] = {


### PR DESCRIPTION
Help macOS systems find Proj4

I am running on a MacOS machine M3 and I found fixing this line helps my machine find Proj4 and build the project.