### PR TITLE
Added missing DLL symbol exports for the public interface

### DIFF
--- a/LASlib/inc/lasfilter.hpp
+++ b/LASlib/inc/lasfilter.hpp
@@ -58,7 +58,7 @@ protected:
     U16 global_encoding = 0;
 };
 
-class LASfilter
+class LASLIB_DLL LASfilter
 {
 public:
 

--- a/LASlib/inc/lasignore.hpp
+++ b/LASlib/inc/lasignore.hpp
@@ -48,7 +48,7 @@
 #define LASIGNORE_WITHHELD        0x00004000
 #define LASIGNORE_OVERLAP         0x00008000
 
-class LASignore
+class LASLIB_DLL LASignore
 {
 public:
   void usage() const;

--- a/LASlib/inc/laskdtree.hpp
+++ b/LASlib/inc/laskdtree.hpp
@@ -44,7 +44,7 @@
 
 typedef std::set<U32> my_index_set;
 
-class LASkdtreeRectangle
+class LASLIB_DLL LASkdtreeRectangle
 {
 public:
   F64 min[2];
@@ -58,7 +58,7 @@ public:
   LASkdtreeRectangle(F64 min_x, F64 min_y, F64 max_x, F64 max_y, U32 index);
 };
 
-class LASkdtreePoint
+class LASLIB_DLL LASkdtreePoint
 {
 public:
   F64 pos[2];
@@ -71,7 +71,7 @@ public:
 
 typedef std::list<LASkdtreeRectangle> my_rectangle_list;
 
-class LASkdtreeRectanglesNode
+class LASLIB_DLL LASkdtreeRectanglesNode
 {
 public:
   F64 split;
@@ -83,7 +83,7 @@ public:
   ~LASkdtreeRectanglesNode();
 };
 
-class LASkdtreeRectangles
+class LASLIB_DLL LASkdtreeRectangles
 {
 public:
   BOOL init();

--- a/LASlib/inc/lasreader_asc.hpp
+++ b/LASlib/inc/lasreader_asc.hpp
@@ -38,7 +38,7 @@
 
 #include <stdio.h>
 
-class LASreaderASC : public LASreader
+class LASLIB_DLL LASreaderASC : public LASreader
 {
 public:
 
@@ -85,7 +85,7 @@ private:
   void populate_bounding_box();
 };
 
-class LASreaderASCrescale : public virtual LASreaderASC
+class LASLIB_DLL LASreaderASCrescale : public virtual LASreaderASC
 {
 public:
   virtual BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
@@ -95,7 +95,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderASCreoffset : public virtual LASreaderASC
+class LASLIB_DLL LASreaderASCreoffset : public virtual LASreaderASC
 {
 public:
   virtual BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);
@@ -104,7 +104,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderASCrescalereoffset : public LASreaderASCrescale, LASreaderASCreoffset
+class LASLIB_DLL LASreaderASCrescalereoffset : public LASreaderASCrescale, LASreaderASCreoffset
 {
 public:
   BOOL open(const CHAR* file_name, BOOL comma_not_point=FALSE);

--- a/LASlib/inc/lasreader_bil.hpp
+++ b/LASlib/inc/lasreader_bil.hpp
@@ -39,7 +39,7 @@
 
 #include <stdio.h>
 
-class LASreaderBIL : public LASreader
+class LASLIB_DLL LASreaderBIL : public LASreader
 {
 public:
 
@@ -84,7 +84,7 @@ private:
   void populate_bounding_box();
 };
 
-class LASreaderBILrescale : public virtual LASreaderBIL
+class LASLIB_DLL LASreaderBILrescale : public virtual LASreaderBIL
 {
 public:
   virtual BOOL open(const CHAR* file_name);
@@ -94,7 +94,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderBILreoffset : public virtual LASreaderBIL
+class LASLIB_DLL LASreaderBILreoffset : public virtual LASreaderBIL
 {
 public:
   virtual BOOL open(const CHAR* file_name);
@@ -103,7 +103,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderBILrescalereoffset : public LASreaderBILrescale, LASreaderBILreoffset
+class LASLIB_DLL LASreaderBILrescalereoffset : public LASreaderBILrescale, LASreaderBILreoffset
 {
 public:
   BOOL open(const CHAR* file_name);

--- a/LASlib/inc/lasreader_bin.hpp
+++ b/LASlib/inc/lasreader_bin.hpp
@@ -37,7 +37,7 @@
 
 #include <stdio.h>
 
-class LASreaderBIN : public LASreader
+class LASLIB_DLL LASreaderBIN : public LASreader
 {
 public:
 
@@ -64,7 +64,7 @@ private:
   I32 version;
 };
 
-class LASreaderBINrescale : public virtual LASreaderBIN
+class LASLIB_DLL LASreaderBINrescale : public virtual LASreaderBIN
 {
 public:
   virtual BOOL open(ByteStreamIn* stream);
@@ -74,7 +74,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderBINreoffset : public virtual LASreaderBIN
+class LASLIB_DLL LASreaderBINreoffset : public virtual LASreaderBIN
 {
 public:
   virtual BOOL open(ByteStreamIn* stream);
@@ -83,7 +83,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderBINrescalereoffset : public LASreaderBINrescale, LASreaderBINreoffset
+class LASLIB_DLL LASreaderBINrescalereoffset : public LASreaderBINrescale, LASreaderBINreoffset
 {
 public:
   BOOL open(ByteStreamIn* stream);

--- a/LASlib/inc/lasreader_dtm.hpp
+++ b/LASlib/inc/lasreader_dtm.hpp
@@ -37,7 +37,7 @@
 
 #include <stdio.h>
 
-class LASreaderDTM : public LASreader
+class LASLIB_DLL LASreaderDTM : public LASreader
 {
 public:
 
@@ -79,7 +79,7 @@ private:
   void populate_bounding_box();
 };
 
-class LASreaderDTMrescale : public virtual LASreaderDTM
+class LASLIB_DLL LASreaderDTMrescale : public virtual LASreaderDTM
 {
 public:
   virtual BOOL open(const CHAR* file_name);
@@ -89,7 +89,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderDTMreoffset : public virtual LASreaderDTM
+class LASLIB_DLL LASreaderDTMreoffset : public virtual LASreaderDTM
 {
 public:
   virtual BOOL open(const CHAR* file_name);
@@ -98,7 +98,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderDTMrescalereoffset : public LASreaderDTMrescale, LASreaderDTMreoffset
+class LASLIB_DLL LASreaderDTMrescalereoffset : public LASreaderDTMrescale, LASreaderDTMreoffset
 {
 public:
   BOOL open(const CHAR* file_name);

--- a/LASlib/inc/lasreader_las.hpp
+++ b/LASlib/inc/lasreader_las.hpp
@@ -91,7 +91,7 @@ private:
   BOOL keep_copc;
 };
 
-class LASreaderLASrescale : public virtual LASreaderLAS
+class LASLIB_DLL LASreaderLASrescale : public virtual LASreaderLAS
 {
 public:
   LASreaderLASrescale(LASreadOpener* opener, F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, BOOL check_for_overflow=TRUE);
@@ -105,7 +105,7 @@ protected:
   F64 orig_x_scale_factor, orig_y_scale_factor, orig_z_scale_factor;
 };
 
-class LASreaderLASreoffset : public virtual LASreaderLAS
+class LASLIB_DLL LASreaderLASreoffset : public virtual LASreaderLAS
 {
 public:
   LASreaderLASreoffset(LASreadOpener* opener, F64 x_offset, F64 y_offset, F64 z_offset);
@@ -120,7 +120,7 @@ protected:
   F64 orig_x_offset, orig_y_offset, orig_z_offset;
 };
 
-class LASreaderLASrescalereoffset : public LASreaderLASrescale, public LASreaderLASreoffset
+class LASLIB_DLL LASreaderLASrescalereoffset : public LASreaderLASrescale, public LASreaderLASreoffset
 {
 public:
   LASreaderLASrescalereoffset(LASreadOpener* opener, F64 x_scale_factor, F64 y_scale_factor, F64 z_scale_factor, F64 x_offset, F64 y_offset, F64 z_offset);
@@ -131,7 +131,7 @@ protected:
   virtual BOOL read_point_default();
 };
 
-class LASreaderLASrescalereoffsetgps : public LASreaderLASrescalereoffset
+class LASLIB_DLL LASreaderLASrescalereoffsetgps : public LASreaderLASrescalereoffset
 {
 public:
     LASreaderLASrescalereoffsetgps(LASreadOpener* opener, BOOL rescale, BOOL reoffset, BOOL gps, 

--- a/LASlib/inc/lasreader_ply.hpp
+++ b/LASlib/inc/lasreader_ply.hpp
@@ -36,7 +36,7 @@
 
 #include <stdio.h>
 
-class LASreaderPLY : public LASreader
+class LASLIB_DLL LASreaderPLY : public LASreader
 {
 public:
 
@@ -97,7 +97,7 @@ private:
   void clean();
 };
 
-class LASreaderPLYrescale : public virtual LASreaderPLY
+class LASLIB_DLL LASreaderPLYrescale : public virtual LASreaderPLY
 {
 public:
   virtual BOOL open(const CHAR* file_name, U8 point_type=0, BOOL populate_header=FALSE);
@@ -107,7 +107,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderPLYreoffset : public virtual LASreaderPLY
+class LASLIB_DLL LASreaderPLYreoffset : public virtual LASreaderPLY
 {
 public:
   virtual BOOL open(const CHAR* file_name, U8 point_type=0, BOOL populate_header=FALSE);
@@ -116,7 +116,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderPLYrescalereoffset : public LASreaderPLYrescale, LASreaderPLYreoffset
+class LASLIB_DLL LASreaderPLYrescalereoffset : public LASreaderPLYrescale, LASreaderPLYreoffset
 {
 public:
   BOOL open(const CHAR* file_name, U8 point_type=0, BOOL populate_header=FALSE);

--- a/LASlib/inc/lasreader_qfit.hpp
+++ b/LASlib/inc/lasreader_qfit.hpp
@@ -38,7 +38,7 @@
 
 #include <stdio.h>
 
-class LASreaderQFIT : public LASreader
+class LASLIB_DLL LASreaderQFIT : public LASreader
 {
 public:
 
@@ -76,7 +76,7 @@ private:
   F64 orig_x_scale_factor, orig_y_scale_factor, orig_z_scale_factor;
 };
 
-class LASreaderQFITrescale : public virtual LASreaderQFIT
+class LASLIB_DLL LASreaderQFITrescale : public virtual LASreaderQFIT
 {
 public:
   virtual BOOL open(ByteStreamIn* stream);
@@ -86,7 +86,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderQFITreoffset : public virtual LASreaderQFIT
+class LASLIB_DLL LASreaderQFITreoffset : public virtual LASreaderQFIT
 {
 public:
   virtual BOOL open(ByteStreamIn* stream);
@@ -95,7 +95,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderQFITrescalereoffset : public LASreaderQFITrescale, LASreaderQFITreoffset
+class LASLIB_DLL LASreaderQFITrescalereoffset : public LASreaderQFITrescale, LASreaderQFITreoffset
 {
 public:
   BOOL open(ByteStreamIn* stream);

--- a/LASlib/inc/lasreader_shp.hpp
+++ b/LASlib/inc/lasreader_shp.hpp
@@ -35,7 +35,7 @@
 
 #include <stdio.h>
 
-class LASreaderSHP : public LASreader
+class LASLIB_DLL LASreaderSHP : public LASreader
 {
 public:
 
@@ -74,7 +74,7 @@ private:
   void clean();
 };
 
-class LASreaderSHPrescale : public virtual LASreaderSHP
+class LASLIB_DLL LASreaderSHPrescale : public virtual LASreaderSHP
 {
 public:
   virtual BOOL open(const char* file_name);
@@ -84,7 +84,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderSHPreoffset : public virtual LASreaderSHP
+class LASLIB_DLL LASreaderSHPreoffset : public virtual LASreaderSHP
 {
 public:
   virtual BOOL open(const char* file_name);
@@ -93,7 +93,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderSHPrescalereoffset : public LASreaderSHPrescale, LASreaderSHPreoffset
+class LASLIB_DLL LASreaderSHPrescalereoffset : public LASreaderSHPrescale, LASreaderSHPreoffset
 {
 public:
   BOOL open(const char* file_name);

--- a/LASlib/inc/lasreader_txt.hpp
+++ b/LASlib/inc/lasreader_txt.hpp
@@ -42,7 +42,7 @@
 
 #include <stdio.h>
 
-class LASreaderTXT : public LASreader
+class LASLIB_DLL LASreaderTXT : public LASreader
 {
 public:
   BOOL iptx_transform;
@@ -127,7 +127,7 @@ private:
     HSL_h = -10, HSL_s = -11, HSL_l = -12};
 };
 
-class LASreaderTXTrescale : public virtual LASreaderTXT
+class LASLIB_DLL LASreaderTXTrescale : public virtual LASreaderTXT
 {
 public:
   virtual BOOL open(const CHAR* file_name, U8 point_type = 0, const CHAR* parse_string = 0, I32 skip_lines = 0, BOOL populate_header = FALSE);
@@ -137,7 +137,7 @@ protected:
   F64 scale_factor[3];
 };
 
-class LASreaderTXTreoffset : public virtual LASreaderTXT
+class LASLIB_DLL LASreaderTXTreoffset : public virtual LASreaderTXT
 {
 public:
   virtual BOOL open(const CHAR* file_name, U8 point_type = 0, const CHAR* parse_string = 0, I32 skip_lines = 0, BOOL populate_header = FALSE);
@@ -146,7 +146,7 @@ protected:
   F64 offset[3];
 };
 
-class LASreaderTXTrescalereoffset : public LASreaderTXTrescale, LASreaderTXTreoffset
+class LASLIB_DLL LASreaderTXTrescalereoffset : public LASreaderTXTrescale, LASreaderTXTreoffset
 {
 public:
   BOOL open(const CHAR* file_name, U8 point_type = 0, const CHAR* parse_string = 0, I32 skip_lines = 0, BOOL populate_header = FALSE);

--- a/LASlib/inc/lasreaderbuffered.hpp
+++ b/LASlib/inc/lasreaderbuffered.hpp
@@ -40,7 +40,7 @@
 
 #include "lasreader.hpp"
 
-class LASreaderBuffered : public LASreader
+class LASLIB_DLL LASreaderBuffered : public LASreader
 {
 public:
 

--- a/LASlib/inc/lasreadermerged.hpp
+++ b/LASlib/inc/lasreadermerged.hpp
@@ -46,7 +46,7 @@
 #include "lasreader_qfit.hpp"
 #include "lasreader_txt.hpp"
 
-class LASreaderMerged : public LASreader
+class LASLIB_DLL LASreaderMerged : public LASreader
 {
 public:
 

--- a/LASlib/inc/lasreaderpipeon.hpp
+++ b/LASlib/inc/lasreaderpipeon.hpp
@@ -36,7 +36,7 @@
 #include "lasreader.hpp"
 #include "laswriter.hpp"
 
-class LASreaderPipeOn : public LASreader
+class LASLIB_DLL LASreaderPipeOn : public LASreader
 {
 public:
 

--- a/LASlib/inc/lasreaderstored.hpp
+++ b/LASlib/inc/lasreaderstored.hpp
@@ -39,7 +39,7 @@
 #include "bytestreamin_array.hpp"
 #include "bytestreamout_array.hpp"
 
-class LASreaderStored : public LASreader
+class LASLIB_DLL LASreaderStored : public LASreader
 {
 public:
 

--- a/LASlib/inc/lastransform.hpp
+++ b/LASlib/inc/lastransform.hpp
@@ -65,7 +65,7 @@ struct LASTransformMatrix {
 	F64 tr3;
 };
 
-class LASoperation
+class LASLIB_DLL LASoperation
 {
 public:
 	virtual const CHAR * name() const = 0;
@@ -242,7 +242,7 @@ class LASoperationMultiplyScaledIntensityRangeIntoRGB : public LASoperation
 #define LASTRANSFORM_XY_COORDINATE (LASTRANSFORM_X_COORDINATE | LASTRANSFORM_Y_COORDINATE)
 #define LASTRANSFORM_XYZ_COORDINATE (LASTRANSFORM_XY_COORDINATE | LASTRANSFORM_Z_COORDINATE)
 
-class LAStransform
+class LASLIB_DLL LAStransform
 {
 public:
   bool needPreread;

--- a/LASzip/src/arithmeticdecoder.hpp
+++ b/LASzip/src/arithmeticdecoder.hpp
@@ -43,7 +43,7 @@
 class ArithmeticModel;
 class ArithmeticBitModel;
 
-class ArithmeticDecoder
+class LASLIB_DLL ArithmeticDecoder
 {
 public:
 

--- a/LASzip/src/arithmeticencoder.hpp
+++ b/LASzip/src/arithmeticencoder.hpp
@@ -42,7 +42,7 @@
 class ArithmeticModel;
 class ArithmeticBitModel;
 
-class ArithmeticEncoder
+class LASLIB_DLL ArithmeticEncoder
 {
 public:
 

--- a/LASzip/src/arithmeticmodel.hpp
+++ b/LASzip/src/arithmeticmodel.hpp
@@ -55,7 +55,7 @@ const U32 BM__MaxCount    = 1 << BM__LengthShift;  // for adaptive models
 const U32 DM__LengthShift = 15;     // length bits discarded before mult.
 const U32 DM__MaxCount    = 1 << DM__LengthShift;  // for adaptive models
 
-class ArithmeticModel
+class LASLIB_DLL ArithmeticModel
 {
 public:
   ArithmeticModel(U32 symbols, BOOL compress);
@@ -73,7 +73,7 @@ private:
   friend class ArithmeticDecoder;
 };
 
-class ArithmeticBitModel
+class LASLIB_DLL ArithmeticBitModel
 {
 public:
   ArithmeticBitModel();

--- a/LASzip/src/integercompressor.hpp
+++ b/LASzip/src/integercompressor.hpp
@@ -51,7 +51,7 @@
 #include "arithmeticencoder.hpp"
 #include "arithmeticdecoder.hpp"
 
-class IntegerCompressor
+class LASLIB_DLL IntegerCompressor
 {
 public:
 

--- a/LASzip/src/lasinterval.hpp
+++ b/LASzip/src/lasinterval.hpp
@@ -38,7 +38,7 @@
 class ByteStreamIn;
 class ByteStreamOut;
 
-class LASintervalCell
+class LASLIB_DLL LASintervalCell
 {
 public:
   U32 start;
@@ -49,7 +49,7 @@ public:
   LASintervalCell(const LASintervalCell* cell);
 };
 
-class LASintervalStartCell : public LASintervalCell
+class LASLIB_DLL LASintervalStartCell : public LASintervalCell
 {
 public:
   U32 full;
@@ -60,7 +60,7 @@ public:
   BOOL add(const U32 p_index, const U32 threshold=1000);
 };
 
-class LASinterval
+class LASLIB_DLL LASinterval
 {
 public:
   LASinterval(const U32 threshold=1000);

--- a/LASzip/src/lasmessage.hpp
+++ b/LASzip/src/lasmessage.hpp
@@ -73,7 +73,7 @@ void LASLIB_DLL unset_las_message_handler();
 
 // @brief Logger-Wrapper that allows to stream to the logger.
 // @usage LASMessageStream(LAS_FATAL_ERROR) << "Pi is approximately: " << LASMessageStream().precision(2) << 3.14159 << std::endl;
-class LASMessageStream
+class LASLIB_DLL LASMessageStream
 {
 public:
     LASMessageStream(LAS_MESSAGE_TYPE type) : setType(type) {}

--- a/LASzip/src/lasreaditemcompressed_v1.hpp
+++ b/LASzip/src/lasreaditemcompressed_v1.hpp
@@ -38,7 +38,7 @@
 #include "arithmeticdecoder.hpp"
 #include "integercompressor.hpp"
 
-class LASreadItemCompressed_POINT10_v1 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_POINT10_v1 : public LASreadItemCompressed
 {
 public:
 
@@ -68,7 +68,7 @@ private:
   ArithmeticModel* m_user_data[256];
 };
 
-class LASreadItemCompressed_GPSTIME11_v1 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_GPSTIME11_v1 : public LASreadItemCompressed
 {
 public:
 
@@ -90,7 +90,7 @@ private:
   I32 last_gpstime_diff;
 };
 
-class LASreadItemCompressed_RGB12_v1 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGB12_v1 : public LASreadItemCompressed
 {
 public:
 
@@ -109,7 +109,7 @@ private:
   IntegerCompressor* ic_rgb;
 };
 
-class LASreadItemCompressed_WAVEPACKET13_v1 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_WAVEPACKET13_v1 : public LASreadItemCompressed
 {
 public:
 
@@ -134,7 +134,7 @@ private:
   IntegerCompressor* ic_xyz;
 };
 
-class LASreadItemCompressed_BYTE_v1 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_BYTE_v1 : public LASreadItemCompressed
 {
 public:
 

--- a/LASzip/src/lasreaditemcompressed_v2.hpp
+++ b/LASzip/src/lasreaditemcompressed_v2.hpp
@@ -39,7 +39,7 @@
 
 #include "laszip_common_v2.hpp"
 
-class LASreadItemCompressed_POINT10_v2 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_POINT10_v2 : public LASreadItemCompressed
 {
 public:
 
@@ -70,7 +70,7 @@ private:
   IntegerCompressor* ic_z;
 };
 
-class LASreadItemCompressed_GPSTIME11_v2 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_GPSTIME11_v2 : public LASreadItemCompressed
 {
 public:
 
@@ -93,7 +93,7 @@ private:
   IntegerCompressor* ic_gpstime;
 };
 
-class LASreadItemCompressed_RGB12_v2 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGB12_v2 : public LASreadItemCompressed
 {
 public:
 
@@ -117,7 +117,7 @@ private:
   ArithmeticModel* m_rgb_diff_5;
 };
 
-class LASreadItemCompressed_BYTE_v2 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_BYTE_v2 : public LASreadItemCompressed
 {
 public:
 

--- a/LASzip/src/lasreaditemcompressed_v3.hpp
+++ b/LASzip/src/lasreaditemcompressed_v3.hpp
@@ -43,7 +43,7 @@
 #include "laszip_common_v3.hpp"
 #include "laszip_decompress_selective_v3.hpp"
 
-class LASreadItemCompressed_POINT14_v3 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_POINT14_v3 : public LASreadItemCompressed
 {
 public:
 
@@ -119,7 +119,7 @@ private:
   void read_gps_time();
 };
 
-class LASreadItemCompressed_RGB14_v3 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGB14_v3 : public LASreadItemCompressed
 {
 public:
 
@@ -156,7 +156,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_RGBNIR14_v3 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGBNIR14_v3 : public LASreadItemCompressed
 {
 public:
 
@@ -198,7 +198,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_WAVEPACKET14_v3 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_WAVEPACKET14_v3 : public LASreadItemCompressed
 {
 public:
 
@@ -235,7 +235,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_BYTE14_v3 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_BYTE14_v3 : public LASreadItemCompressed
 {
 public:
 

--- a/LASzip/src/lasreaditemcompressed_v4.hpp
+++ b/LASzip/src/lasreaditemcompressed_v4.hpp
@@ -44,7 +44,7 @@
 #include "laszip_common_v3.hpp"
 #include "laszip_decompress_selective_v3.hpp"
 
-class LASreadItemCompressed_POINT14_v4 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_POINT14_v4 : public LASreadItemCompressed
 {
 public:
 
@@ -120,7 +120,7 @@ private:
   void read_gps_time();
 };
 
-class LASreadItemCompressed_RGB14_v4 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGB14_v4 : public LASreadItemCompressed
 {
 public:
 
@@ -157,7 +157,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_RGBNIR14_v4 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_RGBNIR14_v4 : public LASreadItemCompressed
 {
 public:
 
@@ -199,7 +199,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_WAVEPACKET14_v4 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_WAVEPACKET14_v4 : public LASreadItemCompressed
 {
 public:
 
@@ -236,7 +236,7 @@ private:
   BOOL createAndInitModelsAndDecompressors(U32 context, const U8* item);
 };
 
-class LASreadItemCompressed_BYTE14_v4 : public LASreadItemCompressed
+class LASLIB_DLL LASreadItemCompressed_BYTE14_v4 : public LASreadItemCompressed
 {
 public:
 

--- a/LASzip/src/lasreadpoint.hpp
+++ b/LASzip/src/lasreadpoint.hpp
@@ -53,7 +53,7 @@
 class LASreadItem;
 class ArithmeticDecoder;
 
-class LASreadPoint
+class LASLIB_DLL LASreadPoint
 {
 public:
   LASreadPoint(U32 decompress_selective=LASZIP_DECOMPRESS_SELECTIVE_ALL);

--- a/LASzip/src/lasunzipper.hpp
+++ b/LASzip/src/lasunzipper.hpp
@@ -49,7 +49,7 @@ using namespace std;
 class ByteStreamIn;
 class LASreadPoint;
 
-class LASunzipper
+class LASLIB_DLL LASunzipper
 {
 public:
   bool open(FILE* file, const LASzip* laszip);

--- a/LASzip/src/laswriteitemcompressed_v1.hpp
+++ b/LASzip/src/laswriteitemcompressed_v1.hpp
@@ -38,7 +38,7 @@
 #include "arithmeticencoder.hpp"
 #include "integercompressor.hpp"
 
-class LASwriteItemCompressed_POINT10_v1 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_POINT10_v1 : public LASwriteItemCompressed
 {
 public:
 
@@ -68,7 +68,7 @@ private:
   ArithmeticModel* m_user_data[256];
 };
 
-class LASwriteItemCompressed_GPSTIME11_v1 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_GPSTIME11_v1 : public LASwriteItemCompressed
 {
 public:
 
@@ -90,7 +90,7 @@ private:
   I32 last_gpstime_diff;
 };
 
-class LASwriteItemCompressed_RGB12_v1 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGB12_v1 : public LASwriteItemCompressed
 {
 public:
 
@@ -109,7 +109,7 @@ private:
   IntegerCompressor* ic_rgb;
 };
 
-class LASwriteItemCompressed_WAVEPACKET13_v1 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_WAVEPACKET13_v1 : public LASwriteItemCompressed
 {
 public:
 
@@ -134,7 +134,7 @@ private:
   IntegerCompressor* ic_xyz;
 };
 
-class LASwriteItemCompressed_BYTE_v1 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_BYTE_v1 : public LASwriteItemCompressed
 {
 public:
 

--- a/LASzip/src/laswriteitemcompressed_v2.hpp
+++ b/LASzip/src/laswriteitemcompressed_v2.hpp
@@ -39,7 +39,7 @@
 
 #include "laszip_common_v2.hpp"
 
-class LASwriteItemCompressed_POINT10_v2 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_POINT10_v2 : public LASwriteItemCompressed
 {
 public:
 
@@ -70,7 +70,7 @@ private:
   IntegerCompressor* ic_z;
 };
 
-class LASwriteItemCompressed_GPSTIME11_v2 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_GPSTIME11_v2 : public LASwriteItemCompressed
 {
 public:
 
@@ -93,7 +93,7 @@ private:
   IntegerCompressor* ic_gpstime;
 };
 
-class LASwriteItemCompressed_RGB12_v2 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGB12_v2 : public LASwriteItemCompressed
 {
 public:
 
@@ -117,7 +117,7 @@ private:
   ArithmeticModel* m_rgb_diff_5;
 };
 
-class LASwriteItemCompressed_BYTE_v2 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_BYTE_v2 : public LASwriteItemCompressed
 {
 public:
 

--- a/LASzip/src/laswriteitemcompressed_v3.hpp
+++ b/LASzip/src/laswriteitemcompressed_v3.hpp
@@ -40,7 +40,7 @@
 
 #include "laszip_common_v3.hpp"
 
-class LASwriteItemCompressed_POINT14_v3 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_POINT14_v3 : public LASwriteItemCompressed
 {
 public:
 
@@ -104,7 +104,7 @@ private:
   void write_gps_time(const U64I64F64 gps_time);
 };
 
-class LASwriteItemCompressed_RGB14_v3 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGB14_v3 : public LASwriteItemCompressed
 {
 public:
 
@@ -137,7 +137,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_RGBNIR14_v3 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGBNIR14_v3 : public LASwriteItemCompressed
 {
 public:
 
@@ -174,7 +174,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_WAVEPACKET14_v3 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_WAVEPACKET14_v3 : public LASwriteItemCompressed
 {
 public:
 
@@ -207,7 +207,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_BYTE14_v3 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_BYTE14_v3 : public LASwriteItemCompressed
 {
 public:
 

--- a/LASzip/src/laswriteitemcompressed_v4.hpp
+++ b/LASzip/src/laswriteitemcompressed_v4.hpp
@@ -41,7 +41,7 @@
 
 #include "laszip_common_v3.hpp"
 
-class LASwriteItemCompressed_POINT14_v4 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_POINT14_v4 : public LASwriteItemCompressed
 {
 public:
 
@@ -105,7 +105,7 @@ private:
   void write_gps_time(const U64I64F64 gps_time);
 };
 
-class LASwriteItemCompressed_RGB14_v4 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGB14_v4 : public LASwriteItemCompressed
 {
 public:
 
@@ -138,7 +138,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_RGBNIR14_v4 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_RGBNIR14_v4 : public LASwriteItemCompressed
 {
 public:
 
@@ -175,7 +175,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_WAVEPACKET14_v4 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_WAVEPACKET14_v4 : public LASwriteItemCompressed
 {
 public:
 
@@ -208,7 +208,7 @@ private:
   BOOL createAndInitModelsAndCompressors(U32 context, const U8* item);
 };
 
-class LASwriteItemCompressed_BYTE14_v4 : public LASwriteItemCompressed
+class LASLIB_DLL LASwriteItemCompressed_BYTE14_v4 : public LASwriteItemCompressed
 {
 public:
 

--- a/LASzip/src/laswritepoint.hpp
+++ b/LASzip/src/laswritepoint.hpp
@@ -49,7 +49,7 @@
 class LASwriteItem;
 class ArithmeticEncoder;
 
-class LASwritePoint
+class LASLIB_DLL LASwritePoint
 {
 public:
   LASwritePoint();

--- a/LASzip/src/laszipper.hpp
+++ b/LASzip/src/laszipper.hpp
@@ -50,7 +50,7 @@ using namespace std;
 class ByteStreamOut;
 class LASwritePoint;
 
-class LASzipper
+class LASLIB_DLL LASzipper
 {
 public:
   bool open(FILE* outfile, const LASzip* laszip);


### PR DESCRIPTION
Hi!,
I was trying to use `LASlib` as a shared library on Windows (using the Ninja generator) which resulted in a lot of linker errors with some of the less commonly used headers that currently gets exported as part of the installed CMake package. So I've added DLL symbol export declarations to all public classes that needs it, fixing the linking errors.