### PR TITLE
fix argument passing bugs, which were found as macos compile errors

### DIFF
--- a/LASzip/src/lasindex.cpp
+++ b/LASzip/src/lasindex.cpp
@@ -309,7 +309,7 @@ BOOL LASindex::read(const char* file_name)
     return FALSE;
   } 
   else if (!read(file)) {
-    laserror("(LASindex): cannot read '%s'", fn);
+    laserror("(LASindex): cannot read '%s'", fn.c_str());
     fclose(file);
     return FALSE;
   } else {
@@ -473,7 +473,7 @@ BOOL LASindex::write(const char* file_name) const
     laserror("(LASindex): cannot open file '%s' for write", fn.c_str());
     return FALSE;
   } else if (!write(file)) {
-    laserror("(LASindex): cannot write '%s'", fn);
+    laserror("(LASindex): cannot write '%s'", fn.c_str());
     fclose(file);
     return FALSE;
   } else {


### PR DESCRIPTION
there were two instances of passing a std::string to laserror as an argument. 
macos clang++ flagged these as errors

```
In file included from /Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.cpp:31:
In file included from /Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.hpp:44:
/Users/pjoyce/Developer/LAStools/LASzip/src/mydefs.hpp:351:30: error: cannot pass object of non-trivial type 'std::string' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
  351 |   LASMessage(LAS_ERROR, fmt, args...);
      |                              ^
/Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.cpp:312:5: note: in instantiation of function template specialization 'laserror<std::string>' requested here
  312 |     laserror("(LASindex): cannot read '%s'", fn);
      |     ^


In file included from /Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.cpp:31:
In file included from /Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.hpp:44:
/Users/pjoyce/Developer/LAStools/LASzip/src/mydefs.hpp:351:30: error: cannot pass object of non-trivial type 'std::string' through variadic function; call will
abort at runtime [-Wnon-pod-varargs]
  351 |   LASMessage(LAS_ERROR, fmt, args...);
      |                              ^
/Users/pjoyce/Developer/LAStools/LASzip/src/lasindex.cpp:476:5: note: in instantiation of function template specialization 'laserror<std::string>' requested here
  476 |     laserror("(LASindex): cannot write '%s'", fn);
      |     ^

```

other occurrences are already correctly passing the .c_str() of the strings