### PR TITLE
export las helper functions if laslib is compiled as DLL 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/*.exe
 *.ilk
 *.o
 *.a
+*.exp
 LASlib/example/lasexample
 LASlib/example/lasexample_add_rgb
 LASlib/example/lasexample_simple_classification

--- a/LASzip/src/mydefs.cpp
+++ b/LASzip/src/mydefs.cpp
@@ -41,7 +41,7 @@
 #include <string>
 #ifdef _WIN32
 #include <windows.h>
-#include <cctype> //needed for vs2017 and vs2019 to avoid std::tolower and std:toupper compile errors
+#include <cctype> //needed for vs2017 to avoid std::tolower and std:toupper compile errors
 #else
 #include <unistd.h>
 #endif

--- a/LASzip/src/mydefs.cpp
+++ b/LASzip/src/mydefs.cpp
@@ -41,6 +41,7 @@
 #include <string>
 #ifdef _WIN32
 #include <windows.h>
+#include <cctype> //needed for vs2017 and vs2019 to avoid std::tolower and std:toupper compile errors
 #else
 #include <unistd.h>
 #endif

--- a/LASzip/src/mydefs.hpp
+++ b/LASzip/src/mydefs.hpp
@@ -549,17 +549,17 @@ bool IsLasLazFile(std::string fn);
 /// returns TRUE if 'val' is found in 'vec'
 bool StringInVector(const std::string& value, const std::vector<std::string>& array, bool casesense);
 
-void* realloc_las(void* ptr, size_t size);
-void* malloc_las(size_t size);
+LASLIB_DLL void* realloc_las(void* ptr, size_t size);
+LASLIB_DLL void* malloc_las(size_t size);
 void bytes_to_readable(size_t bytes, double* value_out, const char** unit_out);
 
 size_t get_available_RAM();
 bool check_available_RAM(size_t size);
 
 /// Wrapper for `sscanf` on other platforms than _MSC_VER and `sscanf_s` on Windows and ensures that the size is passed correctly for strings.
-int sscanf_las(const char* buffer, const char* format, ...);
+LASLIB_DLL int sscanf_las(const char* buffer, const char* format, ...);
 /// Wrapper for `strncpy` on other platforms than _MSC_VER and `strncpy_s` on Windows.
-void strncpy_las(char* dest, size_t destsz, const char* src, size_t count = 0);
+LASLIB_DLL void strncpy_las(char* dest, size_t destsz, const char* src, size_t count = 0);
 
 #ifdef BOOST_USE
 #define BOOST_PRE boost::algorithm::


### PR DESCRIPTION
Changes:

1.  The helper function `realloc_las`, `malloc_las `and `strncpy_las` have to be exported if the LASattribute class is used externally. For uniformity, also `sscanf_las` although it's never used in a header file (currently)
2. Under VS2017 an additional header file (`cctype`) is needed to get the code compiled without errors (include has no negative effect under VS2019)
