### PR TITLE
Fix int32_t overflow causing lascopcindex to crash

### DIFF
--- a/src/lascopcindex.cpp
+++ b/src/lascopcindex.cpp
@@ -509,12 +509,13 @@ struct OctantOnDisk : public Octant
 
     reactivate("r+b");
 
-    point_buffer = (U8*)malloc(point_count * point_size);
-    if (point_buffer != nullptr)
-    {
-      fseek(fp, 0, SEEK_SET);
-      fread(point_buffer, point_size, point_count, fp);
-    }
+    const size_t size = size_t(point_count) * size_t(point_size);
+    point_buffer = (U8*)malloc(size);
+
+    if (point_buffer == nullptr) throw std::runtime_error("ERROR: couldn't allocate memory to read points");
+
+    fseek(fp, 0, SEEK_SET);
+    fread(point_buffer, point_size, point_count, fp);
 
     close();
   };


### PR DESCRIPTION
Seeing a `malloc()` for `44,481,125points * 50bytes = 2,224,056,250 bytes` in `load()`, which won't fit into the `int32_t` you're passing to it. This then gets casted to a crazy large `size_t` and then causes `malloc()` to return a `nullptr`.

Fix is to use `size_t`, which is what `malloc()` expects.

I do not know why its trying to read 44M points at a time and why this only ever crashed on linux but worked on windows.

This might be rapidlasso support issue 653.