### PR TITLE
fix a compilation error on Fedora 42 (with gcc 15.1)

### DIFF
--- a/src/lascopcindex.cpp
+++ b/src/lascopcindex.cpp
@@ -54,6 +54,7 @@
  ===============================================================================
  */
 
+#include <cstdint>
 #include <errno.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
In [a CI build log](https://github.com/CGAL/cgal-testsuite-dockerfiles/actions/runs/14863587176/job/41734605032#step:3:4983), we have that error:

```c++
#12 40.60 /LAStools-master/src/lascopcindex.cpp: In function 'int main(int, char**)':
#12 40.60 /LAStools-master/src/lascopcindex.cpp:1297:60: error: 'uint64_t' does not name a type
#12 40.60  1297 |                 F64 res = octree.get_size() / (static_cast<uint64_t>(1) << it->first.d);
#12 40.60       |                                                            ^~~~~~~~
#12 40.60 /LAStools-master/src/lascopcindex.cpp:72:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
#12 40.60    71 | #include "lastool.hpp"
#12 40.60   +++ |+#include <cstdint>
#12 40.60    72 | 
```

This pull-request fixes the build error, by adding the header.