### PR TITLE
Update cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 set(CMAKE_SUPPRESS_REGENERATION true)
 set(CMAKE_CXX_STANDARD 17)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")

--- a/LASlib/CMakeLists.txt
+++ b/LASlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 set(CMAKE_SUPPRESS_REGENERATION true)
 project("LASlib")
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
... for compatibility with CMake 4.0 (currently in https://www.kitware.com/cmake-4-0-0-rc4-is-ready-for-testing/).

`LASzip/` already required CMake>=3.10. Note that CMake-3.10 was published in [late 2017][*].

[*]: https://www.kitware.com/cmake-3-10-0-available-for-download/
