### PR TITLE
Fix validate_utf8 to correctly accept all valid multi-byte sequences

### DIFF
--- a/LASlib/inc/lasdefinitions.hpp
+++ b/LASlib/inc/lasdefinitions.hpp
@@ -52,7 +52,7 @@
 #ifndef LAS_DEFINITIONS_HPP
 #define LAS_DEFINITIONS_HPP
 
-#define LAS_TOOLS_VERSION 260505
+#define LAS_TOOLS_VERSION 260507
 
 #include <stdio.h>
 #include <string.h>

--- a/LASzip/src/mydefs.cpp
+++ b/LASzip/src/mydefs.cpp
@@ -134,7 +134,6 @@ bool validate_utf8(const char* str, bool restrict_to_two_bytes) noexcept {
   constexpr uint8_t UTF8_CONTINUATION_MASK = 0xC0;
   constexpr uint8_t UTF8_CONTINUATION_PREFIX = 0x80;
 
-  // bool has_two_byte = false;
   const auto* p = reinterpret_cast<const unsigned char*>(str);
 
   while (*p) {
@@ -146,12 +145,6 @@ bool validate_utf8(const char* str, bool restrict_to_two_bytes) noexcept {
       continue;
     }
 
-    // Detect standalone high bytes (0x80-0xFF), common in Windows-1252
-    if (c >= 0x80 && (c < 0xC2 || (c & UTF8_2BYTE_MASK) != UTF8_2BYTE_PREFIX) && (c & UTF8_3BYTE_MASK) != UTF8_3BYTE_PREFIX &&
-        (c & UTF8_4BYTE_MASK) != UTF8_4BYTE_PREFIX) {
-      return false;  // Invalid UTF-8 start byte, likely ANSI
-    }
-
     // 2-byte sequence (U+0080 - U+07FF)
     if ((c & UTF8_2BYTE_MASK) == UTF8_2BYTE_PREFIX) {
       if (c < 0xC2 || !p[1]) {
@@ -159,18 +152,8 @@ bool validate_utf8(const char* str, bool restrict_to_two_bytes) noexcept {
       }
       uint8_t c1 = p[1];
       if ((c1 & UTF8_CONTINUATION_MASK) != UTF8_CONTINUATION_PREFIX) {
-        // Check for ANSI-like second byte (0x40-0x7F), common in GBK/Shift-JIS
-        if (c1 >= 0x40 && c1 <= 0x7F) {
-          return false;  // Likely GBK or Shift-JIS, not UTF-8
-        }
         return false;  // Invalid continuation byte
       }
-      // Decode and check code point to exclude rare ranges
-      uint32_t code_point = ((c & 0x1F) << 6) | (c1 & 0x3F);
-      if (code_point < 0x80 || code_point > 0x7FF || (code_point >= 0x0080 && code_point <= 0x05FF)) {
-        return false;  // Invalid or rare code point, likely ANSI
-      }
-      // has_two_byte = true;
       p += 2;
       continue;
     }


### PR DESCRIPTION
Fixes #263.

Test code (as far as I know in this repo are no tests, so I couldn't integrate them to prevent regressions): https://godbolt.org/z/5r7dbaWW9.

Before fix:
```
=== Expected true (default mode) ===
ASCII: true
Café: false
Jörg: false
für: false
España: false
Ω: false
Ж: false
你好: true
😀: true

=== Expected false (default mode) ===
standalone continuation byte: false
overlong encoding: false
overlong 3-byte: false
UTF-16 surrogate: false
> U+10FFFF: false
bad continuation: false

=== Expected true (restrict_to_two_bytes = true) ===
ASCII: true
Café: false
Jörg: false
für: false
España: false
Ω: false
Ж: false

=== Expected false (restrict_to_two_bytes = true) ===
你好: false
😀: false
standalone continuation byte: false
overlong encoding: false
overlong 3-byte: false
UTF-16 surrogate: false
> U+10FFFF: false
bad continuation: false
```
After fix:
```
=== Expected true (default mode) ===
ASCII: true
Café: true
Jörg: true
für: true
España: true
Ω: true
Ж: true
你好: true
😀: true

=== Expected false (default mode) ===
standalone continuation byte: false
overlong encoding: false
overlong 3-byte: false
UTF-16 surrogate: false
> U+10FFFF: false
bad continuation: false

=== Expected true (restrict_to_two_bytes = true) ===
ASCII: true
Café: true
Jörg: true
für: true
España: true
Ω: true
Ж: true

=== Expected false (restrict_to_two_bytes = true) ===
你好: false
😀: false
standalone continuation byte: false
overlong encoding: false
overlong 3-byte: false
UTF-16 surrogate: false
> U+10FFFF: false
bad continuation: false
```

Short explanation:
- Removed the `code_point` code, which caused the issue
- The other both checks were redundant

Could you create a release tag v2.0.5.1 after this (therefore already increased `LAS_TOOLS_VERSION`)?