### PR TITLE
Unified definition of BOOL across all compilers

### DIFF
--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -79,11 +79,7 @@ typedef long long I64;
 typedef float F32;
 typedef double F64;
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
-typedef int BOOL;
-#else
 typedef bool BOOL;
-#endif
 
 typedef union U32I32F32 {
   U32 u32;


### PR DESCRIPTION
Years ago, I suggested unifying this across all compilers (#17 ). Since the library now requires C++17 and thus the time of Visual Studio 6 should finally be over and as far as I know this structure only existed because of incomplete C99 support in very old compilers, a new attempt to adapt this.

Since I read in a PR that @rapidlasso  does not have so much time to review, here is just the adaptation of the definition. The other changes of #17 I would make in a later PR, when it is in here.

Side note: In the CMake file, the C++ standard is set to 17, but the C standard is not, although the project is marked as a C & C++ project in CMake. If I see it correctly, it is a pure C++ project, or am I missing a C wrapper somewhere that should be taken into account?