### PR TITLE
Improve UTF-8 validation and prevent ANSI/GBK false positives

### DIFF
--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -340,7 +340,7 @@ extern void LASLIB_DLL byebye();
   char* ANSItoUTF8(const char* ansi);
 #endif
 // Validates whether a given string is UTF-8 encoded.
-bool validate_utf8(const char* utf8) noexcept;
+bool validate_utf8(const char* utf8, bool restrict_to_two_bytes = false) noexcept;
 // Opens a file with the specified filename and mode, converting filename and mode to UTF-16 on Windows.
 FILE* LASfopen(const char* const filename, const char* const mode);
 const char* indent_text(const char* text, const char* indent);


### PR DESCRIPTION
The previous validate_utf8 function was too permissive and could misidentify ANSI/GBK encoded paths as UTF-8, causing failures on Windows with non-ASCII file paths.

This update:

- Strict UTF-8 validation to avoid ANSI/GBK false positives
- Optional 2-byte restriction for Windows paths
- FORCE_UTF8_PATH macro to treat paths as UTF-8 explicitly