### PR TITLE
fix linker errors without proj_wrapper.cpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,11 +30,11 @@ set(STANDALONE_TARGETS
 set(ALL_TARGETS ${GEOPROJECTION_TARGETS} ${STANDALONE_TARGETS})
 
 foreach(TARGET ${GEOPROJECTION_TARGETS})
-  add_executable(${TARGET} ${TARGET}.cpp wktparser.cpp geoprojectionconverter.cpp proj_loader.cpp)
+  add_executable(${TARGET} ${TARGET}.cpp wktparser.cpp geoprojectionconverter.cpp proj_loader.cpp proj_wrapper.cpp)
 endforeach(TARGET)
 
 foreach(TARGET ${STANDALONE_TARGETS})
-  add_executable(${TARGET} ${TARGET}.cpp proj_loader.cpp)
+  add_executable(${TARGET} ${TARGET}.cpp proj_loader.cpp proj_wrapper.cpp)
 endforeach(TARGET)
 
 foreach(TARGET ${ALL_TARGETS})


### PR DESCRIPTION
fix linker errors by adding `proj_wrapper.cpp` to all relevant targets in `CMakeLists.txt`

See for example [that CI run](https://github.com/CGAL/cgal-testsuite-dockerfiles/actions/runs/19604050384/job/56139821085) for example of the link errors without this patch.